### PR TITLE
fix: add mobile-friendly tag input with add button and IME support

### DIFF
--- a/src/components/__tests__/tag-input.test.tsx
+++ b/src/components/__tests__/tag-input.test.tsx
@@ -158,4 +158,29 @@ describe("TagInput", () => {
     await user.click(screen.getByText("suggestion1"));
     expect(defaultProps.onAdd).toHaveBeenCalledWith("suggestion1");
   });
+
+  it("clicking add button adds the typed tag", async () => {
+    const user = userEvent.setup();
+    render(<TagInput {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText("新增標籤...");
+    await user.type(input, "newtag");
+
+    const addBtn = screen.getByRole("button", { name: "新增標籤" });
+    await user.click(addBtn);
+
+    expect(defaultProps.onAdd).toHaveBeenCalledWith("newtag");
+    expect(input).toHaveValue("");
+  });
+
+  it("add button is hidden when input is empty", () => {
+    render(<TagInput {...defaultProps} />);
+    expect(screen.queryByRole("button", { name: "新增標籤" })).not.toBeInTheDocument();
+  });
+
+  it("has enterKeyHint=done for mobile keyboards", () => {
+    render(<TagInput {...defaultProps} />);
+    const input = screen.getByPlaceholderText("新增標籤...");
+    expect(input).toHaveAttribute("enterkeyhint", "done");
+  });
 });

--- a/src/components/tag-input.tsx
+++ b/src/components/tag-input.tsx
@@ -1,7 +1,8 @@
 import { useState, useRef, useEffect } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { X, Plus } from "lucide-react";
 
 interface TagInputProps {
   tags: string[];
@@ -64,43 +65,65 @@ export function TagInput({
         ))}
       </div>
       <div className="relative">
-        <Input
-          value={input}
-          onChange={(e) => {
-            setInput(e.target.value);
-            setShowSuggestions(true);
-          }}
-          onKeyDown={(e) => {
-            if (e.key === "ArrowDown" && suggestionsVisible) {
-              e.preventDefault();
-              setHighlightedIndex((prev) => (prev < visibleSuggestions.length - 1 ? prev + 1 : 0));
-            } else if (e.key === "ArrowUp" && suggestionsVisible) {
-              e.preventDefault();
-              setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : visibleSuggestions.length - 1));
-            } else if (e.key === "Tab" && suggestionsVisible && highlightedIndex >= 0) {
-              e.preventDefault();
-              handleAdd(visibleSuggestions[highlightedIndex]!);
-            } else if (e.key === "Enter") {
-              e.preventDefault();
-              if (suggestionsVisible && highlightedIndex >= 0) {
+        <div className="flex gap-1">
+          <Input
+            className="flex-1"
+            value={input}
+            onChange={(e) => {
+              setInput(e.target.value);
+              setShowSuggestions(true);
+            }}
+            onKeyDown={(e) => {
+              // Skip keyboard shortcuts during IME composition (e.g. Chinese input)
+              if (e.nativeEvent.isComposing) return;
+              if (e.key === "ArrowDown" && suggestionsVisible) {
+                e.preventDefault();
+                setHighlightedIndex((prev) =>
+                  prev < visibleSuggestions.length - 1 ? prev + 1 : 0,
+                );
+              } else if (e.key === "ArrowUp" && suggestionsVisible) {
+                e.preventDefault();
+                setHighlightedIndex((prev) =>
+                  prev > 0 ? prev - 1 : visibleSuggestions.length - 1,
+                );
+              } else if (e.key === "Tab" && suggestionsVisible && highlightedIndex >= 0) {
+                e.preventDefault();
                 handleAdd(visibleSuggestions[highlightedIndex]!);
-              } else {
-                handleAdd(input);
+              } else if (e.key === "Enter") {
+                e.preventDefault();
+                if (suggestionsVisible && highlightedIndex >= 0) {
+                  handleAdd(visibleSuggestions[highlightedIndex]!);
+                } else {
+                  handleAdd(input);
+                }
+              } else if (e.key === "Escape") {
+                setShowSuggestions(false);
+                setHighlightedIndex(-1);
               }
-            } else if (e.key === "Escape") {
-              setShowSuggestions(false);
-              setHighlightedIndex(-1);
-            }
-          }}
-          onFocus={() => setShowSuggestions(true)}
-          onBlur={() => setTimeout(() => setShowSuggestions(false), 200)}
-          placeholder={placeholder}
-          role="combobox"
-          aria-expanded={suggestionsVisible}
-          aria-activedescendant={activeDescendant}
-          aria-controls={suggestionsVisible ? "tag-suggestions-listbox" : undefined}
-          aria-autocomplete="list"
-        />
+            }}
+            onFocus={() => setShowSuggestions(true)}
+            onBlur={() => setTimeout(() => setShowSuggestions(false), 200)}
+            placeholder={placeholder}
+            enterKeyHint="done"
+            role="combobox"
+            aria-expanded={suggestionsVisible}
+            aria-activedescendant={activeDescendant}
+            aria-controls={suggestionsVisible ? "tag-suggestions-listbox" : undefined}
+            aria-autocomplete="list"
+          />
+          {input.trim() && (
+            <Button
+              type="button"
+              size="icon-sm"
+              variant="outline"
+              aria-label="新增標籤"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => handleAdd(input)}
+            >
+              <Plus className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
         {suggestionsVisible && (
           <div
             ref={listboxRef}


### PR DESCRIPTION
## Summary

- Add visible "+" button next to tag input that appears when text is entered, allowing tag addition without relying on the Enter key
- Add `enterKeyHint="done"` so mobile keyboards show "Done" instead of "Next", preventing focus from jumping to the next field
- Add `isComposing` guard to skip `onKeyDown` during IME composition, preventing partial Chinese/Japanese text from being added as tags
- Add `flex-1` to Input to prevent layout shift when the "+" button appears

## Test plan

- [x] 16 tag-input unit tests pass (3 new: add button click, add button hidden when empty, enterKeyHint attribute)
- [x] Full suite: 678 tests pass, 0 failures
- [x] ESLint clean, build succeeds
- [ ] Verify on mobile: "+" button visible when typing, tap adds tag
- [ ] Verify on mobile: virtual keyboard shows "Done" not "Next"
- [ ] Verify Chinese input: IME composition Enter does not prematurely add tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)