### PR TITLE
fix: prevent SW controllerchange reload on first install

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -36,10 +36,13 @@ if ("serviceWorker" in navigator) {
       console.log("SW registration failed:", err);
     }
 
-    // Auto-reload when new SW activates (works with skipWaiting + clientsClaim)
+    // Auto-reload when new SW activates (works with skipWaiting + clientsClaim).
+    // Only reload on SW *updates* (controller already existed), not on first
+    // install (controller was null), to avoid reload loops during E2E tests.
+    const hadController = !!navigator.serviceWorker.controller;
     let refreshing = false;
     navigator.serviceWorker.addEventListener("controllerchange", () => {
-      if (refreshing) return;
+      if (!hadController || refreshing) return;
       refreshing = true;
       window.location.reload();
     });


### PR DESCRIPTION
## Summary

- Fix E2E test failures caused by PR #16's `controllerchange` auto-reload
- The reload was firing on first SW install (controller `null` → new), not just on SW updates
- Added guard: only reload when a previous controller existed (`!!navigator.serviceWorker.controller`)

## Test plan

- [x] Build succeeds
- [ ] E2E tests pass in CI (this was the root cause of the failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)