### PR TITLE
fix: update E2E tag test locator for new TagInput DOM structure

### DIFF
--- a/e2e/item-lifecycle.spec.ts
+++ b/e2e/item-lifecycle.spec.ts
@@ -112,9 +112,9 @@ test.describe("Item Lifecycle", () => {
     await page.keyboard.type(tagName);
     await page.keyboard.press("Enter");
 
-    // Scope badge locator to the TagInput component (parent of parent of input)
-    // TagInput structure: <div>(root) > <div>(badges) + <div>(input container) > <input>
-    const tagInputRoot = tagInput.locator("../..");
+    // Scope badge locator to the TagInput component root
+    // TagInput structure: <div>(root) > <div>(badges) + <div>(relative) > <div>(flex) > <input>
+    const tagInputRoot = tagInput.locator("../../..");
     const tagBadge = tagInputRoot.locator('[data-slot="badge"]', { hasText: tagName });
 
     // Verify tag badge appears (saves immediately via saveField)


### PR DESCRIPTION
## Summary

- Fix the only remaining E2E failure from the tag input mobile fix (PR #17)
- TagInput now has an extra `<div class="flex gap-1">` wrapper for the add button
- Parent traversal `../..` → `../../..` to reach the TagInput root where badges live

## Test plan

- [ ] E2E tests pass in CI (24/24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)