### PR TITLE
fix: use explicit column names in migration INSERT

### DIFF
--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -213,7 +213,8 @@ function runMigrations(sqlite: Database.Database) {
           FOREIGN KEY (linked_note_id) REFERENCES items(id) ON DELETE SET NULL
         );
 
-        INSERT INTO items_new SELECT * FROM items;
+        INSERT INTO items_new (id, type, title, content, status, priority, due, tags, origin, source, aliases, linked_note_id, created, modified)
+        SELECT id, type, title, content, status, priority, due, tags, origin, source, aliases, linked_note_id, created, modified FROM items;
         DROP TABLE items;
         ALTER TABLE items_new RENAME TO items;
 


### PR DESCRIPTION
## Summary

**Production outage root cause fix.** Migration 11→12 used `INSERT INTO items_new SELECT * FROM items` which relies on column position. Production tables built through ALTER TABLE have different column order than fresh CREATE TABLE, causing `linked_note_id` (NULL) to map to `modified` (NOT NULL) → crash.

Fix: explicit column names in both INSERT target and SELECT source.

## Test plan
- [x] 707 tests pass
- [x] Production server recovered with this fix
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)