### PR TITLE
ci: pre-migration deploy check, expanded hook, Playwright cache

### DIFF
--- a/.claude/hooks/migration-safety.sh
+++ b/.claude/hooks/migration-safety.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
-# migration-safety.sh — PostToolUse hook
-# Blocks SELECT * in migration code (column order mismatch risk)
-# and shows production DB schema for reference.
+# migration-safety.sh — PostToolUse hook for migration code safety
+#
+# Checks applied when server/db/index.ts is edited:
+# 1. Block SELECT * FROM items (column order mismatch risk)
+# 2. Warn if DROP TABLE items without foreign_keys = OFF
+# 3. Warn if setSchemaVersion inside transaction block
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
@@ -9,7 +12,17 @@ FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 # Only check server/db/index.ts
 [[ "$FILE_PATH" == */server/db/index.ts ]] || exit 0
 
-# Check for SELECT * FROM items in migration context (ignore comments)
+DB_DIR="${CLAUDE_PROJECT_DIR:-$(dirname "$(dirname "$(dirname "$0")")")}"
+
+show_schema() {
+  if [ -f "$DB_DIR/data/todo.db" ]; then
+    echo "" >&2
+    echo "生產 DB 實際 schema (欄位順序以此為準):" >&2
+    sqlite3 "$DB_DIR/data/todo.db" ".schema items" 2>/dev/null | head -20 >&2
+  fi
+}
+
+# --- Check 1: SELECT * FROM items ---
 if grep -n 'SELECT \* FROM items' "$FILE_PATH" | grep -qv '^\s*//\|^\s*\*'; then
   echo "❌ 禁止在 migration 中使用 SELECT * FROM items" >&2
   echo "   ALTER TABLE 追加的欄位在表尾，和 CREATE TABLE 定義順序不同。" >&2
@@ -17,12 +30,27 @@ if grep -n 'SELECT \* FROM items' "$FILE_PATH" | grep -qv '^\s*//\|^\s*\*'; then
   echo "" >&2
   echo "   範例:" >&2
   echo "   INSERT INTO items_new (id, type, title, ...) SELECT id, type, title, ... FROM items;" >&2
-  echo "" >&2
-  if [ -f "${CLAUDE_PROJECT_DIR:-$(dirname "$(dirname "$(dirname "$0")")")}/data/todo.db" ]; then
-    DB_PATH="${CLAUDE_PROJECT_DIR:-$(dirname "$(dirname "$(dirname "$0")")")}/data/todo.db"
-    echo "生產 DB 實際 schema (欄位順序以此為準):" >&2
-    sqlite3 "$DB_PATH" ".schema items" 2>/dev/null | head -20 >&2
+  show_schema
+  exit 2
+fi
+
+# --- Check 2: DROP TABLE items without foreign_keys = OFF ---
+if grep -q 'DROP TABLE items' "$FILE_PATH"; then
+  if ! grep -q 'foreign_keys\s*=\s*OFF\|foreign_keys=OFF' "$FILE_PATH"; then
+    echo "❌ DROP TABLE items 偵測到，但缺少 PRAGMA foreign_keys = OFF" >&2
+    echo "   share_tokens 有 FK 引用 items(id)，不關閉 FK 檢查會導致錯誤。" >&2
+    echo "   在 DROP TABLE 之前加: sqlite.pragma(\"foreign_keys = OFF\");" >&2
+    exit 2
   fi
+fi
+
+# --- Check 3: setSchemaVersion inside transaction ---
+# Pattern: sqlite.transaction(() => { ... setSchemaVersion ... });
+# This is dangerous because if the transaction rolls back, version shouldn't advance
+if awk '/sqlite\.transaction\(/,/^\s*\}\);/' "$FILE_PATH" | grep -q 'setSchemaVersion'; then
+  echo "❌ setSchemaVersion 出現在 sqlite.transaction() 區塊內" >&2
+  echo "   如果 transaction rollback，schema version 不應該被推進。" >&2
+  echo "   將 setSchemaVersion 移到 migrate() 呼叫之後（transaction 外面）。" >&2
   exit 2
 fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,23 @@ jobs:
       - name: Test with coverage
         run: npx vitest run --coverage
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npx playwright --version | tr ' ' '-')" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright browsers
-        run: npx playwright install chromium --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium
+
+      - name: Install Playwright OS deps
+        run: npx playwright install-deps chromium
 
       - name: Run E2E tests
         run: npx playwright test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,18 @@ jobs:
       - name: Build frontend
         run: cd /home/tim/sparkle && npm run build
 
+      - name: Validate migrations against production DB
+        run: |
+          cd /home/tim/sparkle
+          timeout 10 node --env-file=.env --import tsx -e "
+            import './server/db/index.js';
+            console.log('Migration validation passed');
+            process.exit(0);
+          " || {
+            echo '❌ Migration validation failed — aborting deploy (old service still running)'
+            exit 1
+          }
+
       - name: Restart service
         run: sudo systemctl restart sparkle
 


### PR DESCRIPTION
## Summary

Three improvements from the migration 11→12 outage post-mortem:

- **deploy.yml**: New "Validate migrations" step runs `import './server/db/index.js'` against the production DB before restarting. If migration crashes, deploy aborts and old service stays running.
- **migration-safety.sh**: Expanded Claude Code hook with 2 new checks:
  - DROP TABLE without `PRAGMA foreign_keys = OFF` → blocked
  - `setSchemaVersion` inside transaction block → blocked
- **ci.yml**: Cache Playwright browsers via `actions/cache@v4` keyed by Playwright version. Saves ~20s on cache hits.

## Test plan

- [x] Hook syntax: `bash -n` passes
- [x] YAML syntax: `yaml.safe_load` passes for both workflows
- [ ] CI: verify Playwright cache step works (first run = miss, second = hit)
- [ ] Deploy: verify migration validation step appears in workflow log

🤖 Generated with [Claude Code](https://claude.com/claude-code)