### PR TITLE
fix: resolve mobile web stuck in offline mode

### DIFF
--- a/src/hooks/__tests__/use-online-status.test.ts
+++ b/src/hooks/__tests__/use-online-status.test.ts
@@ -2,14 +2,21 @@ import { renderHook, act } from "@testing-library/react";
 import { useOnlineStatus } from "../use-online-status";
 
 let originalOnLine: boolean;
+let originalVisibilityState: string;
 
 beforeEach(() => {
   originalOnLine = navigator.onLine;
+  originalVisibilityState = document.visibilityState;
 });
 
 afterEach(() => {
   Object.defineProperty(navigator, "onLine", {
     value: originalOnLine,
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(document, "visibilityState", {
+    value: originalVisibilityState,
     writable: true,
     configurable: true,
   });
@@ -62,18 +69,84 @@ describe("useOnlineStatus", () => {
     setOnlineStatus(true);
     const addSpy = vi.spyOn(window, "addEventListener");
     const removeSpy = vi.spyOn(window, "removeEventListener");
+    const docAddSpy = vi.spyOn(document, "addEventListener");
+    const docRemoveSpy = vi.spyOn(document, "removeEventListener");
 
     const { unmount } = renderHook(() => useOnlineStatus());
 
     expect(addSpy).toHaveBeenCalledWith("online", expect.any(Function));
     expect(addSpy).toHaveBeenCalledWith("offline", expect.any(Function));
+    expect(docAddSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
 
     unmount();
 
     expect(removeSpy).toHaveBeenCalledWith("online", expect.any(Function));
     expect(removeSpy).toHaveBeenCalledWith("offline", expect.any(Function));
+    expect(docRemoveSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
 
     addSpy.mockRestore();
     removeSpy.mockRestore();
+    docAddSpy.mockRestore();
+    docRemoveSpy.mockRestore();
+  });
+
+  it("re-syncs to online when page becomes visible and navigator.onLine is true", () => {
+    setOnlineStatus(false);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(false);
+
+    // Simulate: phone reconnects while backgrounded, navigator.onLine updates
+    setOnlineStatus(true);
+
+    act(() => {
+      Object.defineProperty(document, "visibilityState", {
+        value: "visible",
+        writable: true,
+        configurable: true,
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("re-syncs to offline when page becomes visible and navigator.onLine is false", () => {
+    setOnlineStatus(true);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+
+    // Simulate: connection lost while backgrounded
+    setOnlineStatus(false);
+
+    act(() => {
+      Object.defineProperty(document, "visibilityState", {
+        value: "visible",
+        writable: true,
+        configurable: true,
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("does not update when page becomes hidden", () => {
+    setOnlineStatus(true);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+
+    setOnlineStatus(false);
+
+    act(() => {
+      Object.defineProperty(document, "visibilityState", {
+        value: "hidden",
+        writable: true,
+        configurable: true,
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    // Should NOT update — only re-sync when becoming visible
+    expect(result.current).toBe(true);
   });
 });

--- a/src/hooks/use-online-status.ts
+++ b/src/hooks/use-online-status.ts
@@ -7,12 +7,22 @@ export function useOnlineStatus(): boolean {
     const goOnline = () => setOnline(true);
     const goOffline = () => setOnline(false);
 
+    // Re-sync when page becomes visible (mobile browsers may not fire
+    // online/offline events while the tab is backgrounded)
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        setOnline(navigator.onLine);
+      }
+    };
+
     window.addEventListener("online", goOnline);
     window.addEventListener("offline", goOffline);
+    document.addEventListener("visibilitychange", onVisibilityChange);
 
     return () => {
       window.removeEventListener("online", goOnline);
       window.removeEventListener("offline", goOffline);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
     };
   }, []);
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -67,4 +67,12 @@ if ("serviceWorker" in navigator) {
     toast.dismiss("offline-fallback");
     navigator.serviceWorker.controller?.postMessage({ type: "REPLAY_QUEUE" });
   });
+
+  // Re-check connectivity when page becomes visible (mobile background → foreground)
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible" && navigator.onLine) {
+      toast.dismiss("offline-fallback");
+      navigator.serviceWorker.controller?.postMessage({ type: "REPLAY_QUEUE" });
+    }
+  });
 }

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,7 +1,7 @@
 /// <reference lib="webworker" />
 
 import { clientsClaim } from "workbox-core";
-import { precacheAndRoute } from "workbox-precaching";
+import { matchPrecache, precacheAndRoute } from "workbox-precaching";
 import { registerRoute } from "workbox-routing";
 import { NetworkFirst } from "workbox-strategies";
 
@@ -11,8 +11,33 @@ declare let self: ServiceWorkerGlobalScope;
 self.skipWaiting();
 clientsClaim();
 
-// Precache Vite build assets
-precacheAndRoute(self.__WB_MANIFEST);
+// Precache Vite build assets (disable navigation mapping so CF Access can check cookies)
+precacheAndRoute(self.__WB_MANIFEST, {
+  directoryIndex: null,
+  cleanURLs: false,
+});
+
+// Navigation requests: network-first so CF Access can verify auth cookies on page load.
+// Falls back to cached page, then precached app shell when truly offline.
+registerRoute(
+  ({ request }) => request.mode === "navigate",
+  new NetworkFirst({
+    cacheName: "pages",
+    plugins: [
+      {
+        handlerDidError: async () => {
+          return (
+            (await matchPrecache("index.html")) ||
+            new Response("<h1>Sparkle is offline</h1><p>請檢查網路連線後重新整理。</p>", {
+              headers: { "Content-Type": "text/html; charset=utf-8" },
+              status: 503,
+            })
+          );
+        },
+      },
+    ],
+  }),
+);
 
 // Runtime caching: GET /api/* with NetworkFirst strategy
 // Online → always fetch from network (fresh data)


### PR DESCRIPTION
## Summary
- 手機瀏覽器背景切回時 `navigator.onLine` 事件不觸發，導致離線狀態卡住。加入 `visibilitychange` 監聽，切回前景時重新讀取 `navigator.onLine`
- SW precache 攔截 navigation request 導致 CF Access 無法在頁面刷新時重新驗證 cookie。改用 `NetworkFirst` 策略，離線時 fallback 到 precached app shell
- 切回前景時清除殘留的離線 toast 並觸發離線佇列 replay

## Test plan
- [x] 710 unit tests passed (新增 3 個 visibilitychange 測試)
- [x] Build 成功（SW inject manifest 正常）
- [x] Lint + format clean
- [ ] 手動驗證：手機開 Web → 背景切走 → 切回 → 不卡在離線模式
- [ ] 手動驗證：CF Access 過期後刷新頁面 → redirect 到 CF 登入頁

🤖 Generated with [Claude Code](https://claude.com/claude-code)