### PR TITLE
fix: add revoke confirmation dialog, accessibility, and E2E tests for share management

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -91,3 +91,21 @@ export async function quickCaptureTodo(page: Page, title: string) {
   await page.locator("button[type='submit']").click();
   await page.getByText("已新增").waitFor({ timeout: 5_000 });
 }
+
+/**
+ * Create a share for an item via API.
+ */
+export async function createShareViaApi(
+  request: APIRequestContext,
+  itemId: string,
+  visibility: "unlisted" | "public" = "unlisted",
+) {
+  const response = await request.post(`${API_BASE}/items/${itemId}/share`, {
+    headers: {
+      Authorization: `Bearer ${AUTH_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    data: { visibility },
+  });
+  return response.json();
+}

--- a/e2e/shares.spec.ts
+++ b/e2e/shares.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "@playwright/test";
+import { createItemViaApi, createShareViaApi, navigateTo } from "./helpers";
+
+test.describe("Share Management", () => {
+  test("navigates to share management page and displays shares", async ({ page, request }) => {
+    // Create a note and share it
+    const note = await createItemViaApi(request, {
+      title: "E2E Shared Note",
+      type: "note",
+    });
+    await createShareViaApi(request, note.id, "public");
+
+    await page.goto("/");
+
+    // Navigate to share management via sidebar
+    await navigateTo(page, "分享管理");
+
+    // Verify page loaded (lazy-loaded)
+    await expect(page.getByRole("heading", { name: "分享管理" })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Verify share is listed with correct details
+    await expect(page.getByText("E2E Shared Note")).toBeVisible();
+    await expect(page.getByText("公開")).toBeVisible();
+  });
+
+  test("revokes share with confirmation dialog", async ({ page, request }) => {
+    const note = await createItemViaApi(request, {
+      title: "Note To Revoke",
+      type: "note",
+    });
+    await createShareViaApi(request, note.id);
+
+    await page.goto("/");
+    await navigateTo(page, "分享管理");
+
+    await expect(page.getByText("Note To Revoke")).toBeVisible({ timeout: 10_000 });
+
+    // Find the row containing "Note To Revoke" and click its revoke button
+    const row = page.locator(".rounded-md.border", { hasText: "Note To Revoke" });
+    await row.getByTitle("撤銷分享").click();
+
+    // Confirmation dialog should appear
+    await expect(page.getByText("確認撤銷分享")).toBeVisible();
+    await expect(page.getByText(/確定要撤銷「Note To Revoke」/)).toBeVisible();
+
+    // Confirm revoke
+    await page.getByRole("button", { name: "撤銷" }).click();
+
+    // Share should be removed
+    await expect(page.getByText("Note To Revoke")).not.toBeVisible({ timeout: 5_000 });
+  });
+
+  test("navigates to source note when title is clicked", async ({ page, request }) => {
+    const note = await createItemViaApi(request, {
+      title: "Navigate Target Note",
+      type: "note",
+      content: "This is the target note content.",
+    });
+    await createShareViaApi(request, note.id);
+
+    await page.goto("/");
+    await navigateTo(page, "分享管理");
+
+    await expect(page.getByText("Navigate Target Note")).toBeVisible({ timeout: 10_000 });
+
+    // Click the note title to navigate
+    await page.getByText("Navigate Target Note").click();
+
+    // Should navigate to the note detail view
+    await expect(page.getByText("This is the target note content.")).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/src/components/__tests__/share-management.test.tsx
+++ b/src/components/__tests__/share-management.test.tsx
@@ -125,7 +125,7 @@ describe("ShareManagement", () => {
     writeTextSpy.mockRestore();
   });
 
-  it("revokes share and removes from list", async () => {
+  it("revokes share after confirmation dialog", async () => {
     const { toast } = await import("sonner");
     mockListShares.mockResolvedValue({
       shares: [makeShare({ id: "s1", item_title: "Shared Note" })],
@@ -139,7 +139,13 @@ describe("ShareManagement", () => {
       expect(screen.getByText("Shared Note")).toBeInTheDocument();
     });
 
+    // Click revoke button opens confirmation dialog
     await user.click(screen.getByTitle("撤銷分享"));
+    expect(screen.getByText("確認撤銷分享")).toBeInTheDocument();
+    expect(screen.getByText(/確定要撤銷「Shared Note」的分享連結嗎/)).toBeInTheDocument();
+
+    // Confirm revoke
+    await user.click(screen.getByRole("button", { name: "撤銷" }));
 
     await waitFor(() => {
       expect(mockRevokeShare).toHaveBeenCalledWith("s1");
@@ -149,6 +155,30 @@ describe("ShareManagement", () => {
     await waitFor(() => {
       expect(screen.queryByText("Shared Note")).not.toBeInTheDocument();
     });
+  });
+
+  it("cancels revoke when cancel button is clicked", async () => {
+    mockListShares.mockResolvedValue({
+      shares: [makeShare({ id: "s1", item_title: "Shared Note" })],
+    });
+
+    const user = userEvent.setup();
+    renderWithContext(<ShareManagement onNavigateToItem={onNavigateToItem} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Shared Note")).toBeInTheDocument();
+    });
+
+    // Click revoke button opens dialog
+    await user.click(screen.getByTitle("撤銷分享"));
+    expect(screen.getByText("確認撤銷分享")).toBeInTheDocument();
+
+    // Click cancel
+    await user.click(screen.getByRole("button", { name: "取消" }));
+
+    // Dialog closed, API not called
+    expect(mockRevokeShare).not.toHaveBeenCalled();
+    expect(screen.getByText("Shared Note")).toBeInTheDocument();
   });
 
   it("shows error toast on revoke failure", async () => {
@@ -163,7 +193,9 @@ describe("ShareManagement", () => {
       expect(screen.getByText("My Shared Note")).toBeInTheDocument();
     });
 
+    // Open dialog and confirm
     await user.click(screen.getByTitle("撤銷分享"));
+    await user.click(screen.getByRole("button", { name: "撤銷" }));
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith("Server error");
@@ -184,6 +216,17 @@ describe("ShareManagement", () => {
 
     await user.click(screen.getByText("Click Me"));
     expect(onNavigateToItem).toHaveBeenCalledWith("note-42");
+  });
+
+  it("navigate button has accessible aria-label", async () => {
+    mockListShares.mockResolvedValue({
+      shares: [makeShare({ item_title: "Accessible Note" })],
+    });
+    renderWithContext(<ShareManagement onNavigateToItem={onNavigateToItem} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("前往筆記：Accessible Note")).toBeInTheDocument();
+    });
   });
 
   it("shows error toast on load failure", async () => {

--- a/src/components/share-management.tsx
+++ b/src/components/share-management.tsx
@@ -5,6 +5,15 @@ import type { ShareToken } from "@/lib/types";
 import { useOnlineStatus } from "@/hooks/use-online-status";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { Share2, Copy, Trash2, Globe, EyeOff, Loader2 } from "lucide-react";
 
 interface ShareManagementProps {
@@ -14,7 +23,7 @@ interface ShareManagementProps {
 export function ShareManagement({ onNavigateToItem }: ShareManagementProps) {
   const [shares, setShares] = useState<ShareToken[]>([]);
   const [loading, setLoading] = useState(true);
-  const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [revokeDialogShareId, setRevokeDialogShareId] = useState<string | null>(null);
   const isOnline = useOnlineStatus();
 
   useEffect(() => {
@@ -47,15 +56,12 @@ export function ShareManagement({ onNavigateToItem }: ShareManagementProps) {
   }
 
   async function handleRevokeShare(shareId: string) {
-    setRevokingId(shareId);
     try {
       await revokeShare(shareId);
       setShares((prev) => prev.filter((s) => s.id !== shareId));
       toast.success("已撤銷分享");
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "撤銷失敗");
-    } finally {
-      setRevokingId(null);
     }
   }
 
@@ -98,8 +104,10 @@ export function ShareManagement({ onNavigateToItem }: ShareManagementProps) {
                   )}
                   <div className="flex-1 min-w-0">
                     <button
+                      type="button"
                       className="text-sm text-primary hover:underline truncate block max-w-full text-left"
                       onClick={() => onNavigateToItem(share.item_id)}
+                      aria-label={`前往筆記：${share.item_title ?? "未知筆記"}`}
                     >
                       {share.item_title ?? "未知筆記"}
                     </button>
@@ -121,20 +129,45 @@ export function ShareManagement({ onNavigateToItem }: ShareManagementProps) {
                   >
                     <Copy className="h-3.5 w-3.5" />
                   </Button>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-7 w-7 shrink-0 text-destructive"
-                    onClick={() => handleRevokeShare(share.id)}
-                    disabled={revokingId === share.id || !isOnline}
-                    title="撤銷分享"
+                  <Dialog
+                    open={revokeDialogShareId === share.id}
+                    onOpenChange={(open) => setRevokeDialogShareId(open ? share.id : null)}
                   >
-                    {revokingId === share.id ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    ) : (
-                      <Trash2 className="h-3.5 w-3.5" />
-                    )}
-                  </Button>
+                    <DialogTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7 shrink-0 text-destructive"
+                        disabled={!isOnline}
+                        title="撤銷分享"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </DialogTrigger>
+                    <DialogContent>
+                      <DialogHeader>
+                        <DialogTitle>確認撤銷分享</DialogTitle>
+                        <DialogDescription>
+                          確定要撤銷「{share.item_title ?? "未知筆記"}
+                          」的分享連結嗎？撤銷後連結將失效。
+                        </DialogDescription>
+                      </DialogHeader>
+                      <DialogFooter>
+                        <Button variant="outline" onClick={() => setRevokeDialogShareId(null)}>
+                          取消
+                        </Button>
+                        <Button
+                          variant="destructive"
+                          onClick={() => {
+                            setRevokeDialogShareId(null);
+                            handleRevokeShare(share.id);
+                          }}
+                        >
+                          撤銷
+                        </Button>
+                      </DialogFooter>
+                    </DialogContent>
+                  </Dialog>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- 撤銷分享按鈕加入確認對話框，防止誤操作（參考 item-detail-header.tsx 的 Dialog pattern）
- Navigate button 加上 `type="button"` 和 `aria-label` 提升無障礙性
- 新增 3 個 E2E tests 覆蓋分享管理頁面（navigation、revoke with dialog、navigate to note）
- 新增 `createShareViaApi()` E2E helper

## Test plan
- [x] 722 unit tests 通過（38 files），含 2 個新增測試（cancel revoke、aria-label）
- [x] 32 E2E tests 通過（7 spec files），含 3 個新增測試
- [x] lint + format 乾淨
- [ ] 手動驗證撤銷分享時出現確認對話框
- [ ] 手動驗證取消按鈕關閉對話框不撤銷
- [ ] 手動驗證確認按鈕撤銷分享並從列表移除

🤖 Generated with [Claude Code](https://claude.com/claude-code)