### PR TITLE
feat: add categories CRUD API and integrate into items

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -23,6 +23,7 @@ import { statsRouter } from "./routes/stats.js";
 import { webhookRouter } from "./routes/webhook.js";
 import { settingsRouter } from "./routes/settings.js";
 import { sharesRouter } from "./routes/shares.js";
+import { categoriesRouter } from "./routes/categories.js";
 import { publicRouter } from "./routes/public.js";
 import { db, sqlite, DB_PATH } from "./db/index.js";
 import { items } from "./db/schema.js";
@@ -157,6 +158,7 @@ app.route("/api/search", searchRouter);
 app.route("/api/stats", statsRouter);
 app.route("/api/webhook", webhookRouter);
 app.route("/api/settings", settingsRouter);
+app.route("/api/categories", categoriesRouter);
 app.route("/api", sharesRouter);
 
 // Health check endpoint (unauthenticated — skipped in auth middleware)

--- a/server/lib/__tests__/categories.test.ts
+++ b/server/lib/__tests__/categories.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { createTestDb } from "../../test-utils.js";
+import {
+  createCategory,
+  getCategory,
+  listCategories,
+  updateCategory,
+  deleteCategory,
+  reorderCategories,
+} from "../categories.js";
+import { createCategorySchema } from "../../schemas/categories.js";
+import { createItem } from "../items.js";
+
+describe("Categories", () => {
+  let db: ReturnType<typeof drizzle>;
+  let sqlite: Database.Database;
+
+  beforeEach(() => {
+    const testDb = createTestDb();
+    db = testDb.db;
+    sqlite = testDb.sqlite;
+  });
+
+  afterAll(() => {
+    sqlite?.close();
+  });
+
+  describe("createCategory", () => {
+    it("creates with name, returns category with id/timestamps", () => {
+      const cat = createCategory(db, { name: "Work" });
+      expect(cat.id).toBeTruthy();
+      expect(cat.name).toBe("Work");
+      expect(cat.color).toBeNull();
+      expect(cat.sort_order).toBe(0);
+      expect(cat.created).toBeTruthy();
+      expect(cat.modified).toBeTruthy();
+    });
+
+    it("auto-increments sort_order", () => {
+      const cat1 = createCategory(db, { name: "First" });
+      const cat2 = createCategory(db, { name: "Second" });
+      const cat3 = createCategory(db, { name: "Third" });
+      expect(cat1.sort_order).toBe(0);
+      expect(cat2.sort_order).toBe(1);
+      expect(cat3.sort_order).toBe(2);
+    });
+
+    it("rejects duplicate name", () => {
+      createCategory(db, { name: "Work" });
+      expect(() => createCategory(db, { name: "Work" })).toThrow("UNIQUE constraint failed");
+    });
+
+    it("creates with color", () => {
+      const cat = createCategory(db, { name: "Personal", color: "#ff0000" });
+      expect(cat.color).toBe("#ff0000");
+    });
+  });
+
+  describe("createCategorySchema (Zod)", () => {
+    it("rejects empty name", () => {
+      const result = createCategorySchema.safeParse({ name: "" });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts valid input", () => {
+      const result = createCategorySchema.safeParse({ name: "Work" });
+      expect(result.success).toBe(true);
+    });
+
+    it("defaults color to null", () => {
+      const result = createCategorySchema.safeParse({ name: "Work" });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.color).toBeNull();
+      }
+    });
+  });
+
+  describe("getCategory", () => {
+    it("returns category by id", () => {
+      const created = createCategory(db, { name: "Work" });
+      const found = getCategory(db, created.id);
+      expect(found).not.toBeNull();
+      expect(found!.id).toBe(created.id);
+      expect(found!.name).toBe("Work");
+    });
+
+    it("returns null for non-existent id", () => {
+      const found = getCategory(db, "non-existent-id");
+      expect(found).toBeNull();
+    });
+  });
+
+  describe("listCategories", () => {
+    it("returns sorted by sort_order", () => {
+      createCategory(db, { name: "C" });
+      createCategory(db, { name: "A" });
+      createCategory(db, { name: "B" });
+      const list = listCategories(db);
+      expect(list).toHaveLength(3);
+      expect(list[0]!.name).toBe("C");
+      expect(list[1]!.name).toBe("A");
+      expect(list[2]!.name).toBe("B");
+    });
+
+    it("returns empty array when none exist", () => {
+      const list = listCategories(db);
+      expect(list).toEqual([]);
+    });
+  });
+
+  describe("updateCategory", () => {
+    it("updates name and modified timestamp", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      const cat = createCategory(db, { name: "Old" });
+      expect(cat.modified).toBe("2026-01-01T00:00:00.000Z");
+
+      vi.setSystemTime(new Date("2026-01-01T01:00:00Z"));
+      const updated = updateCategory(db, cat.id, { name: "New" });
+      expect(updated).not.toBeNull();
+      expect(updated!.name).toBe("New");
+      expect(updated!.modified).toBe("2026-01-01T01:00:00.000Z");
+      vi.useRealTimers();
+    });
+
+    it("updates color", () => {
+      const cat = createCategory(db, { name: "Work" });
+      const updated = updateCategory(db, cat.id, { color: "#00ff00" });
+      expect(updated).not.toBeNull();
+      expect(updated!.color).toBe("#00ff00");
+    });
+
+    it("returns null for non-existent id", () => {
+      const result = updateCategory(db, "non-existent-id", { name: "Nope" });
+      expect(result).toBeNull();
+    });
+
+    it("rejects duplicate name on rename", () => {
+      createCategory(db, { name: "Work" });
+      const cat2 = createCategory(db, { name: "Personal" });
+      expect(() => updateCategory(db, cat2.id, { name: "Work" })).toThrow(
+        "UNIQUE constraint failed",
+      );
+    });
+  });
+
+  describe("deleteCategory", () => {
+    it("deletes and returns true", () => {
+      const cat = createCategory(db, { name: "ToDelete" });
+      const result = deleteCategory(db, cat.id);
+      expect(result).toBe(true);
+      expect(getCategory(db, cat.id)).toBeNull();
+    });
+
+    it("returns false for non-existent id", () => {
+      const result = deleteCategory(db, "non-existent-id");
+      expect(result).toBe(false);
+    });
+
+    it("items with category_id get set to NULL (FK ON DELETE SET NULL)", () => {
+      const cat = createCategory(db, { name: "Work" });
+      const item = createItem(db, { title: "Test item" });
+
+      // Manually set category_id on the item
+      sqlite.prepare("UPDATE items SET category_id = ? WHERE id = ?").run(cat.id, item.id);
+
+      // Verify it's set
+      const before = sqlite.prepare("SELECT category_id FROM items WHERE id = ?").get(item.id) as {
+        category_id: string | null;
+      };
+      expect(before.category_id).toBe(cat.id);
+
+      // Delete category
+      deleteCategory(db, cat.id);
+
+      // Item's category_id should be NULL
+      const after = sqlite.prepare("SELECT category_id FROM items WHERE id = ?").get(item.id) as {
+        category_id: string | null;
+      };
+      expect(after.category_id).toBeNull();
+    });
+  });
+
+  describe("reorderCategories", () => {
+    it("updates sort_order for multiple categories", () => {
+      const cat1 = createCategory(db, { name: "A" });
+      const cat2 = createCategory(db, { name: "B" });
+      const cat3 = createCategory(db, { name: "C" });
+
+      // Reverse the order
+      reorderCategories(db, [
+        { id: cat3.id, sort_order: 0 },
+        { id: cat2.id, sort_order: 1 },
+        { id: cat1.id, sort_order: 2 },
+      ]);
+
+      const list = listCategories(db);
+      expect(list[0]!.name).toBe("C");
+      expect(list[0]!.sort_order).toBe(0);
+      expect(list[1]!.name).toBe("B");
+      expect(list[1]!.sort_order).toBe(1);
+      expect(list[2]!.name).toBe("A");
+      expect(list[2]!.sort_order).toBe(2);
+    });
+  });
+});

--- a/server/lib/__tests__/export.test.ts
+++ b/server/lib/__tests__/export.test.ts
@@ -72,6 +72,7 @@ function makeItem(overrides: Partial<ExportableItem> = {}): ExportableItem {
     origin: "web",
     priority: null,
     due: null,
+    category_name: null,
     ...overrides,
   };
 }
@@ -140,6 +141,26 @@ describe("generateFrontmatter", () => {
   it("includes non-null due", () => {
     const fm = generateFrontmatter(makeItem({ due: "2026-03-01" }));
     expect(fm).toContain("due: 2026-03-01");
+  });
+
+  it("includes category when category_name is set", () => {
+    const fm = generateFrontmatter(makeItem({ category_name: "Work" }));
+    expect(fm).toContain('category: "Work"');
+  });
+
+  it("omits category when category_name is null", () => {
+    const fm = generateFrontmatter(makeItem({ category_name: null }));
+    expect(fm).not.toContain("category:");
+  });
+
+  it("places category after sparkle_id and before tags", () => {
+    const fm = generateFrontmatter(makeItem({ category_name: "Research", tags: '["science"]' }));
+    const lines = fm.split("\n");
+    const catIndex = lines.findIndex((l) => l.startsWith("category:"));
+    const sparkleIndex = lines.findIndex((l) => l.startsWith("sparkle_id:"));
+    const tagsIndex = lines.findIndex((l) => l.startsWith("tags:"));
+    expect(catIndex).toBeGreaterThan(sparkleIndex);
+    expect(catIndex).toBeLessThan(tagsIndex);
   });
 
   it("uses local time without Z suffix", () => {

--- a/server/lib/__tests__/items.test.ts
+++ b/server/lib/__tests__/items.test.ts
@@ -641,6 +641,81 @@ describe("Data Access Layer", () => {
     });
   });
 
+  describe("category_id", () => {
+    function insertCategory(name: string): string {
+      const id = crypto.randomUUID();
+      const now = new Date().toISOString();
+      sqlite
+        .prepare(
+          "INSERT INTO categories (id, name, sort_order, created, modified) VALUES (?, ?, 0, ?, ?)",
+        )
+        .run(id, name, now, now);
+      return id;
+    }
+
+    it("createItem with category_id stores it", () => {
+      const catId = insertCategory("Work");
+      const item = createItem(db, { title: "Categorized note", category_id: catId });
+      expect(item.category_id).toBe(catId);
+    });
+
+    it("updateItem with category_id updates it", () => {
+      const catId = insertCategory("Personal");
+      const item = createItem(db, { title: "Uncategorized" });
+      expect(item.category_id).toBeNull();
+      const updated = updateItem(db, item.id, { category_id: catId });
+      expect(updated!.category_id).toBe(catId);
+    });
+
+    it("updateItem can clear category_id", () => {
+      const catId = insertCategory("Temp");
+      const item = createItem(db, { title: "Will uncategorize", category_id: catId });
+      const updated = updateItem(db, item.id, { category_id: null });
+      expect(updated!.category_id).toBeNull();
+    });
+
+    it("listItems filtered by category_id", () => {
+      const catId = insertCategory("Filter Cat");
+      createItem(db, { title: "In category", category_id: catId });
+      createItem(db, { title: "No category" });
+      const result = listItems(db, { category_id: catId });
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]!.title).toBe("In category");
+    });
+
+    it("category_name is resolved in getItem response", () => {
+      const catId = insertCategory("Resolved Cat");
+      const item = createItem(db, { title: "With category", category_id: catId });
+      const fetched = getItem(db, item.id);
+      expect(fetched!.category_name).toBe("Resolved Cat");
+    });
+
+    it("category_name is null when no category_id", () => {
+      const item = createItem(db, { title: "No cat" });
+      const fetched = getItem(db, item.id);
+      expect(fetched!.category_name).toBeNull();
+    });
+
+    it("category_id preserved on type conversion to scratch", () => {
+      const catId = insertCategory("Keep Me");
+      const note = createItem(db, { title: "Note with cat", type: "note", category_id: catId });
+      const updated = updateItem(db, note.id, { type: "scratch" });
+      expect(updated!.type).toBe("scratch");
+      expect(updated!.category_id).toBe(catId);
+    });
+
+    it("listItems returns category_name for items", () => {
+      const catId = insertCategory("List Cat");
+      createItem(db, { title: "Categorized", category_id: catId });
+      createItem(db, { title: "Uncategorized" });
+      const result = listItems(db);
+      const categorized = result.items.find((i) => i.title === "Categorized");
+      const uncategorized = result.items.find((i) => i.title === "Uncategorized");
+      expect(categorized!.category_name).toBe("List Cat");
+      expect(uncategorized!.category_name).toBeNull();
+    });
+  });
+
   describe("scratch field clearing", () => {
     it("creates scratch item without tags/priority/due/aliases/linked_note_id", () => {
       const item = createItem(db, {

--- a/server/lib/categories.ts
+++ b/server/lib/categories.ts
@@ -1,0 +1,75 @@
+import { eq, asc, sql } from "drizzle-orm";
+import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import { v4 as uuidv4 } from "uuid";
+import { categories } from "../db/schema.js";
+import type { CreateCategoryInput, UpdateCategoryInput } from "../schemas/categories.js";
+import type * as schema from "../db/schema.js";
+
+type DB = BetterSQLite3Database<typeof schema>;
+
+export function createCategory(db: DB, input: CreateCategoryInput) {
+  const now = new Date().toISOString();
+  const id = uuidv4();
+
+  return db.transaction((tx) => {
+    // Get max sort_order inside transaction to prevent race conditions
+    const maxResult = tx
+      .select({ maxOrder: sql<number | null>`MAX(${categories.sort_order})` })
+      .from(categories)
+      .get();
+    const sort_order = maxResult?.maxOrder != null ? maxResult.maxOrder + 1 : 0;
+
+    tx.insert(categories)
+      .values({
+        id,
+        name: input.name,
+        color: input.color ?? null,
+        sort_order,
+        created: now,
+        modified: now,
+      })
+      .run();
+
+    return tx.select().from(categories).where(eq(categories.id, id)).get()!;
+  });
+}
+
+export function getCategory(db: DB, id: string) {
+  return db.select().from(categories).where(eq(categories.id, id)).get() ?? null;
+}
+
+export function listCategories(db: DB) {
+  return db.select().from(categories).orderBy(asc(categories.sort_order)).all();
+}
+
+export function updateCategory(db: DB, id: string, input: UpdateCategoryInput) {
+  const existing = getCategory(db, id);
+  if (!existing) return null;
+
+  const now = new Date().toISOString();
+  const updates: Record<string, unknown> = { modified: now };
+
+  if (input.name !== undefined) updates.name = input.name;
+  if (input.color !== undefined) updates.color = input.color;
+  if (input.sort_order !== undefined) updates.sort_order = input.sort_order;
+
+  db.update(categories).set(updates).where(eq(categories.id, id)).run();
+
+  return getCategory(db, id);
+}
+
+export function deleteCategory(db: DB, id: string): boolean {
+  const result = db.delete(categories).where(eq(categories.id, id)).run();
+  return result.changes > 0;
+}
+
+export function reorderCategories(db: DB, items: { id: string; sort_order: number }[]): void {
+  db.transaction((tx) => {
+    for (const item of items) {
+      tx.update(categories)
+        .set({ sort_order: item.sort_order, modified: new Date().toISOString() })
+        .where(eq(categories.id, item.id))
+        .run();
+    }
+  });
+}

--- a/server/lib/export.ts
+++ b/server/lib/export.ts
@@ -48,6 +48,7 @@ export interface ExportableItem {
   origin: string | null;
   priority: string | null;
   due: string | null;
+  category_name: string | null;
 }
 
 /**
@@ -59,6 +60,11 @@ export function generateFrontmatter(item: ExportableItem): string {
 
   // Always present
   lines.push(`sparkle_id: "${item.id}"`);
+
+  // Category — include when non-null
+  if (item.category_name) {
+    lines.push(`category: "${item.category_name.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`);
+  }
 
   // Tags — include when non-empty
   const tags: string[] = JSON.parse(item.tags);

--- a/server/lib/items.ts
+++ b/server/lib/items.ts
@@ -2,7 +2,7 @@ import { eq, desc, asc, sql, and, notInArray, inArray } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import type Database from "better-sqlite3";
 import { v4 as uuidv4 } from "uuid";
-import { items, shareTokens } from "../db/schema.js";
+import { items, shareTokens, categories } from "../db/schema.js";
 import type { CreateItemInput, UpdateItemInput } from "../schemas/items.js";
 import type * as schema from "../db/schema.js";
 
@@ -74,6 +74,7 @@ export type ItemWithLinkedInfo = typeof items.$inferSelect & {
   linked_note_title: string | null;
   linked_todo_count: number;
   share_visibility: "public" | "unlisted" | null;
+  category_name: string | null;
 };
 
 function resolveLinkedInfo(db: DB, rows: (typeof items.$inferSelect)[]): ItemWithLinkedInfo[] {
@@ -134,11 +135,27 @@ function resolveLinkedInfo(db: DB, rows: (typeof items.$inferSelect)[]): ItemWit
     }
   }
 
+  // Resolve category_name for all items
+  const categoryIds = rows.map((r) => r.category_id).filter((id): id is string => id != null);
+  const categoryNameMap = new Map<string, string>();
+  if (categoryIds.length > 0) {
+    const uniqueCatIds = [...new Set(categoryIds)];
+    const catRows = db
+      .select({ id: categories.id, name: categories.name })
+      .from(categories)
+      .where(inArray(categories.id, uniqueCatIds))
+      .all();
+    for (const cr of catRows) {
+      categoryNameMap.set(cr.id, cr.name);
+    }
+  }
+
   return rows.map((row) => ({
     ...row,
     linked_note_title: row.linked_note_id ? (titleMap.get(row.linked_note_id) ?? null) : null,
     linked_todo_count: row.type === "note" ? (countMap.get(row.id) ?? 0) : 0,
     share_visibility: shareMap.get(row.id) ?? null,
+    category_name: row.category_id ? (categoryNameMap.get(row.category_id) ?? null) : null,
   }));
 }
 
@@ -161,6 +178,7 @@ export function createItem(db: DB, input: Partial<CreateItemInput> & { title: st
     source: input.source ?? null,
     aliases: type === "scratch" ? "[]" : JSON.stringify(input.aliases ?? []),
     linked_note_id: type === "todo" ? (input.linked_note_id ?? null) : null,
+    category_id: input.category_id ?? null,
     created: now,
     modified: now,
   };
@@ -183,6 +201,7 @@ export function listItems(
     type?: string;
     tag?: string;
     linked_note_id?: string;
+    category_id?: string;
     sort?: "created" | "priority" | "due" | "modified";
     order?: "asc" | "desc";
     limit?: number;
@@ -202,6 +221,9 @@ export function listItems(
   }
   if (filters?.linked_note_id) {
     conditions.push(eq(items.linked_note_id, filters.linked_note_id));
+  }
+  if (filters?.category_id) {
+    conditions.push(eq(items.category_id, filters.category_id));
   }
   if (filters?.tag) {
     conditions.push(sql`json_each.value = ${filters.tag}`);
@@ -280,6 +302,7 @@ export function updateItem(db: DB, id: string, input: UpdateItemInput) {
   if (input.source !== undefined) updates.source = input.source;
   if (input.aliases !== undefined) updates.aliases = JSON.stringify(input.aliases);
   if (input.linked_note_id !== undefined) updates.linked_note_id = input.linked_note_id;
+  if (input.category_id !== undefined) updates.category_id = input.category_id;
 
   // Type conversion auto-mapping (Section 9)
   if (input.type !== undefined && input.type !== existing.type) {

--- a/server/routes/categories.ts
+++ b/server/routes/categories.ts
@@ -1,0 +1,88 @@
+import { Hono } from "hono";
+import { db } from "../db/index.js";
+import {
+  createCategory,
+  listCategories,
+  updateCategory,
+  deleteCategory,
+  reorderCategories,
+} from "../lib/categories.js";
+import {
+  createCategorySchema,
+  updateCategorySchema,
+  reorderCategoriesSchema,
+} from "../schemas/categories.js";
+import { ZodError } from "zod";
+
+const categoriesRouter = new Hono();
+
+// List all categories
+categoriesRouter.get("/", (c) => {
+  const result = listCategories(db);
+  return c.json({ categories: result });
+});
+
+// Create category
+categoriesRouter.post("/", async (c) => {
+  try {
+    const body = await c.req.json();
+    const input = createCategorySchema.parse(body);
+    const category = createCategory(db, input);
+    return c.json(category, 201);
+  } catch (e) {
+    if (e instanceof ZodError) {
+      return c.json({ error: e.issues[0]?.message ?? "Validation error" }, 400);
+    }
+    if (e instanceof Error && e.message.includes("UNIQUE constraint")) {
+      return c.json({ error: "Category name already exists" }, 409);
+    }
+    throw e;
+  }
+});
+
+// Reorder categories (MUST be before /:id to avoid matching "reorder" as id)
+categoriesRouter.patch("/reorder", async (c) => {
+  try {
+    const body = await c.req.json();
+    const { items } = reorderCategoriesSchema.parse(body);
+    reorderCategories(db, items);
+    return c.json({ ok: true });
+  } catch (e) {
+    if (e instanceof ZodError) {
+      return c.json({ error: e.issues[0]?.message ?? "Validation error" }, 400);
+    }
+    throw e;
+  }
+});
+
+// Update category
+categoriesRouter.patch("/:id", async (c) => {
+  try {
+    const body = await c.req.json();
+    const input = updateCategorySchema.parse(body);
+    const category = updateCategory(db, c.req.param("id"), input);
+    if (!category) {
+      return c.json({ error: "Category not found" }, 404);
+    }
+    return c.json(category);
+  } catch (e) {
+    if (e instanceof ZodError) {
+      return c.json({ error: e.issues[0]?.message ?? "Validation error" }, 400);
+    }
+    if (e instanceof Error && e.message.includes("UNIQUE constraint")) {
+      return c.json({ error: "Category name already exists" }, 409);
+    }
+    throw e;
+  }
+});
+
+// Delete category
+categoriesRouter.delete("/:id", (c) => {
+  const deleted = deleteCategory(db, c.req.param("id"));
+  if (!deleted) {
+    return c.json({ error: "Category not found" }, 404);
+  }
+  return c.json({ ok: true });
+});
+
+export { categoriesRouter };

--- a/server/routes/items.ts
+++ b/server/routes/items.ts
@@ -29,6 +29,7 @@ itemsRouter.get("/", (c) => {
       excludeStatus: c.req.query("excludeStatus"),
       type: c.req.query("type"),
       tag: c.req.query("tag"),
+      category_id: c.req.query("category_id"),
       sort: c.req.query("sort"),
       order: c.req.query("order"),
       limit: c.req.query("limit"),

--- a/server/schemas/categories.ts
+++ b/server/schemas/categories.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+export const createCategorySchema = z.object({
+  name: z.string().min(1, "Name is required").max(50),
+  color: z.string().max(20).nullable().default(null),
+});
+
+export const updateCategorySchema = z.object({
+  name: z.string().min(1).max(50).optional(),
+  color: z.string().max(20).nullable().optional(),
+  sort_order: z.number().int().min(0).optional(),
+});
+
+export const reorderCategoriesSchema = z.object({
+  items: z
+    .array(
+      z.object({
+        id: z.string().uuid(),
+        sort_order: z.number().int().min(0),
+      }),
+    )
+    .min(1),
+});
+
+export type CreateCategoryInput = z.infer<typeof createCategorySchema>;
+export type UpdateCategoryInput = z.infer<typeof updateCategorySchema>;

--- a/server/schemas/items.ts
+++ b/server/schemas/items.ts
@@ -27,6 +27,7 @@ export const createItemSchema = z.object({
   source: z.string().max(2000).nullable().default(null),
   aliases: z.array(z.string().max(200)).max(10).default([]),
   linked_note_id: z.string().uuid().nullable().default(null),
+  category_id: z.string().uuid().nullable().default(null),
 });
 
 export const updateItemSchema = z.object({
@@ -45,6 +46,7 @@ export const updateItemSchema = z.object({
   source: z.string().max(2000).nullable().optional(),
   aliases: z.array(z.string().max(200)).max(10).optional(),
   linked_note_id: z.string().uuid().nullable().optional(),
+  category_id: z.string().uuid().nullable().optional(),
 });
 
 export const listItemsSchema = z.object({
@@ -58,6 +60,7 @@ export const listItemsSchema = z.object({
   excludeStatus: z
     .union([z.string().transform((s) => s.split(",").filter(Boolean)), z.array(z.string())])
     .optional(),
+  category_id: z.string().uuid().optional(),
 });
 
 export const batchSchema = z.object({


### PR DESCRIPTION
## Summary
- New `/api/categories` endpoints: CRUD + reorder
- `category_id` nullable FK integrated into items create/update/list
- `category_name` computed field resolved in API responses (batch lookup)
- Obsidian export includes `category: "name"` in frontmatter (YAML-safe quoting)
- `category_id` preserved on all type conversions (including → scratch)

## Code review fixes (applied by team lead)
- YAML injection fix: category name now quoted in frontmatter (like sparkle_id, source)
- Race condition fix: createCategory uses transaction for MAX(sort_order) + INSERT

## Test plan
- [x] 19 new categories CRUD tests
- [x] 8 new items integration tests (create, update, list filter, category_name resolution, scratch preservation)
- [x] 3 new export frontmatter tests (include, omit, ordering)
- [x] All 755 tests pass (40 files, 0 regressions)
- [x] Lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)