### PR TITLE
fix: auto-focus category create input after Radix Select closes

### DIFF
--- a/src/components/__tests__/category-select.test.tsx
+++ b/src/components/__tests__/category-select.test.tsx
@@ -114,6 +114,7 @@ describe("CategorySelect", () => {
     await user.click(option);
 
     expect(screen.getByPlaceholderText("分類名稱...")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("分類名稱...")).toHaveFocus();
   });
 
   it("creates category and selects it on Enter", async () => {

--- a/src/components/category-select.tsx
+++ b/src/components/category-select.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import {
   Select,
   SelectContent,
@@ -23,6 +23,8 @@ export function CategorySelect({ value, onChange, disabled }: CategorySelectProp
   const [categories, setCategories] = useState<Category[]>([]);
   const [showCreateInput, setShowCreateInput] = useState(false);
   const [createInputValue, setCreateInputValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const shouldFocusCreateInput = useRef(false);
 
   useEffect(() => {
     listCategories().then((res) => {
@@ -34,6 +36,7 @@ export function CategorySelect({ value, onChange, disabled }: CategorySelectProp
     if (v === CREATE_VALUE) {
       setShowCreateInput(true);
       setCreateInputValue("");
+      shouldFocusCreateInput.current = true;
       return;
     }
     onChange(v === NONE_VALUE ? null : v);
@@ -60,6 +63,12 @@ export function CategorySelect({ value, onChange, disabled }: CategorySelectProp
     }
   };
 
+  useEffect(() => {
+    if (showCreateInput && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [showCreateInput]);
+
   const selectedCategory = categories.find((c) => c.id === value);
   const displayValue = value && selectedCategory ? value : NONE_VALUE;
 
@@ -83,7 +92,14 @@ export function CategorySelect({ value, onChange, disabled }: CategorySelectProp
             )}
           </SelectValue>
         </SelectTrigger>
-        <SelectContent>
+        <SelectContent
+          onCloseAutoFocus={(e) => {
+            if (shouldFocusCreateInput.current) {
+              e.preventDefault();
+              shouldFocusCreateInput.current = false;
+            }
+          }}
+        >
           <SelectItem value={NONE_VALUE}>未分類</SelectItem>
           {categories.map((cat) => (
             <SelectItem key={cat.id} value={cat.id}>
@@ -104,12 +120,12 @@ export function CategorySelect({ value, onChange, disabled }: CategorySelectProp
 
       {showCreateInput && (
         <Input
+          ref={inputRef}
           className="mt-2 w-32"
           placeholder="分類名稱..."
           value={createInputValue}
           onChange={(e) => setCreateInputValue(e.target.value)}
           onKeyDown={handleCreateKeyDown}
-          autoFocus
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- 修正點擊「+ 新增分類」後輸入框沒有自動聚焦的問題
- 使用 Radix 官方 `onCloseAutoFocus` API 阻止 focus 歸還 SelectTrigger
- 改用 `useRef` + `useEffect` 在 input 掛載後聚焦，取代失效的 `autoFocus`

## Test plan
- [x] 單元測試新增 `toHaveFocus()` 斷言，驗證 input 自動聚焦
- [x] 全部 772 個測試通過，零 regression
- [ ] 手動測試：開啟筆記 → 分類下拉 → 點「+ 新增分類」→ 確認游標在輸入框內

🤖 Generated with [Claude Code](https://claude.com/claude-code)