### PR TITLE
feat: add category select to fleeting triage

### DIFF
--- a/src/components/__tests__/fleeting-triage.test.tsx
+++ b/src/components/__tests__/fleeting-triage.test.tsx
@@ -6,11 +6,15 @@ import { toast } from "sonner";
 const mockListItems = vi.fn();
 const mockUpdateItem = vi.fn();
 const mockGetTags = vi.fn();
+const mockListCategories = vi.fn();
+const mockCreateCategory = vi.fn();
 
 vi.mock("@/lib/api", () => ({
   listItems: (...args: unknown[]) => mockListItems(...args),
   updateItem: (...args: unknown[]) => mockUpdateItem(...args),
   getTags: (...args: unknown[]) => mockGetTags(...args),
+  listCategories: (...args: unknown[]) => mockListCategories(...args),
+  createCategory: (...args: unknown[]) => mockCreateCategory(...args),
 }));
 
 vi.mock("sonner", () => ({
@@ -33,6 +37,8 @@ function makeFleetingItem(overrides: Record<string, unknown> = {}) {
     linked_note_id: null,
     linked_note_title: null,
     linked_todo_count: 0,
+    category_id: null,
+    category_name: null,
     share_visibility: null,
     created: "2026-02-28T10:00:00Z",
     modified: "2026-02-28T10:00:00Z",
@@ -44,11 +50,27 @@ function setupWithItems(items: Record<string, unknown>[]) {
   mockListItems.mockResolvedValue({ items, total: items.length });
   mockGetTags.mockResolvedValue({ tags: ["existing-tag"] });
   mockUpdateItem.mockResolvedValue({});
+  mockListCategories.mockResolvedValue({
+    categories: [
+      { id: "cat-1", name: "工作", color: "#ef4444", sort_order: 0 },
+      { id: "cat-2", name: "學習", color: "#3b82f6", sort_order: 1 },
+    ],
+  });
 }
 
 describe("FleetingTriage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Radix Select polyfills for jsdom
+    window.HTMLElement.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);
+    window.HTMLElement.prototype.setPointerCapture = vi.fn();
+    window.HTMLElement.prototype.releasePointerCapture = vi.fn();
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    window.ResizeObserver = vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+    }));
   });
 
   it("shows loading spinner initially", () => {
@@ -242,6 +264,109 @@ describe("FleetingTriage", () => {
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith("Network error");
+    });
+  });
+
+  describe("category selection", () => {
+    // Helper: CategorySelect trigger is the combobox that is a <button>, not the TagInput <input>
+    function getCategoryCombobox() {
+      const comboboxes = screen.getAllByRole("combobox");
+      const selectTrigger = comboboxes.find((el) => el.tagName === "BUTTON");
+      if (!selectTrigger) throw new Error("CategorySelect combobox not found");
+      return selectTrigger;
+    }
+
+    it("includes category_id in primary action when category is selected", async () => {
+      setupWithItems([makeFleetingItem({ id: "cat-note-1" })]);
+
+      const user = userEvent.setup();
+      render(<FleetingTriage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Test Fleeting Note")).toBeInTheDocument();
+      });
+
+      // Open category select and pick "工作"
+      await user.click(getCategoryCombobox());
+      const option = await screen.findByRole("option", { name: /工作/ });
+      await user.click(option);
+
+      await user.click(screen.getByText("發展"));
+
+      await waitFor(() => {
+        expect(mockUpdateItem).toHaveBeenCalledWith("cat-note-1", {
+          status: "developing",
+          category_id: "cat-1",
+        });
+      });
+    });
+
+    it("includes category_id in archive action when category is selected", async () => {
+      setupWithItems([makeFleetingItem({ id: "cat-arch-1" })]);
+
+      const user = userEvent.setup();
+      render(<FleetingTriage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Test Fleeting Note")).toBeInTheDocument();
+      });
+
+      await user.click(getCategoryCombobox());
+      const option = await screen.findByRole("option", { name: /學習/ });
+      await user.click(option);
+
+      await user.click(screen.getByText("封存"));
+
+      await waitFor(() => {
+        expect(mockUpdateItem).toHaveBeenCalledWith("cat-arch-1", {
+          status: "archived",
+          category_id: "cat-2",
+        });
+      });
+    });
+
+    it("does not include category_id when no category change is made", async () => {
+      setupWithItems([makeFleetingItem({ id: "no-cat-1" })]);
+
+      const user = userEvent.setup();
+      render(<FleetingTriage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("發展")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("發展"));
+
+      await waitFor(() => {
+        expect(mockUpdateItem).toHaveBeenCalledWith("no-cat-1", { status: "developing" });
+      });
+    });
+
+    it("resets category selection when skipping to next item", async () => {
+      setupWithItems([
+        makeFleetingItem({ id: "item-1", title: "First" }),
+        makeFleetingItem({ id: "item-2", title: "Second" }),
+      ]);
+
+      const user = userEvent.setup();
+      render(<FleetingTriage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("First")).toBeInTheDocument();
+      });
+
+      // Select a category on first item
+      await user.click(getCategoryCombobox());
+      const option = await screen.findByRole("option", { name: /工作/ });
+      await user.click(option);
+
+      // Skip to next
+      await user.click(screen.getByText("保留"));
+
+      expect(screen.getByText("Second")).toBeInTheDocument();
+
+      // Category select should show "未分類" (reset to next item's default)
+      expect(getCategoryCombobox()).toHaveTextContent("未分類");
     });
   });
 

--- a/src/components/fleeting-triage.tsx
+++ b/src/components/fleeting-triage.tsx
@@ -3,6 +3,7 @@ import { listItems, updateItem, getTags } from "@/lib/api";
 import { parseItems, type ParsedItem } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import { TagInput } from "@/components/tag-input";
+import { CategorySelect } from "@/components/category-select";
 import { useOnlineStatus } from "@/hooks/use-online-status";
 import { toast } from "sonner";
 import {
@@ -23,6 +24,7 @@ interface FleetingTriageProps {
 interface PendingChanges {
   type?: "note" | "todo";
   tags?: string[];
+  category_id?: string | null;
 }
 
 export function FleetingTriage({ onDone }: FleetingTriageProps) {
@@ -59,6 +61,8 @@ export function FleetingTriage({ onDone }: FleetingTriageProps) {
   // Resolved values: pending overrides current
   const resolvedType = pending.type ?? current?.type ?? "note";
   const resolvedTags = pending.tags ?? current?.tags ?? [];
+  const resolvedCategoryId =
+    pending.category_id !== undefined ? pending.category_id : (current?.category_id ?? null);
   const resetAndNext = () => {
     setPending({});
     if (currentIndex + 1 >= items.length) {
@@ -79,6 +83,7 @@ export function FleetingTriage({ onDone }: FleetingTriageProps) {
       updates.status = targetType === "note" ? "developing" : "active";
       if (pending.type !== undefined) updates.type = pending.type;
       if (pending.tags !== undefined) updates.tags = pending.tags;
+      if (pending.category_id !== undefined) updates.category_id = pending.category_id;
       await updateItem(current.id, updates);
       toast.success(targetType === "note" ? "已設為發展中" : "已設為進行中");
       resetAndNext();
@@ -93,6 +98,7 @@ export function FleetingTriage({ onDone }: FleetingTriageProps) {
       const updates: Record<string, unknown> = { status: "archived" };
       if (pending.type !== undefined) updates.type = pending.type;
       if (pending.tags !== undefined) updates.tags = pending.tags;
+      if (pending.category_id !== undefined) updates.category_id = pending.category_id;
       await updateItem(current.id, updates);
       toast.success("已封存");
       resetAndNext();
@@ -199,6 +205,15 @@ export function FleetingTriage({ onDone }: FleetingTriageProps) {
               placeholder="輸入標籤"
             />
           </div>
+        </div>
+
+        {/* Category */}
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-muted-foreground w-10">分類</span>
+          <CategorySelect
+            value={resolvedCategoryId}
+            onChange={(categoryId) => setPending((p) => ({ ...p, category_id: categoryId }))}
+          />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- 在閃念整理（FleetingTriage）的屬性區塊加入 CategorySelect，讓使用者在快速處理閃念筆記時可以指定分類
- 遵循現有的 PendingChanges 累積模式，選擇的分類在點「發展/進行/封存」時才送出 API
- 新增 4 個測試覆蓋分類選擇、封存、未選分類、跳過後重置等情境

## Test plan
- [x] 19 unit tests 全部通過（含 4 個新增的分類測試）
- [x] 776 全專案測試通過
- [x] lint + format 無錯誤
- [ ] 手動驗證：開啟閃念整理，選擇分類後點「發展」，確認 item 帶上 category_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)