### PR TITLE
fix: eliminate fixed-positioning layout pollution in mobile view

### DIFF
--- a/e2e/basic-flow.spec.ts
+++ b/e2e/basic-flow.spec.ts
@@ -15,7 +15,7 @@ test.describe("Login", () => {
     await page.getByRole("button", { name: "登入" }).click();
 
     // Main app loads — desktop default view is dashboard
-    await expect(page.getByText("總覽")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole("heading", { name: "總覽" })).toBeVisible({ timeout: 10_000 });
   });
 
   test("shows error for invalid token", async ({ page }) => {

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="zh-TW">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#0f172a" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -218,140 +218,144 @@ function MainApp() {
 
   return (
     <AppContext.Provider value={appContextValue}>
-      <div className="h-screen flex flex-col md:flex-row overflow-hidden">
+      <div className="h-dvh flex flex-col overflow-hidden">
         <OfflineIndicator />
-        <InstallPrompt />
 
-        {/* Desktop Sidebar */}
-        <div className="hidden md:flex">
-          <Sidebar />
-        </div>
+        {/* Inner wrapper: horizontal on desktop (sidebar + content) */}
+        <div className="flex-1 flex flex-col md:flex-row min-h-0 overflow-hidden">
+          {/* Desktop Sidebar */}
+          <div className="hidden md:flex">
+            <Sidebar />
+          </div>
 
-        {/* Main content area */}
-        <div className="flex-1 flex flex-col md:flex-row min-w-0 overflow-hidden">
-          {currentView === "dashboard" ? (
-            /* Dashboard takes full width */
-            <ErrorBoundary>
-              <Suspense fallback={<LoadingFallback />}>
-                <Dashboard
-                  onSelectItem={(item) => {
-                    setNavStack((prev) => [...prev, { view: "dashboard", itemId: null }]);
-                    setCurrentView("all");
-                    setSelectedItem(item);
-                  }}
-                />
-              </Suspense>
-            </ErrorBoundary>
-          ) : currentView === "settings" ? (
-            /* Settings takes full width */
-            <ErrorBoundary>
-              <Suspense fallback={<LoadingFallback />}>
-                <Settings onSettingsChanged={handleSettingsChanged} />
-              </Suspense>
-            </ErrorBoundary>
-          ) : currentView === "shares" ? (
-            /* Share Management takes full width */
-            <ErrorBoundary>
-              <Suspense fallback={<LoadingFallback />}>
-                <ShareManagement
-                  onNavigateToItem={async (itemId) => {
-                    setNavStack((prev) => [...prev, { view: "shares", itemId: null }]);
-                    try {
-                      const data = await getItem(itemId);
+          {/* Main content area */}
+          <div className="flex-1 flex flex-col md:flex-row min-w-0 overflow-hidden">
+            {currentView === "dashboard" ? (
+              /* Dashboard takes full width */
+              <ErrorBoundary>
+                <Suspense fallback={<LoadingFallback />}>
+                  <Dashboard
+                    onSelectItem={(item) => {
+                      setNavStack((prev) => [...prev, { view: "dashboard", itemId: null }]);
                       setCurrentView("all");
-                      setSelectedItem(parseItem(data));
-                    } catch {
-                      /* item may have been deleted */
-                    }
-                  }}
-                />
-              </Suspense>
-            </ErrorBoundary>
-          ) : (
-            <>
-              {/* List panel */}
-              <div
-                className={`flex-1 flex flex-col min-w-0 overflow-hidden ${
-                  selectedItem ? "hidden md:flex" : "flex"
-                } md:w-96 md:max-w-none md:flex-none md:border-r`}
-              >
-                <QuickCapture />
+                      setSelectedItem(item);
+                    }}
+                  />
+                </Suspense>
+              </ErrorBoundary>
+            ) : currentView === "settings" ? (
+              /* Settings takes full width */
+              <ErrorBoundary>
+                <Suspense fallback={<LoadingFallback />}>
+                  <Settings onSettingsChanged={handleSettingsChanged} />
+                </Suspense>
+              </ErrorBoundary>
+            ) : currentView === "shares" ? (
+              /* Share Management takes full width */
+              <ErrorBoundary>
+                <Suspense fallback={<LoadingFallback />}>
+                  <ShareManagement
+                    onNavigateToItem={async (itemId) => {
+                      setNavStack((prev) => [...prev, { view: "shares", itemId: null }]);
+                      try {
+                        const data = await getItem(itemId);
+                        setCurrentView("all");
+                        setSelectedItem(parseItem(data));
+                      } catch {
+                        /* item may have been deleted */
+                      }
+                    }}
+                  />
+                </Suspense>
+              </ErrorBoundary>
+            ) : (
+              <>
+                {/* List panel */}
+                <div
+                  className={`flex-1 flex flex-col min-w-0 overflow-hidden ${
+                    selectedItem ? "hidden md:flex" : "flex"
+                  } md:w-96 md:max-w-none md:flex-none md:border-r`}
+                >
+                  <QuickCapture />
 
-                {/* Triage toggle for fleeting view */}
-                {isFleetingView && (
-                  <div className="flex border-b">
-                    <Button
-                      variant="ghost"
-                      className={`flex-1 rounded-none gap-1.5 ${!triageMode ? "border-b-2 border-primary text-primary" : "text-muted-foreground"}`}
-                      onClick={() => setTriageMode(false)}
-                    >
-                      <List className="h-4 w-4" />
-                      列表
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      className={`flex-1 rounded-none gap-1.5 ${triageMode ? "border-b-2 border-primary text-primary" : "text-muted-foreground"}`}
-                      onClick={() => setTriageMode(true)}
-                    >
-                      <ListTodo className="h-4 w-4" />
-                      整理
-                    </Button>
-                  </div>
-                )}
+                  {/* Triage toggle for fleeting view */}
+                  {isFleetingView && (
+                    <div className="flex border-b">
+                      <Button
+                        variant="ghost"
+                        className={`flex-1 rounded-none gap-1.5 ${!triageMode ? "border-b-2 border-primary text-primary" : "text-muted-foreground"}`}
+                        onClick={() => setTriageMode(false)}
+                      >
+                        <List className="h-4 w-4" />
+                        列表
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        className={`flex-1 rounded-none gap-1.5 ${triageMode ? "border-b-2 border-primary text-primary" : "text-muted-foreground"}`}
+                        onClick={() => setTriageMode(true)}
+                      >
+                        <ListTodo className="h-4 w-4" />
+                        整理
+                      </Button>
+                    </div>
+                  )}
 
-                {isTriageActive ? (
-                  <div className="flex-1 overflow-y-auto">
+                  {isTriageActive ? (
+                    <div className="flex-1 overflow-y-auto">
+                      <ErrorBoundary>
+                        <Suspense fallback={<LoadingFallback />}>
+                          <FleetingTriage onDone={() => setTriageMode(false)} />
+                        </Suspense>
+                      </ErrorBoundary>
+                    </div>
+                  ) : currentView === "search" ? (
+                    <div className="flex-1 overflow-y-auto p-3 md:hidden">
+                      <SearchBar onSelect={handleSelect} />
+                    </div>
+                  ) : (
+                    <div className="flex-1 overflow-y-auto">
+                      <ItemList
+                        status={statusFilter}
+                        type={typeFilter}
+                        selectedId={selectedItem?.id}
+                        noteSubView={noteSubView}
+                        todoSubView={todoSubView}
+                        onNoteSubViewChange={setNoteSubView}
+                        onTodoSubViewChange={setTodoSubView}
+                      />
+                    </div>
+                  )}
+                </div>
+
+                {/* Detail panel */}
+                {selectedItem && (
+                  <div className="fixed inset-0 z-50 bg-background md:static md:z-auto md:flex-1 md:min-w-0 md:border-l">
                     <ErrorBoundary>
                       <Suspense fallback={<LoadingFallback />}>
-                        <FleetingTriage onDone={() => setTriageMode(false)} />
+                        <ItemDetail
+                          itemId={selectedItem.id}
+                          onDeleted={() => {
+                            setSelectedItem(null);
+                            setNavStack([]);
+                          }}
+                        />
                       </Suspense>
                     </ErrorBoundary>
                   </div>
-                ) : currentView === "search" ? (
-                  <div className="flex-1 overflow-y-auto p-3 md:hidden">
-                    <SearchBar onSelect={handleSelect} />
-                  </div>
-                ) : (
-                  <div className="flex-1 overflow-y-auto">
-                    <ItemList
-                      status={statusFilter}
-                      type={typeFilter}
-                      selectedId={selectedItem?.id}
-                      noteSubView={noteSubView}
-                      todoSubView={todoSubView}
-                      onNoteSubViewChange={setNoteSubView}
-                      onTodoSubViewChange={setTodoSubView}
-                    />
+                )}
+
+                {/* Empty state for desktop when no item selected */}
+                {!selectedItem && !isTriageActive && currentView !== "search" && (
+                  <div className="hidden md:flex flex-1 items-center justify-center text-muted-foreground">
+                    <p>選擇一個項目以查看詳情</p>
                   </div>
                 )}
-              </div>
-
-              {/* Detail panel */}
-              {selectedItem && (
-                <div className="fixed inset-0 z-50 bg-background md:static md:z-auto md:flex-1 md:min-w-0 md:border-l">
-                  <ErrorBoundary>
-                    <Suspense fallback={<LoadingFallback />}>
-                      <ItemDetail
-                        itemId={selectedItem.id}
-                        onDeleted={() => {
-                          setSelectedItem(null);
-                          setNavStack([]);
-                        }}
-                      />
-                    </Suspense>
-                  </ErrorBoundary>
-                </div>
-              )}
-
-              {/* Empty state for desktop when no item selected */}
-              {!selectedItem && !isTriageActive && currentView !== "search" && (
-                <div className="hidden md:flex flex-1 items-center justify-center text-muted-foreground">
-                  <p>選擇一個項目以查看詳情</p>
-                </div>
-              )}
-            </>
-          )}
+              </>
+            )}
+          </div>
         </div>
+
+        <InstallPrompt />
 
         {/* Mobile Bottom Nav - hidden when detail panel is open */}
         {!selectedItem && <BottomNav />}

--- a/src/components/__tests__/bottom-nav.test.tsx
+++ b/src/components/__tests__/bottom-nav.test.tsx
@@ -71,9 +71,8 @@ describe("BottomNav", () => {
     await user.click(screen.getByText("更多"));
     expect(screen.getByText("全部")).toBeInTheDocument();
 
-    // Click the overlay (the fixed inset-0 div)
-    const overlay = screen.getByText("全部").closest(".absolute")!.parentElement!;
-    await user.click(overlay);
+    // Click the overlay to close
+    await user.click(screen.getByTestId("more-overlay"));
 
     expect(screen.queryByText("全部")).not.toBeInTheDocument();
   });

--- a/src/components/bottom-nav.tsx
+++ b/src/components/bottom-nav.tsx
@@ -35,12 +35,17 @@ export function BottomNav() {
   const isMoreActive = moreItems.some((item) => item.id === currentView);
 
   return (
-    <>
-      {/* More sheet overlay */}
+    <nav className="relative bg-card border-t md:hidden pb-[env(safe-area-inset-bottom)]">
+      {/* More menu overlay + popup */}
       {moreOpen && (
-        <div className="fixed inset-0 z-40 md:hidden" onClick={() => setMoreOpen(false)}>
+        <>
           <div
-            className="absolute bottom-14 right-2 bg-popover border rounded-lg shadow-lg p-2 min-w-[120px]"
+            data-testid="more-overlay"
+            className="fixed inset-0 z-40"
+            onClick={() => setMoreOpen(false)}
+          />
+          <div
+            className="absolute bottom-full right-2 mb-2 z-40 bg-popover border rounded-lg shadow-lg p-2 min-w-[120px]"
             onClick={(e) => e.stopPropagation()}
           >
             {moreItems.map((item) => (
@@ -61,34 +66,32 @@ export function BottomNav() {
               </button>
             ))}
           </div>
-        </div>
+        </>
       )}
 
-      <nav className="fixed bottom-0 left-0 right-0 bg-card border-t z-40 md:hidden safe-area-pb">
-        <div className="flex justify-around">
-          {mainNavItems.map((item) => (
-            <button
-              key={item.id}
-              className={`flex flex-col items-center py-2 px-3 flex-1 ${
-                currentView === item.id ? "text-primary" : "text-muted-foreground"
-              }`}
-              onClick={() => onViewChange(item.id)}
-            >
-              {item.icon}
-              <span className="text-xs mt-0.5">{item.label}</span>
-            </button>
-          ))}
+      <div className="flex justify-around">
+        {mainNavItems.map((item) => (
           <button
+            key={item.id}
             className={`flex flex-col items-center py-2 px-3 flex-1 ${
-              isMoreActive || moreOpen ? "text-primary" : "text-muted-foreground"
+              currentView === item.id ? "text-primary" : "text-muted-foreground"
             }`}
-            onClick={() => setMoreOpen(!moreOpen)}
+            onClick={() => onViewChange(item.id)}
           >
-            <Menu className="h-5 w-5" />
-            <span className="text-xs mt-0.5">更多</span>
+            {item.icon}
+            <span className="text-xs mt-0.5">{item.label}</span>
           </button>
-        </div>
-      </nav>
-    </>
+        ))}
+        <button
+          className={`flex flex-col items-center py-2 px-3 flex-1 ${
+            isMoreActive || moreOpen ? "text-primary" : "text-muted-foreground"
+          }`}
+          onClick={() => setMoreOpen(!moreOpen)}
+        >
+          <Menu className="h-5 w-5" />
+          <span className="text-xs mt-0.5">更多</span>
+        </button>
+      </div>
+    </nav>
   );
 }

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -102,7 +102,7 @@ export function Dashboard({ onSelectItem }: DashboardProps) {
   if (!stats) return null;
 
   return (
-    <div className="flex-1 overflow-y-auto pb-20 md:pb-4">
+    <div className="flex-1 overflow-y-auto pb-4">
       <div className="max-w-2xl mx-auto p-4 space-y-6">
         {/* Page title */}
         <div className="flex items-center gap-2">

--- a/src/components/install-prompt.tsx
+++ b/src/components/install-prompt.tsx
@@ -46,7 +46,7 @@ export function InstallPrompt() {
   };
 
   return (
-    <div className="fixed bottom-20 left-4 right-4 z-50 mx-auto max-w-md animate-in slide-in-from-bottom-4 fade-in duration-300">
+    <div className="px-4 py-2 mx-auto max-w-md md:pb-4 animate-in slide-in-from-bottom-4 fade-in duration-300">
       <div className="flex items-center gap-3 rounded-lg border bg-background p-3 shadow-lg">
         <Download className="h-5 w-5 shrink-0 text-primary" />
         <p className="flex-1 text-sm">安裝到主畫面，享受更好的體驗</p>

--- a/src/components/offline-indicator.tsx
+++ b/src/components/offline-indicator.tsx
@@ -7,7 +7,7 @@ export function OfflineIndicator() {
   if (online) return null;
 
   return (
-    <div className="fixed top-0 left-0 right-0 bg-yellow-500 text-yellow-950 text-center py-1 text-sm z-50 flex items-center justify-center gap-1">
+    <div className="bg-yellow-500 text-yellow-950 text-center py-1 text-sm flex items-center justify-center gap-1">
       <WifiOff className="h-3.5 w-3.5" />
       離線模式
     </div>

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -142,7 +142,7 @@ export function Settings({ onSettingsChanged }: SettingsProps) {
   }
 
   return (
-    <div className="flex-1 overflow-y-auto pb-20 md:pb-4">
+    <div className="flex-1 overflow-y-auto pb-4">
       <div className="max-w-2xl mx-auto p-4 space-y-6">
         {/* Page title */}
         <div className="flex items-center gap-2">

--- a/src/components/share-management.tsx
+++ b/src/components/share-management.tsx
@@ -74,7 +74,7 @@ export function ShareManagement({ onNavigateToItem }: ShareManagementProps) {
   }
 
   return (
-    <div className="flex-1 overflow-y-auto pb-20 md:pb-4">
+    <div className="flex-1 overflow-y-auto pb-4">
       <div className="max-w-2xl mx-auto p-4 space-y-6">
         {/* Page title */}
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- **根因**：BottomNav、OfflineIndicator、InstallPrompt 使用 `position: fixed` 脫離 flex flow，導致每個捲動容器都需手動加 `pb-20` 補償——遺漏就爆（ItemList、FleetingTriage 兩處遺漏，手機上最後一筆被遮住）
- **修正**：將三個元件改為 in-flow flex children，由 flexbox 自動分配空間。新增 inner wrapper 讓 outer 永遠 `flex-col`（OfflineIndicator / content / BottomNav 垂直堆疊），inner 負責桌面 `md:flex-row`
- 移除 3 處 `pb-20 md:pb-4` workaround（settings、dashboard、share-management）
- 修復不存在的 `safe-area-pb` class → 改用 `pb-[env(safe-area-inset-bottom)]`
- `h-screen` → `h-dvh`（dynamic viewport height）
- 加 `viewport-fit=cover` 讓 iOS safe area inset 生效
- BottomNav More menu 改用 `bottom-full` 相對定位，消除 `bottom-14` magic number

## Test plan
- [x] Unit tests: 776 passed, 0 failed
- [x] E2E tests: 32 passed, 0 failed
- [x] Build: success
- [x] Lint: clean
- [ ] 手機實機驗證：列表最後一筆可見、BottomNav 不遮擋

🤖 Generated with [Claude Code](https://claude.com/claude-code)