### PR TITLE
fix: eliminate silent failures and harden error handling

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -112,7 +112,7 @@ app.use("*", async (c, next) => {
   await next();
   c.res.headers.set(
     "Content-Security-Policy",
-    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; worker-src 'self'; manifest-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'",
+    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; worker-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'",
   );
 });
 

--- a/server/routes/public.ts
+++ b/server/routes/public.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { sqlite } from "../db/index.js";
 import { getShareByToken, listPublicShares } from "../lib/shares.js";
 import { renderPublicPage, renderNotFoundPage } from "../lib/render-public-page.js";
+import { logger } from "../lib/logger.js";
 
 const publicRouter = new Hono();
 
@@ -18,7 +19,10 @@ publicRouter.get("/api/public/:token", (c) => {
   try {
     tags = JSON.parse(share.item_tags);
   } catch {
-    tags = [];
+    logger.warn(
+      { token: share.token, raw: share.item_tags },
+      "Failed to parse tags in shared item",
+    );
   }
 
   return c.json({
@@ -57,7 +61,10 @@ publicRouter.get("/s/:token", (c) => {
   try {
     tags = JSON.parse(share.item_tags);
   } catch {
-    tags = [];
+    logger.warn(
+      { token: share.token, raw: share.item_tags },
+      "Failed to parse tags in shared item",
+    );
   }
 
   const html = renderPublicPage({

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -18,8 +18,7 @@ searchRouter.get("/", (c) => {
     if (e instanceof ZodError) {
       return c.json({ error: e.issues[0]?.message ?? "Validation error" }, 400);
     }
-    // Catch FTS5 syntax errors and other unexpected failures gracefully
-    return c.json({ results: [] });
+    return c.json({ results: [], error: "搜尋失敗" }, 500);
   }
 });
 

--- a/server/routes/webhook.ts
+++ b/server/routes/webhook.ts
@@ -99,7 +99,7 @@ webhookRouter.post("/line", async (c) => {
             reply = formatNumberedList(`🔍 搜尋「${cmd.keyword}」`, results, results.length);
           }
         } catch {
-          reply = `🔍 找不到「${cmd.keyword}」相關的項目`;
+          reply = `❌ 搜尋失敗，請稍後再試`;
         }
         break;
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useMemo, lazy, Suspense } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { AuthGate } from "@/components/auth-gate";
 import { Toaster } from "@/components/ui/sonner";
+import { toast } from "sonner";
 import { QuickCapture } from "@/components/quick-capture";
 import { ItemList } from "@/components/item-list";
 import { SearchBar } from "@/components/search-bar";
@@ -98,7 +99,8 @@ function MainApp() {
         const itemData = await getItem(itemId);
         setSelectedItem(parseItem(itemData));
       } catch {
-        // item may have been deleted
+        setNavStack((prev) => prev.slice(0, -1));
+        toast.error("項目不存在或已被刪除");
       }
     },
     [currentView, selectedItem?.id],

--- a/src/components/install-prompt.tsx
+++ b/src/components/install-prompt.tsx
@@ -33,10 +33,14 @@ export function InstallPrompt() {
 
   const handleInstall = async () => {
     if (!deferredPrompt) return;
-    await deferredPrompt.prompt();
-    const { outcome } = await deferredPrompt.userChoice;
-    if (outcome === "accepted") {
-      deferredPrompt = null;
+    try {
+      await deferredPrompt.prompt();
+      const { outcome } = await deferredPrompt.userChoice;
+      if (outcome === "accepted") {
+        deferredPrompt = null;
+        setShow(false);
+      }
+    } catch {
       setShow(false);
     }
   };

--- a/src/components/linked-items-section.tsx
+++ b/src/components/linked-items-section.tsx
@@ -143,6 +143,7 @@ export function LinkedItemsSection({
         setNoteSearchResults(res.results.filter((r) => r.type === "note"));
       } catch {
         setNoteSearchResults([]);
+        toast.error("搜尋失敗");
       } finally {
         setNoteSearching(false);
       }

--- a/src/components/share-dialog.tsx
+++ b/src/components/share-dialog.tsx
@@ -47,7 +47,7 @@ export function ShareDialog({
       const res = await getItemShares(itemId);
       setShares(res.shares);
     } catch {
-      // silently fail
+      toast.error("無法載入分享資料");
     } finally {
       setLoading(false);
     }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -33,7 +33,7 @@ if ("serviceWorker" in navigator) {
       // Check for SW updates periodically (every 60 minutes)
       setInterval(() => reg.update(), 60 * 60 * 1000);
     } catch (err) {
-      console.log("SW registration failed:", err);
+      console.warn("SW registration failed:", err);
     }
 
     // Auto-reload when new SW activates (works with skipWaiting + clientsClaim).


### PR DESCRIPTION
## Summary
系統性缺陷搜查第二+三波，修復 9 個靜默失敗與防禦性缺陷：

- **Search API**：DB/FTS5 錯誤返回 500 + error message，而非靜默返回空結果
- **Share dialog**：載入失敗時顯示 toast.error，而非空列表
- **Navigation**：導覽到已刪除項目時顯示 toast + 回退 navStack
- **LINE find**：區分搜尋錯誤（❌）和無結果（🔍）
- **Linked items search**：搜尋失敗時顯示 toast
- **PWA install prompt**：加 try-catch 防止未捕獲 rejection
- **CSP**：加 `object-src 'none'`（OWASP 合規）
- **SW registration**：`console.log` → `console.warn`
- **Public share routes**：JSON 解析失敗加 `logger.warn`

## Test plan
- [x] Unit tests: 776 passed, 0 failed
- [x] Build: success
- [x] Lint: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)