### PR TITLE
fix: add offline sync failure notification and status SSOT guard

### DIFF
--- a/server/lib/__tests__/status-sync.test.ts
+++ b/server/lib/__tests__/status-sync.test.ts
@@ -1,0 +1,18 @@
+import { NOTE_STATUSES, TODO_STATUSES, SCRATCH_STATUSES } from "../items.js";
+import { statusEnum } from "../../schemas/items.js";
+
+describe("status constants sync", () => {
+  it("type-specific status arrays cover all statuses in Zod schema", () => {
+    const fromArrays = new Set([...NOTE_STATUSES, ...TODO_STATUSES, ...SCRATCH_STATUSES]);
+    const fromSchema = new Set(statusEnum.options);
+
+    expect(fromArrays).toEqual(fromSchema);
+  });
+
+  it("no unexpected statuses in type arrays that are missing from schema", () => {
+    const schemaStatuses = new Set(statusEnum.options);
+    for (const s of NOTE_STATUSES) expect(schemaStatuses.has(s)).toBe(true);
+    for (const s of TODO_STATUSES) expect(schemaStatuses.has(s)).toBe(true);
+    for (const s of SCRATCH_STATUSES) expect(schemaStatuses.has(s)).toBe(true);
+  });
+});

--- a/server/lib/items.ts
+++ b/server/lib/items.ts
@@ -8,9 +8,15 @@ import type * as schema from "../db/schema.js";
 
 type DB = BetterSQLite3Database<typeof schema>;
 
-const NOTE_STATUSES = ["fleeting", "developing", "permanent", "exported", "archived"] as const;
-const TODO_STATUSES = ["active", "done", "archived"] as const;
-const SCRATCH_STATUSES = ["draft", "archived"] as const;
+export const NOTE_STATUSES = [
+  "fleeting",
+  "developing",
+  "permanent",
+  "exported",
+  "archived",
+] as const;
+export const TODO_STATUSES = ["active", "done", "archived"] as const;
+export const SCRATCH_STATUSES = ["draft", "archived"] as const;
 
 export function isValidTypeStatus(type: string, status: string): boolean {
   if (type === "note") return (NOTE_STATUSES as readonly string[]).includes(status);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -168,6 +168,7 @@ export async function listItems(params?: {
   offset?: number;
   excludeStatus?: string[];
 }): Promise<ListItemsResponse> {
+  // Source of truth: server/schemas/items.ts statusEnum
   const validStatuses = new Set([
     "fleeting",
     "developing",
@@ -175,6 +176,7 @@ export async function listItems(params?: {
     "exported",
     "active",
     "done",
+    "draft",
     "archived",
   ]);
   const search = new URLSearchParams();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -53,6 +53,9 @@ if ("serviceWorker" in navigator) {
     if (event.data?.type === "OFFLINE_SYNC") {
       toast.success(`已同步 ${event.data.count} 個離線項目`);
     }
+    if (event.data?.type === "OFFLINE_SYNC_FAILED") {
+      toast.warning(`${event.data.count} 個離線項目同步失敗，將稍後重試`);
+    }
     if (event.data?.type === "CACHE_FALLBACK") {
       toast.info("離線模式：顯示的是快取資料", { id: "offline-fallback" });
     }

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -199,10 +199,17 @@ async function replayQueue() {
 
   if (syncedIds.length > 0) {
     await deleteFromQueue(syncedIds);
-    // Notify clients about synced items
-    const clients = await self.clients.matchAll({ type: "window" });
-    for (const client of clients) {
+  }
+
+  // Notify clients about sync results
+  const failedCount = items.length - syncedIds.length;
+  const clients = await self.clients.matchAll({ type: "window" });
+  for (const client of clients) {
+    if (syncedIds.length > 0) {
       client.postMessage({ type: "OFFLINE_SYNC", count: syncedIds.length });
+    }
+    if (failedCount > 0) {
+      client.postMessage({ type: "OFFLINE_SYNC_FAILED", count: failedCount });
     }
   }
 }


### PR DESCRIPTION
## Summary
系統性缺陷搜查最終波：

- **Offline queue 同步失敗通知**：SW replayQueue 失敗時發送 `OFFLINE_SYNC_FAILED` message，主線程顯示 toast.warning（之前完全靜默，使用者以為資料已保存）
- **狀態常數 SSOT 防護**：新增 `status-sync.test.ts` 驗證 `NOTE_STATUSES ∪ TODO_STATUSES ∪ SCRATCH_STATUSES === statusEnum.options`，防止再次出現像 `draft` 遺漏的 drift
- 前端 `validStatuses` 加 `draft` + SSOT 來源註釋

## Test plan
- [x] Unit tests: 778 passed (含 2 個新 sync tests), 0 failed
- [x] Build: success
- [x] Lint: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)