### PR TITLE
docs: add quality management tracking system support

### DIFF
--- a/.claude/skills/project-structure.md
+++ b/.claude/skills/project-structure.md
@@ -109,6 +109,18 @@ docs/
   self-hosting.md              # Self-hosting guide (English)
   self-hosting.zh-TW.md        # Self-hosting guide (繁體中文)
   cloudflare-access-setup.md   # Cloudflare Access setup guide (繁體中文)
+  plans/
+    quality/
+      README.md                # Quality dashboard (stats, Critical/High items, definitions)
+      defect-taxonomy.md       # Defect taxonomy — systematic search handbook
+      quality-system-design-notes.md  # Methodology design notes (portable)
+      TEMPLATE-DEFECT.md       # Defect item template
+      TEMPLATE-TECH-DEBT.md    # Tech Debt item template
+      TEMPLATE-FEATURE-GAP.md  # Feature Gap item template
+      defects/                 # DEF-NNN items
+      tech-debt/               # TD-NNN items
+      feature-gaps/            # FG-NNN items
+      gates/                   # Quality gate documents
 
 mcp-server/
   package.json            # MCP server dependencies
@@ -153,7 +165,7 @@ eslint.config.js        # ESLint 9 flat config (typescript-eslint, react-hooks, 
   hooks/
     migration-safety.sh   # PostToolUse hook: blocks SELECT * in migrations, enforces FK rules
   settings.json           # Claude Code project settings (hooks config)
-  skills/                 # On-demand documentation skills (6 files)
+  skills/                 # On-demand documentation skills (7 files, incl. quality.md)
 
 certs/                  # mkcert TLS certificates (gitignored)
 data/                   # SQLite database (gitignored)

--- a/.claude/skills/quality.md
+++ b/.claude/skills/quality.md
@@ -1,0 +1,109 @@
+---
+name: quality
+description: >
+  品質管理追蹤系統操作指南。當 Claude 修復 bug、處理缺陷、進行程式碼品質審查、
+  或被要求建立/更新品質追蹤項目時自動載入。涵蓋 Defect、Tech Debt、Feature Gap
+  的完整操作流程、搜查手冊使用、和完成步驟 checklist。
+user-invocable: true
+---
+
+# 品質管理追蹤系統
+
+Dashboard: `docs/plans/quality/README.md`
+搜查手冊: `docs/plans/quality/defect-taxonomy.md`
+設計筆記: `docs/plans/quality/quality-system-design-notes.md`
+
+---
+
+## 快速操作
+
+### 發現活躍項目
+
+```bash
+# 列出所有活躍 Defect
+glob docs/plans/quality/defects/DEF-*.md
+
+# 列出所有活躍 Tech Debt
+glob docs/plans/quality/tech-debt/TD-*.md
+
+# 列出所有活躍 Feature Gap
+glob docs/plans/quality/feature-gaps/FG-*.md
+
+# 搜尋特定狀態的項目
+grep '狀態.*Pending' docs/plans/quality/defects/
+grep '狀態.*In Progress' docs/plans/quality/defects/
+```
+
+### 建立新項目
+
+1. **判斷類型** — 用決策樹：
+   ```
+   有意識的妥協？→ Tech Debt
+   行為與意圖不符？→ Defect
+   功能設計不完整？→ Feature Gap
+   ```
+
+2. **決定 ID** — `ls` 對應目錄找最大編號 +1
+
+3. **複製模板** — `cp TEMPLATE-{TYPE}.md {dir}/{ID}-short-description.md`
+
+4. **填寫 metadata** — 所有欄位都要填（參照 README.md 定義）
+
+5. **更新 Dashboard** — 若 Critical/High → 加入 README Critical/High 表 + 更新統計
+
+6. **連結搜查手冊** — Defect 的「缺陷子類別」欄位連結到 defect-taxonomy.md 對應段落
+
+### 修復完成後（完成步驟 Checklist）
+
+> **IMPORTANT:** 每一步都要做，缺任何一步 = 未完成。
+
+- [ ] 項目檔「狀態」改為 Done
+- [ ] 填寫項目檔「完成紀錄」（Commit、修改摘要、測試結果）
+- [ ] 若在 README Critical/High 表中 → 移除該行
+- [ ] 更新 README 統計概覽（活躍項目數、Critical/High 計數）
+- [ ] 若有相依項目（Complements/Blocks）→ 檢查對方是否需更新
+- [ ] 搜查手冊的「已知實例」加入本項連結
+
+---
+
+## 分類體系
+
+| 分類 | 定義 | 模板 | 目錄 |
+|------|------|------|------|
+| **Defect** | 非預期的錯誤，寫入時就是錯的 | `TEMPLATE-DEFECT.md` | `defects/` |
+| **Tech Debt** | 有意識的妥協，先上線再改 | `TEMPLATE-TECH-DEBT.md` | `tech-debt/` |
+| **Feature Gap** | 功能不完整，缺少預期互動 | `TEMPLATE-FEATURE-GAP.md` | `feature-gaps/` |
+
+## 搜查手冊（Defect Taxonomy）
+
+系統性搜查工具，定義 Sparkle 專案的已知缺陷類別。每個類別有：
+- **定義**：什麼模式構成此類缺陷
+- **搜查方式**：可執行的 grep/搜查指令
+- **判定標準**：如何判斷是否為缺陷
+- **已知實例**：連結到 DEF 項目
+
+目前定義的缺陷類別：
+
+| 代號 | 缺陷類別 | 層級 |
+|------|---------|------|
+| D-SILENT | 靜默失敗與錯誤吞沒 | 全層 |
+| D-VALID | 輸入驗證缺口 | API |
+| D-STATE | 前端狀態管理不一致 | Frontend |
+| D-OFFLINE | 離線同步與 PWA 問題 | Frontend / SW |
+| D-QUERY | 查詢語意錯誤 | Server |
+| D-MIGRATE | DB Migration 安全性 | Server |
+| D-AUTH | 認證與授權缺口 | API |
+| D-EDGE | 邊界條件與資源限制 | 全層 |
+| D-TYPE | TypeScript 型別安全漏洞 | Frontend / Server |
+| D-PERF | 效能問題 | 全層 |
+
+執行搜查時，讀取 `docs/plans/quality/defect-taxonomy.md` 取得每個類別的具體搜查指令。
+
+---
+
+## 行為準則
+
+- **修復 bug 時**：檢查是否有對應的品質追蹤項目。若無且是系統性問題 → 建議建立（但由人類決定）。
+- **發現新問題時**：記錄到 README「待追蹤發現」段落。**不要主動升級為正式項目**。
+- **搜查手冊中發現同類問題時**：記錄到搜查手冊的「搜查結果」中。
+- **完成修復後**：嚴格執行「完成步驟 Checklist」，不要遺漏任何一步。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,14 @@ DB migration: version 0→13, idempotent steps. Claude auto-loads the convention
 
 For detailed conventions on specific modules (API retry, Performance, PWA, Logging, Sentry, CSP, Offline UI, State management, CI/CD, Sharing, Export), Claude auto-loads the conventions-detail skill when relevant.
 
+## Quality Management（品質管理）
+
+活躍的缺陷、技術債、功能缺口追蹤在 `docs/plans/quality/README.md`。Claude auto-loads the quality skill when relevant.
+
+**發現項目：** `glob docs/plans/quality/defects/DEF-*.md` + `grep '狀態.*Pending'`
+**修復後必須更新：** 依照項目檔底部「完成步驟」checklist 逐項執行。
+**建立新項目：** 依照 README.md「建立新項目」段落操作。
+
 ## Skills Reference
 
 Available skills for this project (invoke with `/skill-name` or auto-loaded by Claude):
@@ -110,6 +118,7 @@ Available skills for this project (invoke with `/skill-name` or auto-loaded by C
 | line-bot           | `/line-bot`   | LINE Bot commands & integration    |
 | mcp-server         | `/mcp-server` | MCP server for Claude Code         |
 | conventions-detail | auto          | Detailed module conventions        |
+| quality            | `/quality`    | Quality tracking system operations |
 
 ## Maintenance
 
@@ -122,3 +131,5 @@ When making changes that affect documentation, **update the relevant file in the
 - **`.claude/skills/line-bot.md`**: When LINE Bot commands change
 - **`.claude/skills/mcp-server.md`**: When MCP server tools/config changes
 - **`.claude/skills/conventions-detail.md`**: When module-specific conventions change
+- **`.claude/skills/quality.md`**: When quality tracking system changes
+- **`docs/plans/quality/README.md`**: When quality items are created/completed/updated


### PR DESCRIPTION
## Summary
- Add `Quality Management` section to CLAUDE.md with discovery/update/create instructions
- Add `/quality` skill (`.claude/skills/quality.md`) for AI-operated quality tracking workflows
- Update `project-structure.md` with `docs/plans/quality/` file tree

Quality plan files themselves are local-only (gitignored via `docs/plans/`), tracked in a separate local git repo.

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Verify `/quality` skill loads in new Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)