### PR TITLE
docs: update quality skill to use private companion repo

### DIFF
--- a/.claude/skills/quality.md
+++ b/.claude/skills/quality.md
@@ -82,10 +82,11 @@ grep '狀態.*In Progress' /home/tim/sparkle/docs/plans/quality/defects/
 
 ### 品質檔案版本控制
 
-品質追蹤檔案有獨立的本地 git repo。建立或更新品質項目後，提交變更：
+品質追蹤檔案在 private companion repo（`hottim900/sparkle-quality`），本地路徑同上。
+建立或更新品質項目後，commit + push：
 
 ```bash
-cd /home/tim/sparkle/docs/plans/quality && git add -A && git commit -m "描述變更"
+cd /home/tim/sparkle/docs/plans/quality && git add -A && git commit -m "描述變更" && git push
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Quality tracking files migrated from local-only git repo to private companion repo (`hottim900/sparkle-quality`)
- Updated skill commit instructions to include `git push`

## Test plan
- [x] Private repo created and files pushed
- [ ] Verify skill loads correctly in new session

🤖 Generated with [Claude Code](https://claude.com/claude-code)