### PR TITLE
docs: migrate skills to directory-based SKILL.md format

### DIFF
--- a/.claude/skills/conventions-detail/SKILL.md
+++ b/.claude/skills/conventions-detail/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: conventions-detail
-description: >
-  Detailed implementation conventions for specific Sparkle modules: API client retry/timeout
-  (fetchWithRetry), Performance and cache-control, PWA/Service Worker caching (Workbox),
-  pino logging, Sentry error tracking, CSP header, offline UI (useOnlineStatus), AppContext
-  state management, public sharing (SSR/OpenGraph), Obsidian export, Settings API, CI/CD
-  pipeline, Dependabot, Release-Please, DB migration history. Use when modifying these subsystems.
+description: Detailed implementation conventions for Sparkle subsystems. Use when modifying API client, PWA, logging, Sentry, CSP, offline UI, state management, CI/CD, sharing, export, or DB migrations.
 user-invocable: false
 ---
 

--- a/.claude/skills/line-bot/SKILL.md
+++ b/.claude/skills/line-bot/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: line-bot
-description: >
-  LINE Bot integration for Sparkle. Complete command reference (create, query, advance,
-  operate items), session mechanism with numbered items and 10-min TTL, natural language
-  date parsing (chrono-node zh.hant), webhook config. Use when developing LINE Bot features
-  or debugging webhook. Key files: server/routes/webhook.ts, server/lib/line*.ts.
+description: LINE Bot command reference and integration guide. Use when developing LINE Bot features or debugging the webhook.
 user-invocable: true
 ---
 

--- a/.claude/skills/mcp-server/SKILL.md
+++ b/.claude/skills/mcp-server/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: mcp-server
-description: >
-  MCP server for Claude Code integration with Sparkle. stdio transport, 10 tools
-  (search, CRUD, workflow, stats, guide), knowledge layer, build/dev/test commands,
-  registration via claude mcp add. Use when working on mcp-server/ code or debugging
-  Claude Code integration.
+description: MCP server for Claude Code integration. Use when working on mcp-server/ code or debugging Claude Code tool integration.
 user-invocable: true
 ---
 

--- a/.claude/skills/ops/SKILL.md
+++ b/.claude/skills/ops/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: ops
-description: >
-  Production deployment and operations for Sparkle. Self-hosted on WSL2 with systemd,
-  Cloudflare Tunnel, WireGuard VPN. Covers auto-deploy (GitHub Actions self-hosted runner),
-  environment variables, HTTPS/mkcert, iptables firewall, restic backup with offsite copy,
-  LINE push alert monitoring, Cloudflare Tunnel + Access setup, systemd service management.
-  Use for deployment issues, infrastructure changes, or ops tasks.
+description: Production deployment and operations guide. Use when troubleshooting deployment, modifying infrastructure, or managing systemd services.
 user-invocable: true
 ---
 

--- a/.claude/skills/project-structure/SKILL.md
+++ b/.claude/skills/project-structure/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: project-structure
-description: >
-  Complete annotated file tree for the Sparkle project. Maps every directory and file
-  to its purpose. Use when locating files, deciding where new code goes, tracing import
-  paths, or understanding relationships between server routes, lib modules, frontend
-  components, scripts, and config files.
+description: Complete annotated file tree. Use when locating files, deciding where new code goes, or tracing import paths.
 user-invocable: false
 ---
 
@@ -165,7 +161,14 @@ eslint.config.js        # ESLint 9 flat config (typescript-eslint, react-hooks, 
   hooks/
     migration-safety.sh   # PostToolUse hook: blocks SELECT * in migrations, enforces FK rules
   settings.json           # Claude Code project settings (hooks config)
-  skills/                 # On-demand documentation skills (7 files, incl. quality.md)
+  skills/                 # On-demand documentation skills (7 skill directories, each with SKILL.md)
+    ops/SKILL.md            # Production deployment & operations
+    testing/SKILL.md        # Test architecture & patterns
+    conventions-detail/SKILL.md  # Detailed module conventions
+    quality/SKILL.md        # Quality tracking system
+    mcp-server/SKILL.md     # MCP server for Claude Code
+    line-bot/SKILL.md       # LINE Bot integration
+    project-structure/SKILL.md   # This file — annotated file tree
 
 certs/                  # mkcert TLS certificates (gitignored)
 data/                   # SQLite database (gitignored)

--- a/.claude/skills/quality/SKILL.md
+++ b/.claude/skills/quality/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: quality
-description: >
-  品質管理追蹤系統操作指南。當 Claude 修復 bug、處理缺陷、進行程式碼品質審查、
-  或被要求建立/更新品質追蹤項目時自動載入。涵蓋 Defect、Tech Debt、Feature Gap
-  的完整操作流程、搜查手冊使用、和完成步驟 checklist。
+description: Quality tracking system operations guide. Use when fixing bugs, managing defect/tech-debt/feature-gap items, or running code quality audits.
 user-invocable: true
 ---
 

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: testing
-description: >
-  Test architecture, configuration, and patterns for Sparkle. Vitest unit tests
-  (server + frontend 707 tests), Playwright E2E tests (29 tests), coverage thresholds,
-  mock patterns (vi.mock, createTestDb, renderWithContext), E2E helpers and flakiness
-  workarounds, MCP server tests. Use when writing tests, debugging test failures,
-  or modifying test infrastructure.
+description: Test architecture and patterns reference. Use when writing tests, debugging test failures, or modifying test infrastructure.
 user-invocable: true
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,11 +123,11 @@ Available skills for this project (invoke with `/skill-name` or auto-loaded by C
 When making changes that affect documentation, **update the relevant file in the same commit or follow-up commit**:
 
 - **CLAUDE.md**: Core conventions, data model, dev commands, Skills Reference table
-- **`.claude/skills/project-structure.md`**: When files are added/removed/renamed
-- **`.claude/skills/testing.md`**: When tests are added/removed or test infra changes
-- **`.claude/skills/ops.md`**: When deployment/infra changes
-- **`.claude/skills/line-bot.md`**: When LINE Bot commands change
-- **`.claude/skills/mcp-server.md`**: When MCP server tools/config changes
-- **`.claude/skills/conventions-detail.md`**: When module-specific conventions change
-- **`.claude/skills/quality.md`**: When quality tracking system changes
+- **`.claude/skills/project-structure/SKILL.md`**: When files are added/removed/renamed
+- **`.claude/skills/testing/SKILL.md`**: When tests are added/removed or test infra changes
+- **`.claude/skills/ops/SKILL.md`**: When deployment/infra changes
+- **`.claude/skills/line-bot/SKILL.md`**: When LINE Bot commands change
+- **`.claude/skills/mcp-server/SKILL.md`**: When MCP server tools/config changes
+- **`.claude/skills/conventions-detail/SKILL.md`**: When module-specific conventions change
+- **`.claude/skills/quality/SKILL.md`**: When quality tracking system changes
 - **`docs/plans/quality/README.md`**: When quality items are created/completed/updated


### PR DESCRIPTION
## Summary
- Convert 7 flat `.claude/skills/*.md` files to official Claude Code directory format (`<name>/SKILL.md`)
- Simplify all skill descriptions from verbose multi-line summaries to concise "what it does + when to use" format
- Update `CLAUDE.md` maintenance section paths and `project-structure` file tree to reflect new structure

## Test plan
- [ ] Verify `/ops`, `/testing`, `/quality`, `/mcp-server`, `/line-bot` slash commands load correctly in a new Claude Code session
- [ ] Verify auto-loaded skills (`conventions-detail`, `project-structure`) still trigger on relevant context
- [ ] Confirm pre-commit hook still detects `.claude/skills/` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)