### PR TITLE
fix: add response.ok check to SW replayQueue and safe JSON parse (DEF-001, DEF-008)

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -132,11 +132,23 @@ export interface ParsedItem extends Omit<Item, "tags" | "aliases"> {
   aliases: string[];
 }
 
+function safeParseStringArray(json: string): string[] {
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (Array.isArray(parsed) && parsed.every((t) => typeof t === "string")) {
+      return parsed;
+    }
+  } catch {
+    // invalid JSON
+  }
+  return [];
+}
+
 export function parseItem(item: Item): ParsedItem {
   return {
     ...item,
-    tags: JSON.parse(item.tags) as string[],
-    aliases: JSON.parse(item.aliases) as string[],
+    tags: safeParseStringArray(item.tags),
+    aliases: safeParseStringArray(item.aliases),
   };
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -53,6 +53,9 @@ if ("serviceWorker" in navigator) {
     if (event.data?.type === "OFFLINE_SYNC") {
       toast.success(`已同步 ${event.data.count} 個離線項目`);
     }
+    if (event.data?.type === "OFFLINE_SYNC_REJECTED") {
+      toast.error(`${event.data.count} 個離線項目被伺服器拒絕，已從佇列移除`);
+    }
     if (event.data?.type === "OFFLINE_SYNC_FAILED") {
       toast.warning(`${event.data.count} 個離線項目同步失敗，將稍後重試`);
     }

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -165,6 +165,7 @@ async function replayQueue() {
   if (items.length === 0) return;
 
   const syncedIds: number[] = [];
+  const rejectedIds: number[] = [];
   for (const item of items) {
     try {
       // We need the auth token — get it from clients
@@ -182,7 +183,7 @@ async function replayQueue() {
         if (token) break;
       }
 
-      await fetch("/api/items", {
+      const res = await fetch("/api/items", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -190,6 +191,12 @@ async function replayQueue() {
         },
         body: JSON.stringify(item.body),
       });
+      if (!res.ok) {
+        if (res.status >= 500) break; // 5xx: temporary failure, stop and retry later
+        // 4xx: permanent failure, notify user but continue processing other items
+        rejectedIds.push(item.id);
+        continue;
+      }
       syncedIds.push(item.id);
     } catch {
       // If any request fails, stop and try again later
@@ -197,16 +204,23 @@ async function replayQueue() {
     }
   }
 
-  if (syncedIds.length > 0) {
-    await deleteFromQueue(syncedIds);
+  const idsToDelete = [...syncedIds, ...rejectedIds];
+  if (idsToDelete.length > 0) {
+    await deleteFromQueue(idsToDelete);
   }
 
   // Notify clients about sync results
-  const failedCount = items.length - syncedIds.length;
+  const failedCount = items.length - syncedIds.length - rejectedIds.length;
   const clients = await self.clients.matchAll({ type: "window" });
   for (const client of clients) {
     if (syncedIds.length > 0) {
       client.postMessage({ type: "OFFLINE_SYNC", count: syncedIds.length });
+    }
+    if (rejectedIds.length > 0) {
+      client.postMessage({
+        type: "OFFLINE_SYNC_REJECTED",
+        count: rejectedIds.length,
+      });
     }
     if (failedCount > 0) {
       client.postMessage({ type: "OFFLINE_SYNC_FAILED", count: failedCount });


### PR DESCRIPTION
## Summary
- **DEF-001**: SW `replayQueue()` now checks `response.ok` — 5xx stops replay, 4xx sends `OFFLINE_SYNC_REJECTED` notification and continues
- **DEF-008**: `parseItem()` uses `safeParseStringArray()` with try-catch instead of bare `JSON.parse`

## Test plan
- [x] 815 unit tests pass
- [ ] E2E tests pass after build
- [ ] Manual: offline create → online sync → verify notification on success/rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)