### PR TITLE
fix: complete React Query invalidation and adjust staleTime (DEF-002, TD-002)

### DIFF
--- a/src/components/linked-items-section.tsx
+++ b/src/components/linked-items-section.tsx
@@ -122,6 +122,7 @@ export function LinkedItemsSection({
       queryClient.invalidateQueries({ queryKey: queryKeys.items.all });
       queryClient.invalidateQueries({ queryKey: queryKeys.tags });
       queryClient.invalidateQueries({ queryKey: queryKeys.stats });
+      queryClient.invalidateQueries({ queryKey: queryKeys.categories });
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "建立失敗");
     } finally {
@@ -159,6 +160,9 @@ export function LinkedItemsSection({
       setNoteSearchQuery("");
       setNoteSearchResults([]);
       queryClient.invalidateQueries({ queryKey: queryKeys.items.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags });
+      queryClient.invalidateQueries({ queryKey: queryKeys.stats });
+      queryClient.invalidateQueries({ queryKey: queryKeys.categories });
       onSaveStatusChange("saved");
       if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
       savedTimerRef.current = setTimeout(() => onSaveStatusChange("idle"), 2000);
@@ -174,6 +178,9 @@ export function LinkedItemsSection({
       const updated = await updateItem(item.id, { linked_note_id: null });
       onItemChange(parseItem(updated));
       queryClient.invalidateQueries({ queryKey: queryKeys.items.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.tags });
+      queryClient.invalidateQueries({ queryKey: queryKeys.stats });
+      queryClient.invalidateQueries({ queryKey: queryKeys.categories });
       onSaveStatusChange("saved");
       if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
       savedTimerRef.current = setTimeout(() => onSaveStatusChange("idle"), 2000);

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -4,7 +4,7 @@ export function createQueryClient() {
   return new QueryClient({
     defaultOptions: {
       queries: {
-        staleTime: 0,
+        staleTime: 60_000,
         refetchOnWindowFocus: true,
         retry: false, // api.ts already has retry logic
       },


### PR DESCRIPTION
## Summary
- **DEF-002**: LinkedItemsSection — added missing `categories`, `tags`, `stats` invalidation to `handleCreateLinkedTodo`, `handleLinkNote`, `handleUnlinkNote`
- **TD-002**: React Query global `staleTime` changed from `0` to `60_000` (1 minute)

## Test plan
- [x] 815 unit tests pass
- [ ] E2E tests pass after build
- [ ] Manual: create linked todo → verify category stats update
- [ ] Manual: window focus → verify no unnecessary refetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)