### PR TITLE
refactor: replace webhook body any with Zod schema and document type assertions (TD-001)

### DIFF
--- a/server/lib/items.ts
+++ b/server/lib/items.ts
@@ -174,9 +174,9 @@ export function createItem(db: DB, input: Partial<CreateItemInput> & { title: st
   const values = {
     id,
     title: input.title,
-    type: type as "note" | "todo" | "scratch",
+    type: type as "note" | "todo" | "scratch", // SAFETY: Drizzle enum; validated by caller
     content: input.content ?? "",
-    status: status as "fleeting",
+    status: status as "fleeting", // SAFETY: Drizzle enum; validated by caller or defaultStatusForType
     priority: type === "scratch" ? null : (input.priority ?? null),
     due: type === "todo" ? (input.due ?? null) : null,
     tags: type === "scratch" ? "[]" : JSON.stringify(input.tags ?? []),
@@ -217,12 +217,15 @@ export function listItems(
   const conditions = [];
 
   if (filters?.status) {
+    // SAFETY: Drizzle requires literal union type; value is validated by Zod in route layer
     conditions.push(eq(items.status, filters.status as "fleeting"));
   }
   if (filters?.excludeStatus && filters.excludeStatus.length > 0) {
+    // SAFETY: Drizzle requires literal union type; values are validated by Zod in route layer
     conditions.push(notInArray(items.status, filters.excludeStatus as ["fleeting"]));
   }
   if (filters?.type) {
+    // SAFETY: Drizzle requires literal union type; value is validated by Zod in route layer
     conditions.push(eq(items.type, filters.type as "note"));
   }
   if (filters?.linked_note_id) {
@@ -407,6 +410,7 @@ export function searchItems(
       ORDER BY created DESC
       LIMIT ?
     `);
+    // SAFETY: better-sqlite3 returns unknown[]; columns match items schema by migration
     const rows = stmt.all(pattern, pattern, limit) as (typeof items.$inferSelect)[];
     return resolveLinkedInfo(db, rows);
   }
@@ -421,6 +425,7 @@ export function searchItems(
     LIMIT ?
   `);
 
+  // SAFETY: better-sqlite3 returns unknown[]; columns match items schema by migration
   const rows = stmt.all(escaped, limit) as (typeof items.$inferSelect)[];
   return resolveLinkedInfo(db, rows);
 }
@@ -433,6 +438,7 @@ export function getAllTags(sqlite: Database.Database): string[] {
     ORDER BY value
   `);
 
+  // SAFETY: better-sqlite3 returns unknown[]; single-column query result
   const rows = stmt.all() as { tag: string }[];
   return rows.map((r) => r.tag);
 }

--- a/server/lib/shares.ts
+++ b/server/lib/shares.ts
@@ -35,6 +35,7 @@ export function createShareToken(
   visibility: "unlisted" | "public" = "unlisted",
 ): ShareTokenRow | null {
   // Verify item exists and is a note
+  // SAFETY: better-sqlite3 .get() returns unknown; schema enforced by migration
   const item = sqlite.prepare("SELECT id, type FROM items WHERE id = ?").get(itemId) as
     | { id: string; type: string }
     | undefined;
@@ -52,6 +53,7 @@ export function createShareToken(
     )
     .run(id, itemId, token, visibility, now);
 
+  // SAFETY: better-sqlite3 .get() returns unknown; columns match ShareTokenRow by migration schema
   return sqlite.prepare("SELECT * FROM share_tokens WHERE id = ?").get(id) as ShareTokenRow;
 }
 
@@ -72,36 +74,43 @@ export function getShareByToken(sqlite: Database.Database, token: string): Share
       JOIN items i ON i.id = s.item_id
       WHERE s.token = ?`,
     )
+    // SAFETY: better-sqlite3 .get() returns unknown; columns match ShareWithItem by query + migration schema
     .get(token) as ShareWithItem | undefined;
 
   return row ?? null;
 }
 
 export function listShares(sqlite: Database.Database): ShareListItem[] {
-  return sqlite
-    .prepare(
-      `SELECT
+  return (
+    sqlite
+      .prepare(
+        `SELECT
         s.id, s.item_id, s.token, s.visibility, s.created,
         i.title AS item_title
       FROM share_tokens s
       JOIN items i ON i.id = s.item_id
       ORDER BY s.created DESC`,
-    )
-    .all() as ShareListItem[];
+      )
+      // SAFETY: better-sqlite3 .all() returns unknown[]; columns match ShareListItem by query + migration schema
+      .all() as ShareListItem[]
+  );
 }
 
 export function listPublicShares(sqlite: Database.Database): ShareListItem[] {
-  return sqlite
-    .prepare(
-      `SELECT
+  return (
+    sqlite
+      .prepare(
+        `SELECT
         s.id, s.item_id, s.token, s.visibility, s.created,
         i.title AS item_title
       FROM share_tokens s
       JOIN items i ON i.id = s.item_id
       WHERE s.visibility = 'public'
       ORDER BY s.created DESC`,
-    )
-    .all() as ShareListItem[];
+      )
+      // SAFETY: better-sqlite3 .all() returns unknown[]; columns match ShareListItem by query + migration schema
+      .all() as ShareListItem[]
+  );
 }
 
 export function revokeShare(sqlite: Database.Database, shareId: string): boolean {
@@ -110,7 +119,10 @@ export function revokeShare(sqlite: Database.Database, shareId: string): boolean
 }
 
 export function getSharesByItemId(sqlite: Database.Database, itemId: string): ShareTokenRow[] {
-  return sqlite
-    .prepare("SELECT * FROM share_tokens WHERE item_id = ? ORDER BY created DESC")
-    .all(itemId) as ShareTokenRow[];
+  return (
+    sqlite
+      .prepare("SELECT * FROM share_tokens WHERE item_id = ? ORDER BY created DESC")
+      // SAFETY: better-sqlite3 .all() returns unknown[]; columns match ShareTokenRow by migration schema
+      .all(itemId) as ShareTokenRow[]
+  );
 }

--- a/server/routes/webhook.ts
+++ b/server/routes/webhook.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import crypto from "node:crypto";
+import { z } from "zod";
 import { safeCompare } from "../lib/safe-compare.js";
 import { logger } from "../lib/logger.js";
 import { db, sqlite } from "../db/index.js";
@@ -25,6 +26,17 @@ import {
   replyLine,
   STATUS_LABELS,
 } from "../lib/line-format.js";
+
+const lineEventSchema = z.object({
+  type: z.string(),
+  message: z.object({ type: z.string(), text: z.string().optional() }).optional(),
+  source: z.object({ userId: z.string() }).optional(),
+  replyToken: z.string().optional(),
+});
+
+const lineWebhookSchema = z.object({
+  events: z.array(lineEventSchema).default([]),
+});
 
 export const webhookRouter = new Hono();
 
@@ -61,23 +73,24 @@ webhookRouter.post("/line", async (c) => {
     return c.json({ error: "Invalid signature" }, 401);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let body: any;
+  let parsed: z.infer<typeof lineWebhookSchema>;
   try {
-    body = JSON.parse(rawBody);
+    const json: unknown = JSON.parse(rawBody);
+    parsed = lineWebhookSchema.parse(json);
   } catch {
     return c.json({ error: "Invalid JSON body" }, 400);
   }
-  const events = body.events ?? [];
+  const events = parsed.events;
 
   for (const event of events) {
-    if (event.type !== "message" || event.message.type !== "text") {
-      if (event.type === "message" && event.message.type !== "text" && event.replyToken) {
+    if (event.type !== "message" || event.message?.type !== "text") {
+      if (event.type === "message" && event.message?.type !== "text" && event.replyToken) {
         await replyLine(channelToken, event.replyToken, "📎 目前僅支援文字訊息");
       }
       continue;
     }
 
+    if (!event.message?.text) continue; // narrowing: guaranteed by message.type === "text" check above
     const text: string = event.message.text;
     const userId: string = event.source?.userId ?? "unknown";
     const cmd = parseCommand(text);


### PR DESCRIPTION
## Summary
- **TD-001**: Replace `body: any` in webhook.ts with Zod schema validation
- Add `// SAFETY:` comments to justified `as` assertions in shares.ts and items.ts
- `tsc --noEmit` clean

## Test plan
- [x] 815 unit tests pass
- [x] tsc --noEmit passes
- [ ] Manual: LINE Bot commands still work after webhook schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)