### PR TITLE
feat: display item ID in detail view metadata

### DIFF
--- a/src/components/item-detail.tsx
+++ b/src/components/item-detail.tsx
@@ -497,6 +497,7 @@ export function ItemDetail({ itemId, onDeleted }: ItemDetailProps) {
 
         {/* Metadata */}
         <div className="text-xs text-muted-foreground space-y-1">
+          <p>ID: {item.id}</p>
           <p>建立: {new Date(item.created).toLocaleString("zh-TW")}</p>
           <p>更新: {new Date(item.modified).toLocaleString("zh-TW")}</p>
         </div>


### PR DESCRIPTION
## Summary
- Show the item ID in the detail page metadata section (alongside created/modified timestamps)
- Enables users to easily reference note IDs when using MCP tools

## Test plan
- [ ] Open any note/todo/scratch detail view
- [ ] Verify the ID is displayed above the created/modified timestamps
- [ ] Verify the ID matches the expected value from the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)