### PR TITLE
feat: move metadata below title in detail view

### DIFF
--- a/src/components/item-detail.tsx
+++ b/src/components/item-detail.tsx
@@ -281,6 +281,12 @@ export function ItemDetail({ itemId, onDeleted }: ItemDetailProps) {
           placeholder="標題"
         />
 
+        {/* Metadata */}
+        <div className="text-xs text-muted-foreground font-mono">
+          {item.id} · 建立 {new Date(item.created).toLocaleString("zh-TW")} · 更新{" "}
+          {new Date(item.modified).toLocaleString("zh-TW")}
+        </div>
+
         {/* Type + Status + Priority row */}
         <div className="flex gap-2 flex-wrap">
           <Select
@@ -494,13 +500,6 @@ export function ItemDetail({ itemId, onDeleted }: ItemDetailProps) {
             }
           }}
         />
-
-        {/* Metadata */}
-        <div className="text-xs text-muted-foreground space-y-1">
-          <p>ID: {item.id}</p>
-          <p>建立: {new Date(item.created).toLocaleString("zh-TW")}</p>
-          <p>更新: {new Date(item.modified).toLocaleString("zh-TW")}</p>
-        </div>
       </div>
 
       {/* Share Dialog */}


### PR DESCRIPTION
## Summary
- Move ID and created/updated timestamps from bottom of detail page to below title
- Always visible without scrolling, regardless of content length
- Type indicator bar restored to clean state (type label only)

Supersedes #85

## Test plan
- [ ] Open any note/todo/scratch detail view
- [ ] Verify ID and timestamps appear below title, above type/status selectors
- [ ] Verify bottom of detail page has no metadata
- [ ] Verify type indicator bar only shows type label

🤖 Generated with [Claude Code](https://claude.com/claude-code)