### PR TITLE
feat: show short ID with click-to-copy full UUID

### DIFF
--- a/src/components/item-detail.tsx
+++ b/src/components/item-detail.tsx
@@ -283,7 +283,18 @@ export function ItemDetail({ itemId, onDeleted }: ItemDetailProps) {
 
         {/* Metadata */}
         <div className="text-xs text-muted-foreground font-mono">
-          {item.id} · 建立 {new Date(item.created).toLocaleString("zh-TW")} · 更新{" "}
+          <button
+            type="button"
+            className="hover:text-foreground transition-colors cursor-pointer"
+            title="點擊複製完整 ID"
+            onClick={() => {
+              navigator.clipboard.writeText(item.id);
+              toast.success("已複製 ID");
+            }}
+          >
+            {item.id.split("-")[0]}
+          </button>
+          {" · "}建立 {new Date(item.created).toLocaleString("zh-TW")} · 更新{" "}
           {new Date(item.modified).toLocaleString("zh-TW")}
         </div>
 


### PR DESCRIPTION
## Summary
- Display only first segment of UUID (8 chars) in detail view metadata
- Click the short ID to copy full UUID to clipboard
- Toast confirmation on copy

## Test plan
- [ ] Open any item detail view
- [ ] Verify short ID (8 chars) is shown below title
- [ ] Click the short ID → clipboard should have full UUID, toast "已複製 ID" appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)