### PR TITLE
fix: prevent SW from caching CF Access pages after idle

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -99,6 +99,11 @@ if (lineSecret || lineToken) {
 const app = new Hono();
 
 app.use("*", requestLogger);
+// Marker header for SW to distinguish Sparkle responses from CF Access pages
+app.use("*", async (c, next) => {
+  await next();
+  c.res.headers.set("X-Sparkle", "1");
+});
 app.use("*", compress());
 app.use("*", async (c, next) => {
   await next();

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -25,6 +25,10 @@ registerRoute(
     cacheName: "pages",
     plugins: [
       {
+        // Only cache responses from Sparkle server, not CF Access challenge pages
+        cacheWillUpdate: async ({ response }) => {
+          return response && response.headers.get("X-Sparkle") === "1" ? response : null;
+        },
         handlerDidError: async () => {
           return (
             (await matchPrecache("index.html")) ||
@@ -52,7 +56,9 @@ registerRoute(
     plugins: [
       {
         cacheWillUpdate: async ({ response }) => {
-          return response && response.status === 200 ? response : null;
+          return response && response.status === 200 && response.headers.get("X-Sparkle") === "1"
+            ? response
+            : null;
         },
         fetchDidFail: async ({ request }) => {
           failedFetches.add(request.url);


### PR DESCRIPTION
## Summary
- Server 加 `X-Sparkle: 1` response header，標記來自 Sparkle 的回應
- SW navigation 和 API `NetworkFirst` route 加 `cacheWillUpdate` plugin，只快取帶有 `X-Sparkle` header 的 response
- CF Access challenge/login 頁面不帶此 header → 不快取 → 不汙染後續請求

## Problem
閒置一段時間後 CF Access session 過期，SW 把 CF Access 的 challenge 頁面快取到 `pages`/`api-cache`，導致後續重新整理仍顯示離線狀態，需要 Ctrl+Shift+R 或刪 cookie 才能恢復。

## Test Plan
- [x] `npm run build` 成功
- [x] `npx tsc --noEmit` 通過
- [x] `npx vitest run` 838 tests 全部通過
- [ ] Deploy 後手動測試：閒置至 CF Access 過期 → 重新整理後正常走認證流程

🤖 Generated with [Claude Code](https://claude.com/claude-code)