### PR TITLE
feat: support short ID prefix lookup in GET /api/items/:id

### DIFF
--- a/mcp-server/src/__tests__/tools.test.ts
+++ b/mcp-server/src/__tests__/tools.test.ts
@@ -14,6 +14,7 @@ vi.mock("../client.js", () => ({
 }));
 
 import * as client from "../client.js";
+import { registerReadTools } from "../tools/read.js";
 import { registerSearchTools } from "../tools/search.js";
 import { registerWriteTools } from "../tools/write.js";
 import { registerWorkflowTools } from "../tools/workflow.js";
@@ -57,6 +58,44 @@ describe("sparkle_search", () => {
     const result = await handler({ query: "fail", limit: 20 });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("Network error");
+  });
+});
+
+describe("sparkle_get_note", () => {
+  function getReadHandler() {
+    const server = makeMockServer();
+    registerReadTools(server as never);
+    return server.getHandler("sparkle_get_note");
+  }
+
+  it("accepts short ID prefix (8 chars)", async () => {
+    const handler = getReadHandler();
+    const item = makeItem({ title: "Found by prefix" });
+    getItem.mockResolvedValue(item);
+
+    const result = await handler({ id: "a4662876" });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("Found by prefix");
+    expect(getItem).toHaveBeenCalledWith("a4662876");
+  });
+
+  it("still accepts full UUID", async () => {
+    const handler = getReadHandler();
+    const item = makeItem();
+    getItem.mockResolvedValue(item);
+
+    const result = await handler({ id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" });
+    expect(result.isError).toBeUndefined();
+    expect(getItem).toHaveBeenCalledWith("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+  });
+
+  it("returns error when item not found", async () => {
+    const handler = getReadHandler();
+    getItem.mockRejectedValue(new Error("Not found"));
+
+    const result = await handler({ id: "deadbeef" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Not found");
   });
 });
 

--- a/mcp-server/src/tools/read.ts
+++ b/mcp-server/src/tools/read.ts
@@ -8,14 +8,15 @@ export function registerReadTools(server: McpServer): void {
     "sparkle_get_note",
     {
       title: "Get Sparkle Note",
-      description: `Read a single Sparkle note or todo by ID. Returns full content, metadata, tags, aliases, and linked items info.
+      description: `Read a single Sparkle note or todo by ID. Supports full UUID or short ID prefix (min 4 chars, e.g. "a4662876").
 
 Args:
-  - id (string): Item UUID
+  - id (string): Full UUID or short ID prefix (min 4 chars)
 
-Returns: Full item with title, content, status, tags, aliases, linked items, and metadata.`,
+Returns: Full item with title, content, status, tags, aliases, linked items, and metadata.
+If prefix matches multiple items, returns error with candidate IDs.`,
       inputSchema: {
-        id: z.string().uuid().describe("Item UUID"),
+        id: z.string().min(4).describe("Item UUID or short ID prefix (min 4 chars)"),
       },
       annotations: {
         readOnlyHint: true,
@@ -60,10 +61,25 @@ Args:
 
 Returns: List of items with total count and pagination info.`,
       inputSchema: {
-        status: z.enum(["fleeting", "developing", "permanent", "exported", "active", "done", "draft", "archived"]).optional().describe("Filter by status"),
+        status: z
+          .enum([
+            "fleeting",
+            "developing",
+            "permanent",
+            "exported",
+            "active",
+            "done",
+            "draft",
+            "archived",
+          ])
+          .optional()
+          .describe("Filter by status"),
         tag: z.string().optional().describe("Filter by tag name"),
         type: z.enum(["note", "todo", "scratch"]).default("note").describe("Item type"),
-        sort: z.enum(["created", "modified", "priority", "due"]).default("created").describe("Sort field"),
+        sort: z
+          .enum(["created", "modified", "priority", "due"])
+          .default("created")
+          .describe("Sort field"),
         limit: z.number().int().min(1).max(100).default(50).describe("Max results"),
         offset: z.number().int().min(0).default(0).describe("Pagination offset"),
       },

--- a/server/lib/items.ts
+++ b/server/lib/items.ts
@@ -1,4 +1,4 @@
-import { eq, desc, asc, sql, and, notInArray, inArray } from "drizzle-orm";
+import { eq, desc, asc, sql, and, notInArray, inArray, like } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import type Database from "better-sqlite3";
 import { v4 as uuidv4 } from "uuid";
@@ -193,10 +193,35 @@ export function createItem(db: DB, input: Partial<CreateItemInput> & { title: st
   return db.select().from(items).where(eq(items.id, id)).get()!;
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 export function getItem(db: DB, id: string): ItemWithLinkedInfo | null {
-  const row = db.select().from(items).where(eq(items.id, id)).get() ?? null;
-  if (!row) return null;
-  return resolveLinkedInfo(db, [row])[0]!;
+  // Full UUID — exact match (fast path)
+  if (UUID_RE.test(id)) {
+    const row = db.select().from(items).where(eq(items.id, id)).get() ?? null;
+    if (!row) return null;
+    return resolveLinkedInfo(db, [row])[0]!;
+  }
+
+  // Short prefix — LIKE match (min 4 chars)
+  if (id.length < 4) return null;
+  const rows = db
+    .select()
+    .from(items)
+    .where(like(items.id, `${id}%`))
+    .limit(2)
+    .all();
+  if (rows.length === 0) return null;
+  if (rows.length > 1) {
+    const error = new Error(`Ambiguous ID prefix '${id}' matches multiple items`) as Error & {
+      status: number;
+      matches: string[];
+    };
+    error.status = 409;
+    error.matches = rows.map((r) => r.id);
+    throw error;
+  }
+  return resolveLinkedInfo(db, [rows[0]!])[0]!;
 }
 
 export function listItems(

--- a/server/routes/__tests__/api.test.ts
+++ b/server/routes/__tests__/api.test.ts
@@ -562,6 +562,30 @@ describe("Items CRUD", () => {
       const body = await res.json();
       expect(body.error).toMatch(/not found/i);
     });
+
+    it("resolves short ID prefix (8 chars) to full item", async () => {
+      const createRes = await app.request("/api/items", {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({ title: "Prefix Test" }),
+      });
+      const created = await createRes.json();
+      const shortId = created.id.substring(0, 8);
+
+      const res = await app.request(`/api/items/${shortId}`, {
+        headers: authHeaders(),
+      });
+      expect(res.status).toBe(200);
+      const item = await res.json();
+      expect(item.id).toBe(created.id);
+    });
+
+    it("returns 404 for non-matching prefix", async () => {
+      const res = await app.request("/api/items/zzzzzzzz", {
+        headers: authHeaders(),
+      });
+      expect(res.status).toBe(404);
+    });
   });
 
   describe("PATCH /api/items/:id", () => {

--- a/server/routes/items.ts
+++ b/server/routes/items.ts
@@ -215,13 +215,26 @@ itemsRouter.post("/:id/export", (c) => {
   }
 });
 
-// Get single item
+// Get single item (supports full UUID or short ID prefix)
 itemsRouter.get("/:id", (c) => {
-  const item = getItem(db, c.req.param("id"));
-  if (!item) {
-    return c.json({ error: "Item not found" }, 404);
+  try {
+    const item = getItem(db, c.req.param("id"));
+    if (!item) {
+      return c.json({ error: "Item not found" }, 404);
+    }
+    return c.json(item);
+  } catch (e) {
+    if ((e as { status?: number }).status === 409) {
+      return c.json(
+        {
+          error: (e as Error).message,
+          matches: (e as { matches: string[] }).matches,
+        },
+        409,
+      );
+    }
+    throw e;
   }
-  return c.json(item);
 });
 
 // Update item


### PR DESCRIPTION
## Summary

- `getItem()` 支援短 ID 前綴查詢（最少 4 碼），透過 `LIKE 'prefix%'` 匹配
- 完整 UUID 走 exact match fast path，行為不變
- 前綴碰撞回傳 409 + 候選 ID 清單
- MCP `sparkle_get_note` schema 放寬為 `.min(4)`，可直接用筆記中的 8 碼 ref ID

## Test plan

- [x] Server route test: 短 ID prefix 解析成功 (200)
- [x] Server route test: 不匹配 prefix 回 404
- [x] MCP test: 8 碼短 ID 正常取得筆記
- [x] MCP test: 完整 UUID 仍正常運作
- [x] MCP test: 找不到時回傳 error
- [x] Full test suite: 840/840 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)