### PR TITLE
fix: don't serve stale API cache when online and fetch fails

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -61,7 +61,16 @@ registerRoute(
             : null;
         },
         fetchDidFail: async ({ request }) => {
-          failedFetches.add(request.url);
+          if (navigator.onLine) {
+            // Online but fetch failed (likely CF Access session expired).
+            // Delete stale cache so NetworkFirst can't fall back,
+            // letting the error propagate to fetchWithRetry which shows
+            // "連線已過期，請重新整理頁面以重新驗證".
+            const cache = await caches.open("api-cache");
+            await cache.delete(request.url);
+          } else {
+            failedFetches.add(request.url);
+          }
         },
         handlerDidRespond: async ({ request, response }) => {
           const url = request.url;


### PR DESCRIPTION
## Summary
- SW 的 `fetchDidFail` 改為在 `navigator.onLine` 時清除 stale cache entry，讓 NetworkFirst 無法 fallback
- Error 穿透到 `fetchWithRetry` → 觸發既有的 "連線已過期，請重新整理頁面以重新驗證" 提示
- 離線行為（`navigator.onLine === false`）不變

## Problem
CF Access session 過期後，API fetch 因跨域 redirect 產生 CORS error。SW 的 NetworkFirst 退而求其次回傳之前存的合法 cache，導致使用者看到 "離線模式：顯示的是快取資料" + stale data，必須手動清快取才能恢復。

上次修復 (15d2ac1) 只防止 CF Access 頁面進入 cache，但 stale cache 是正常使用時存的合法 response。

## Root Cause
經 Workbox 源碼驗證：`fetchDidFail`（await）→ error re-throw → `cacheMatch`。在 `fetchDidFail` 中刪除 cache entry 保證在 cache lookup 之前完成。

## Test plan
- [x] `npm run build` 成功
- [x] `npx tsc --noEmit` 通過
- [x] `npx vitest run` 840 tests 全部通過
- [ ] Deploy 後手動測試：CF Access 過期 → 看到 "連線已過期" 而非 "離線模式"
- [ ] 離線測試：斷網 → 仍看到 "離線模式" toast（行為不變）

🤖 Generated with [Claude Code](https://claude.com/claude-code)