### PR TITLE
feat: add SW fetch failure diagnostics for idle debugging

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -62,6 +62,16 @@ if ("serviceWorker" in navigator) {
     if (event.data?.type === "CACHE_FALLBACK") {
       toast.info("離線模式：顯示的是快取資料", { id: "offline-fallback" });
     }
+    if (event.data?.type === "FETCH_DIAG") {
+      const { url, online, error, time } = event.data;
+      const entry = `[${time}] online=${online} err=${error} url=${url}`;
+      console.warn("[SW fetch-diag]", entry);
+      // Persist last 20 entries in localStorage for post-mortem analysis
+      const log = JSON.parse(localStorage.getItem("sw_fetch_diag") || "[]") as string[];
+      log.push(entry);
+      if (log.length > 20) log.shift();
+      localStorage.setItem("sw_fetch_diag", JSON.stringify(log));
+    }
     if (event.data?.type === "GET_AUTH_TOKEN") {
       const token = localStorage.getItem("auth_token") || "";
       event.ports[0]?.postMessage({ token });

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -60,12 +60,21 @@ registerRoute(
             ? response
             : null;
         },
-        fetchDidFail: async ({ request }) => {
+        fetchDidFail: async ({ request, error }) => {
+          const diag = {
+            url: request.url,
+            online: navigator.onLine,
+            error: error instanceof Error ? `${error.name}: ${error.message}` : String(error),
+            time: new Date().toISOString(),
+          };
+          // Diagnostic: send to clients so main thread can log/persist
+          const clients = await self.clients.matchAll({ type: "window" });
+          for (const client of clients) {
+            client.postMessage({ type: "FETCH_DIAG", ...diag });
+          }
           if (navigator.onLine) {
-            // Online but fetch failed (likely CF Access session expired).
-            // Delete stale cache so NetworkFirst can't fall back,
-            // letting the error propagate to fetchWithRetry which shows
-            // "連線已過期，請重新整理頁面以重新驗證".
+            // Online but fetch failed — delete stale cache so NetworkFirst
+            // can't fall back, letting error propagate to fetchWithRetry.
             const cache = await caches.open("api-cache");
             await cache.delete(request.url);
           } else {


### PR DESCRIPTION
## Summary
- SW 的 `fetchDidFail` 加入診斷資訊（error type、URL、online 狀態、時間戳）
- 透過 `postMessage` 傳到 main thread，存入 `localStorage`（key: `sw_fetch_diag`，保留最近 20 筆）
- 用於事後分析閒置後 "離線模式" 問題的真正原因

## Context
PR #90 修正了 online 時不 fallback 到 stale cache 的行為，但無法重現原始問題（刪除 CF_Authorization cookie 後 F5 仍正常運作）。需要診斷資料來找到真正的 root cause。

## 使用方式
問題發生後，在 DevTools Console 執行：
```js
JSON.parse(localStorage.getItem('sw_fetch_diag'))
```

## Test plan
- [x] `npm run build` 成功
- [x] `npx tsc --noEmit` 通過
- [x] `npx vitest run` 840 tests 全部通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)