### PR TITLE
fix: auto-reload on CF Access session expiry instead of showing error

### DIFF
--- a/src/lib/__tests__/fetch-with-retry.test.ts
+++ b/src/lib/__tests__/fetch-with-retry.test.ts
@@ -197,8 +197,12 @@ describe("fetchWithRetry", () => {
 
   // --- CF Access JWT expiry detection ---
 
-  it("throws ApiClientError when all retries fail with network error while online (CF Access expired)", async () => {
+  it("auto-reloads on first CF Access expiry (network error while online)", async () => {
     vi.stubGlobal("navigator", { onLine: true });
+    const reloadMock = vi.fn();
+    vi.stubGlobal("location", { reload: reloadMock });
+    sessionStorage.clear();
+
     fetchSpy
       .mockRejectedValueOnce(new TypeError("Failed to fetch"))
       .mockRejectedValueOnce(new TypeError("Failed to fetch"))
@@ -208,6 +212,28 @@ describe("fetchWithRetry", () => {
     await vi.runAllTimersAsync();
 
     const error = await promise.catch((e: unknown) => e);
+    expect(reloadMock).toHaveBeenCalledOnce();
+    expect(error).toBeInstanceOf(ApiClientError);
+    expect(error).toMatchObject({ message: "重新驗證中…", status: 0 });
+  });
+
+  it("throws error instead of reload loop when CF Access reload already attempted", async () => {
+    vi.stubGlobal("navigator", { onLine: true });
+    const reloadMock = vi.fn();
+    vi.stubGlobal("location", { reload: reloadMock });
+    // Simulate a recent reload
+    sessionStorage.setItem("cf_auth_reload", String(Date.now()));
+
+    fetchSpy
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+    const promise = fetchWithRetry("/api/test");
+    await vi.runAllTimersAsync();
+
+    const error = await promise.catch((e: unknown) => e);
+    expect(reloadMock).not.toHaveBeenCalled();
     expect(error).toBeInstanceOf(ApiClientError);
     expect(error).toMatchObject({
       message: "連線已過期，請重新整理頁面以重新驗證",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -111,6 +111,18 @@ export async function fetchWithRetry(url: string, options: RequestInit = {}): Pr
           throw new ApiClientError("Request timed out", 0);
         }
         if (isNetworkError(error) && navigator.onLine) {
+          // CF Access session likely expired — auto-reload to re-authenticate.
+          // Guard with sessionStorage to prevent infinite reload loops
+          // (e.g. if server is actually down, reload won't help).
+          const RELOAD_KEY = "cf_auth_reload";
+          const RELOAD_COOLDOWN_MS = 30_000;
+          const lastReload = sessionStorage.getItem(RELOAD_KEY);
+          const now = Date.now();
+          if (!lastReload || now - Number(lastReload) > RELOAD_COOLDOWN_MS) {
+            sessionStorage.setItem(RELOAD_KEY, String(now));
+            window.location.reload();
+            throw new ApiClientError("重新驗證中…", 0);
+          }
           throw new ApiClientError("連線已過期，請重新整理頁面以重新驗證", 0);
         }
         throw error;


### PR DESCRIPTION
## Summary
- CF Access session 過期後，API fetch 全部 CORS 失敗，之前只顯示錯誤訊息要使用者手動重新整理
- 手機上更慘，沒有 hard-reload 快捷鍵，只能手動刪 cookie 重新登入
- 現在自動 `window.location.reload()` 觸發 CF Access 重新驗證
- 用 `sessionStorage` 30 秒 cooldown 防止無限 reload 迴圈（例如伺服器真的掛了）

## Test plan
- [x] 新增測試：首次 CF Access 過期時自動 reload
- [x] 新增測試：cooldown 內不重複 reload，改為顯示錯誤訊息
- [x] 全部 841 tests 通過
- [ ] 部署後閒置測試：等 CF Access session 過期，確認手機自動恢復

🤖 Generated with [Claude Code](https://claude.com/claude-code)