### PR TITLE
chore: add branch name convention validation (TD-010)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -15,6 +15,16 @@ if [ "$branch" = "main" ]; then
   exit 1
 fi
 
+# Branch name convention check
+if [[ ! "$branch" =~ ^(feat|fix|docs|chore|refactor|test|perf|ci|build|style|revert)/[a-z0-9] ]]; then
+  echo ""
+  echo "ERROR: Branch 名稱 '$branch' 不符合 {type}/{short-description} 格式。"
+  echo "允許的 types: feat, fix, docs, chore, refactor, test, perf, ci, build, style, revert"
+  echo "範例: fix/error-boundary, feat/aria-labels"
+  echo ""
+  exit 1
+fi
+
 # === CLAUDE.md / skills update warning ===
 has_code_change=$(git diff --cached --name-only | grep -qE '^(mcp-server|server|src|scripts|docs)/' && echo true || echo false)
 has_doc_change=$(git diff --cached --name-only | grep -qE '^(CLAUDE\.md|\.claude/skills/)' && echo true || echo false)


### PR DESCRIPTION
## Summary
- 在 pre-commit hook 加入 branch 命名規範檢查
- 分支名稱必須符合 `{type}/{short-description}` 格式
- 不合規分支會顯示錯誤訊息和範例

## Quality
- Closes TD-010

## Test plan
- [ ] 在不合規 branch（如 `test_bad`）上嘗試 commit → 被擋
- [ ] 在合規 branch（如 `fix/test`）上 commit → 正常通過
- [ ] `main` branch 仍然被擋（既有邏輯）

🤖 Generated with [Claude Code](https://claude.com/claude-code)