### PR TITLE
chore: upgrade hono to latest 4.x (TD-006)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.13.8",
+        "@hono/node-server": "^1.19.11",
         "@sentry/node": "^10.40.0",
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-router": "^1.166.7",
@@ -19,7 +19,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.1",
-        "hono": "^4.7.4",
+        "hono": "^4.12.7",
         "hono-rate-limiter": "^0.5.3",
         "lucide-react": "^0.577.0",
         "marked": "^17.0.3",
@@ -10055,9 +10055,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
+      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     ]
   },
   "dependencies": {
-    "@hono/node-server": "^1.13.8",
+    "@hono/node-server": "^1.19.11",
     "@sentry/node": "^10.40.0",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-router": "^1.166.7",
@@ -47,7 +47,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.1",
-    "hono": "^4.7.4",
+    "hono": "^4.12.7",
     "hono-rate-limiter": "^0.5.3",
     "lucide-react": "^0.577.0",
     "marked": "^17.0.3",


### PR DESCRIPTION
## Summary
- 升級 `hono` 4.7.4 → 4.12.7 和 `@hono/node-server` 1.13.8 → 1.19.11
- 驗證 `hono-rate-limiter` peer dependency 相容性（要求 hono ^4 || ^5，已滿足）

## Quality
- Closes TD-006

## Test plan
- [x] `npm audit --audit-level=high` 無 Hono 漏洞
- [x] `npx tsc --noEmit` 通過
- [x] `npx vitest run` 通過（856 tests passed）
- [ ] Server 正常啟動

🤖 Generated with [Claude Code](https://claude.com/claude-code)