### PR TITLE
fix: add ErrorBoundary to list Outlet and error state UI (DEF-015, DEF-016)

### DIFF
--- a/src/components/item-list.tsx
+++ b/src/components/item-list.tsx
@@ -37,6 +37,7 @@ import {
   StickyNote,
   ChevronDown,
   ChevronRight,
+  AlertCircle,
 } from "lucide-react";
 
 type SortOption = {
@@ -173,6 +174,7 @@ export function ItemList({ status, type }: ItemListProps) {
     data: itemsData,
     isPending,
     error: itemsError,
+    refetch,
   } = useQuery({
     queryKey: queryKeys.items.list(filters),
     queryFn: () => listItems(filters),
@@ -361,6 +363,18 @@ export function ItemList({ status, type }: ItemListProps) {
     return (
       <div className="flex items-center justify-center py-12">
         <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (itemsError) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+        <AlertCircle className="h-10 w-10 mb-2" />
+        <p className="text-sm">載入失敗</p>
+        <Button variant="ghost" size="sm" onClick={() => refetch()} className="mt-2">
+          重試
+        </Button>
       </div>
     );
   }

--- a/src/routes/_list.tsx
+++ b/src/routes/_list.tsx
@@ -19,7 +19,9 @@ function ListLayout() {
         } md:w-96 md:max-w-none md:flex-none md:border-r`}
       >
         <QuickCapture />
-        <Outlet />
+        <ErrorBoundary>
+          <Outlet />
+        </ErrorBoundary>
       </div>
 
       {/* Detail panel */}


### PR DESCRIPTION
## Summary
- DEF-015: 在 `_list.tsx` 的 list panel `<Outlet />` 外包 `<ErrorBoundary>`，防止 render error 白屏
- DEF-016: 在 `item-list.tsx` 加入錯誤狀態 UI（載入失敗 + 重試按鈕），與既有 toast 互補

## Quality
- Closes DEF-015, DEF-016

## Test plan
- [ ] `npx tsc --noEmit` 通過
- [ ] `npx vitest run` 通過
- [ ] 手動：React DevTools 模擬 render error → 看到 ErrorBoundary fallback
- [ ] 手動：斷網 → 列表顯示「載入失敗」+ 重試按鈕

🤖 Generated with [Claude Code](https://claude.com/claude-code)