### PR TITLE
fix: preserve search params on navigate + remove type casts (DEF-017, TD-004)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -15,15 +15,19 @@ if [ "$branch" = "main" ]; then
   exit 1
 fi
 
-# Branch name convention check
-if [[ ! "$branch" =~ ^(feat|fix|docs|chore|refactor|test|perf|ci|build|style|revert)/[a-z0-9] ]]; then
-  echo ""
-  echo "ERROR: Branch 名稱 '$branch' 不符合 {type}/{short-description} 格式。"
-  echo "允許的 types: feat, fix, docs, chore, refactor, test, perf, ci, build, style, revert"
-  echo "範例: fix/error-boundary, feat/aria-labels"
-  echo ""
-  exit 1
-fi
+# Branch name convention check (POSIX sh compatible — husky runs hooks with sh)
+case "$branch" in
+  feat/*|fix/*|docs/*|chore/*|refactor/*|test/*|perf/*|ci/*|build/*|style/*|revert/*)
+    ;; # valid
+  *)
+    echo ""
+    echo "ERROR: Branch 名稱 '$branch' 不符合 {type}/{short-description} 格式。"
+    echo "允許的 types: feat, fix, docs, chore, refactor, test, perf, ci, build, style, revert"
+    echo "範例: fix/error-boundary, feat/aria-labels"
+    echo ""
+    exit 1
+    ;;
+esac
 
 # === CLAUDE.md / skills update warning ===
 has_code_change=$(git diff --cached --name-only | grep -qE '^(mcp-server|server|src|scripts|docs)/' && echo true || echo false)

--- a/src/components/__tests__/sidebar.test.tsx
+++ b/src/components/__tests__/sidebar.test.tsx
@@ -107,10 +107,15 @@ describe("Sidebar", () => {
 
     await user.click(screen.getByText("idea"));
     expect(mockNavigate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        search: { tag: "idea", item: undefined },
-      }),
+      expect.objectContaining({ search: expect.any(Function) }),
     );
+    const searchFn = mockNavigate.mock.calls[0][0].search;
+    expect(searchFn({ sort: "created", cat: "cat-1" })).toEqual({
+      sort: "created",
+      cat: "cat-1",
+      tag: "idea",
+      item: undefined,
+    });
   });
 
   it("clicking an already-selected tag deselects it", async () => {
@@ -125,10 +130,14 @@ describe("Sidebar", () => {
 
     await user.click(screen.getByText("idea"));
     expect(mockNavigate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        search: { tag: undefined, item: undefined },
-      }),
+      expect.objectContaining({ search: expect.any(Function) }),
     );
+    const searchFn = mockNavigate.mock.calls[0][0].search;
+    expect(searchFn({ tag: "idea", sort: "created" })).toEqual({
+      tag: undefined,
+      item: undefined,
+      sort: "created",
+    });
   });
 
   it("settings link points to /settings", () => {

--- a/src/components/item-detail.tsx
+++ b/src/components/item-detail.tsx
@@ -80,14 +80,14 @@ export function ItemDetail({ itemId, onDeleted }: ItemDetailProps) {
 
   const handleBack = useCallback(() => {
     navigate({
-      search: (prev: Record<string, unknown>) => ({ ...prev, item: undefined }),
+      search: (prev) => ({ ...prev, item: undefined }),
     } as NavigateOptions);
   }, [navigate]);
 
   const handleNavigate = useCallback(
     (linkedItemId: string) => {
       navigate({
-        search: (prev: Record<string, unknown>) => ({ ...prev, item: linkedItemId }),
+        search: (prev) => ({ ...prev, item: linkedItemId }),
       } as NavigateOptions);
     },
     [navigate],

--- a/src/components/item-list.tsx
+++ b/src/components/item-list.tsx
@@ -333,7 +333,7 @@ export function ItemList({ status, type }: ItemListProps) {
   const handleSelect = useCallback(
     (item: ParsedItem) => {
       navigate({
-        search: (prev: Record<string, unknown>) => ({ ...prev, item: item.id }),
+        search: (prev) => ({ ...prev, item: item.id }),
       } as NavigateOptions);
     },
     [navigate],
@@ -342,7 +342,7 @@ export function ItemList({ status, type }: ItemListProps) {
   const handleNavigate = useCallback(
     (itemId: string) => {
       navigate({
-        search: (prev: Record<string, unknown>) => ({ ...prev, item: itemId }),
+        search: (prev) => ({ ...prev, item: itemId }),
       } as NavigateOptions);
     },
     [navigate],

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -104,11 +104,12 @@ export function Sidebar() {
     queryFn: () => getTags().then((r) => r.tags),
   });
 
-  const searchParams = useRouterState({ select: (s) => s.location.search }) as Record<
-    string,
-    unknown
-  >;
-  const selectedTag = typeof searchParams.tag === "string" ? searchParams.tag : undefined;
+  const selectedTag = useRouterState({
+    select: (s) => {
+      const search = s.location.search as Record<string, unknown>;
+      return typeof search.tag === "string" ? search.tag : undefined;
+    },
+  });
 
   return (
     <div data-testid="sidebar" className="w-64 border-r h-full flex flex-col bg-card">
@@ -116,7 +117,9 @@ export function Sidebar() {
       <div className="p-3 border-b">
         <SearchBar
           onSelect={(item) => {
-            navigate({ search: { item: item.id } } as NavigateOptions);
+            navigate({
+              search: (prev) => ({ ...prev, item: item.id }),
+            } as NavigateOptions);
           }}
         />
       </div>
@@ -137,8 +140,7 @@ export function Sidebar() {
                 className="w-full justify-start gap-2"
                 asChild
               >
-                {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-                <Link to={v.path} search={{} as any}>
+                <Link to={v.path} search={{}}>
                   {v.icon}
                   {v.label}
                 </Link>
@@ -161,7 +163,7 @@ export function Sidebar() {
                 onClick={() => {
                   const newTag = selectedTag === tag ? undefined : tag;
                   navigate({
-                    search: { tag: newTag, item: undefined },
+                    search: (prev) => ({ ...prev, tag: newTag, item: undefined }),
                   } as NavigateOptions);
                 }}
               >
@@ -179,8 +181,7 @@ export function Sidebar() {
           className="w-full justify-start gap-2 text-muted-foreground"
           asChild
         >
-          {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-          <Link to="/settings" search={{} as any}>
+          <Link to="/settings" search={{}}>
             <Settings className="h-4 w-4" />
             設定
           </Link>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -64,7 +64,7 @@ function RootLayout() {
   const handleMobileSearchSelect = useCallback(
     (item: { id: string }) => {
       setMobileSearchOpen(false);
-      navigate({ search: { item: item.id } });
+      navigate({ search: (prev) => ({ ...prev, item: item.id }) });
     },
     [navigate],
   );


### PR DESCRIPTION
## Summary

- **DEF-017 fix**: 3 處 `navigate({ search: { ... } })` 改為 function updater `(prev) => ({ ...prev, ... })`，修復 sidebar tag click、search select、mobile search 靜默覆蓋 sort/order/cat params 的 bug
- **TD-004 partial**: 移除 sidebar 的 2 個 `as any` cast + 2 個 `eslint-disable` 註解；簡化 search param selector。共用元件的 `as NavigateOptions` 因 TanStack Router 結構限制保留
- **Pre-commit fix**: `[[ =~ ]]` bash-only 語法改為 POSIX `case`（husky 用 `sh` 執行 hook，此系統 `sh` 是 dash）

## Test plan

- [x] `npx tsc --noEmit` 通過
- [x] `npx vitest run` — 855 tests 全通過
- [x] `grep "as any" src/components/sidebar.tsx` — 零結果
- [ ] E2E: 設定排序後點 tag，確認排序 params 保留
- [ ] E2E: 設定 tag 後搜尋選取項目，確認 tag param 保留

🤖 Generated with [Claude Code](https://claude.com/claude-code)