### PR TITLE
refactor: unify type-status validation in Zod schema + optional enrichment (TD-013, TD-014)

### DIFF
--- a/server/lib/__tests__/item-type-system.test.ts
+++ b/server/lib/__tests__/item-type-system.test.ts
@@ -8,7 +8,7 @@ import {
   getAutoMappedStatus,
   defaultStatusForType,
 } from "../item-type-system.js";
-import { statusEnum } from "../../schemas/items.js";
+import { statusEnum, createItemSchema } from "../../schemas/items.js";
 
 describe("item-type-system", () => {
   describe("TYPE_STATUS_MAP is single source of truth", () => {
@@ -85,6 +85,30 @@ describe("item-type-system", () => {
     it("maps scratch↔todo", () => {
       expect(getAutoMappedStatus("scratch", "todo", "draft")).toBe("active");
       expect(getAutoMappedStatus("todo", "scratch", "active")).toBe("draft");
+    });
+  });
+
+  describe("createItemSchema type-status refine", () => {
+    it("rejects invalid status for note type", () => {
+      expect(() =>
+        createItemSchema.parse({ title: "x", type: "note", status: "active" }),
+      ).toThrow();
+    });
+
+    it("accepts valid status for todo type", () => {
+      const result = createItemSchema.parse({ title: "x", type: "todo", status: "active" });
+      expect(result.status).toBe("active");
+    });
+
+    it("accepts missing status (uses default)", () => {
+      const result = createItemSchema.parse({ title: "x" });
+      expect(result.status).toBeUndefined();
+    });
+
+    it("rejects todo status for scratch type", () => {
+      expect(() =>
+        createItemSchema.parse({ title: "x", type: "scratch", status: "active" }),
+      ).toThrow();
     });
   });
 

--- a/server/lib/__tests__/items.test.ts
+++ b/server/lib/__tests__/items.test.ts
@@ -783,4 +783,38 @@ describe("Data Access Layer", () => {
       expect(fetched!.share_visibility).toBe("unlisted");
     });
   });
+
+  describe("enrich=false skips enrichment queries", () => {
+    it("getItem with enrich=false returns null/0 enrichment fields", () => {
+      const item = createItem(db, { title: "Test note" });
+      const fetched = getItem(db, item.id, false);
+      expect(fetched).not.toBeNull();
+      expect(fetched!.title).toBe("Test note");
+      expect(fetched!.linked_note_title).toBeNull();
+      expect(fetched!.linked_todo_count).toBe(0);
+      expect(fetched!.share_visibility).toBeNull();
+      expect(fetched!.category_name).toBeNull();
+    });
+
+    it("listItems with enrich=false returns null/0 enrichment fields", () => {
+      createItem(db, { title: "A", type: "note" });
+      createItem(db, { title: "B", type: "todo" });
+      const result = listItems(db, {}, false);
+      expect(result.items.length).toBe(2);
+      for (const item of result.items) {
+        expect(item.linked_note_title).toBeNull();
+        expect(item.linked_todo_count).toBe(0);
+        expect(item.share_visibility).toBeNull();
+        expect(item.category_name).toBeNull();
+      }
+    });
+
+    it("searchItems with enrich=false returns null/0 enrichment fields", () => {
+      createItem(db, { title: "Searchable note" });
+      const results = searchItems(sqlite, db, "Searchable", 10, false);
+      expect(results.length).toBe(1);
+      expect(results[0]!.linked_note_title).toBeNull();
+      expect(results[0]!.linked_todo_count).toBe(0);
+    });
+  });
 });

--- a/server/lib/item-enrichment.ts
+++ b/server/lib/item-enrichment.ts
@@ -15,8 +15,19 @@ export type ItemWithLinkedInfo = typeof items.$inferSelect & {
 export function resolveLinkedInfo(
   db: DB,
   rows: (typeof items.$inferSelect)[],
+  enrich = true,
 ): ItemWithLinkedInfo[] {
   if (rows.length === 0) return [];
+
+  if (!enrich) {
+    return rows.map((row) => ({
+      ...row,
+      linked_note_title: null,
+      linked_todo_count: 0,
+      share_visibility: null,
+      category_name: null,
+    }));
+  }
 
   // Resolve linked_note_title for todos
   const linkedIds = rows.map((r) => r.linked_note_id).filter((id): id is string => id != null);

--- a/server/lib/items.ts
+++ b/server/lib/items.ts
@@ -41,12 +41,12 @@ export function createItem(db: DB, input: Partial<CreateItemInput> & { title: st
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const LIKE_SAFE_RE = /^[^%_]{4,36}$/;
 
-export function getItem(db: DB, id: string): ItemWithLinkedInfo | null {
+export function getItem(db: DB, id: string, enrich = true): ItemWithLinkedInfo | null {
   // Full UUID — exact match (fast path)
   if (UUID_RE.test(id)) {
     const row = db.select().from(items).where(eq(items.id, id)).get() ?? null;
     if (!row) return null;
-    return resolveLinkedInfo(db, [row])[0]!;
+    return resolveLinkedInfo(db, [row], enrich)[0]!;
   }
 
   // Short prefix — LIKE match (hex only, 4–36 chars)
@@ -68,7 +68,7 @@ export function getItem(db: DB, id: string): ItemWithLinkedInfo | null {
     error.matches = rows.map((r) => r.id);
     throw error;
   }
-  return resolveLinkedInfo(db, [rows[0]!])[0]!;
+  return resolveLinkedInfo(db, [rows[0]!], enrich)[0]!;
 }
 
 export function listItems(
@@ -85,6 +85,7 @@ export function listItems(
     limit?: number;
     offset?: number;
   },
+  enrich = true,
 ) {
   const conditions = [];
 
@@ -140,7 +141,7 @@ export function listItems(
       sql`SELECT DISTINCT items.* FROM items, json_each(items.tags) ${whereClause} ${orderSql} LIMIT ${limit} OFFSET ${offset}`,
     );
 
-    return { items: resolveLinkedInfo(db, rows), total };
+    return { items: resolveLinkedInfo(db, rows, enrich), total };
   }
 
   const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
@@ -270,6 +271,7 @@ export function searchItems(
   db: DB,
   query: string,
   limit = 20,
+  enrich = true,
 ): ItemWithLinkedInfo[] {
   // Trigram tokenizer requires at least 3 characters; fall back to LIKE for shorter queries
   if (query.length < 3) {
@@ -282,7 +284,7 @@ export function searchItems(
     `);
     // SAFETY: better-sqlite3 returns unknown[]; columns match items schema by migration
     const rows = stmt.all(pattern, pattern, limit) as (typeof items.$inferSelect)[];
-    return resolveLinkedInfo(db, rows);
+    return resolveLinkedInfo(db, rows, enrich);
   }
 
   const escaped = escapeFts5Query(query);

--- a/server/routes/items.ts
+++ b/server/routes/items.ts
@@ -47,14 +47,6 @@ itemsRouter.post("/", async (c) => {
     const body = await c.req.json();
     const input = createItemSchema.parse(body);
 
-    // Validate type-status combination if explicit status provided
-    if (input.status && !isValidTypeStatus(input.type ?? "note", input.status)) {
-      return c.json(
-        { error: `Invalid status '${input.status}' for type '${input.type ?? "note"}'` },
-        400,
-      );
-    }
-
     const created = createItem(db, input);
     const item = getItem(db, created.id)!;
     return c.json(item, 201);

--- a/server/schemas/items.ts
+++ b/server/schemas/items.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isValidTypeStatus } from "../lib/item-type-system.js";
 
 export const statusEnum = z.enum([
   "fleeting",
@@ -11,24 +12,29 @@ export const statusEnum = z.enum([
   "archived",
 ]);
 
-export const createItemSchema = z.object({
-  title: z.string().min(1, "Title is required").max(500),
-  type: z.enum(["note", "todo", "scratch"]).default("note"),
-  content: z.string().max(50000).default(""),
-  status: statusEnum.optional(),
-  priority: z.enum(["low", "medium", "high"]).nullable().default(null),
-  due: z
-    .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/, "Must be YYYY-MM-DD format")
-    .nullable()
-    .default(null),
-  tags: z.array(z.string().max(50)).max(20).default([]),
-  origin: z.string().max(200).default(""),
-  source: z.string().max(2000).nullable().default(null),
-  aliases: z.array(z.string().max(200)).max(10).default([]),
-  linked_note_id: z.string().uuid().nullable().default(null),
-  category_id: z.string().uuid().nullable().default(null),
-});
+export const createItemSchema = z
+  .object({
+    title: z.string().min(1, "Title is required").max(500),
+    type: z.enum(["note", "todo", "scratch"]).default("note"),
+    content: z.string().max(50000).default(""),
+    status: statusEnum.optional(),
+    priority: z.enum(["low", "medium", "high"]).nullable().default(null),
+    due: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, "Must be YYYY-MM-DD format")
+      .nullable()
+      .default(null),
+    tags: z.array(z.string().max(50)).max(20).default([]),
+    origin: z.string().max(200).default(""),
+    source: z.string().max(2000).nullable().default(null),
+    aliases: z.array(z.string().max(200)).max(10).default([]),
+    linked_note_id: z.string().uuid().nullable().default(null),
+    category_id: z.string().uuid().nullable().default(null),
+  })
+  .refine((data) => !data.status || isValidTypeStatus(data.type ?? "note", data.status), {
+    message: "Invalid status for the given type",
+    path: ["status"],
+  });
 
 export const updateItemSchema = z.object({
   title: z.string().min(1).max(500).optional(),


### PR DESCRIPTION
## Summary

- **TD-013 Phase 2**: `createItemSchema` 加入 `.refine()` 驗證 type-status 配對，POST handler 移除手動 `isValidTypeStatus()` 呼叫。PATCH handler 保留手動驗證（依賴 DB context 做 type conversion auto-mapping）
- **TD-014 Phase 2**: `getItem`/`listItems`/`searchItems` 加入 `enrich` 參數（default `true`）。`enrich=false` 時跳過 4 個 enrichment 查詢，回傳 null/0 defaults。所有 route handler 維持 `enrich=true`

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.server.json` 通過
- [x] `npx vitest run server/` — 550 tests 全通過（含 7 個新測試）
- [x] `npx vitest run` — 862 tests 全通過
- [x] `grep "isValidTypeStatus" server/routes/items.ts` — 只剩 PATCH handler 1 處
- [x] Schema refine tests: invalid type-status → throws, valid → passes, no status → passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)