### PR TITLE
fix: forward enrich param in all resolveLinkedInfo call sites

### DIFF
--- a/server/lib/items.ts
+++ b/server/lib/items.ts
@@ -162,11 +162,11 @@ export function listItems(
     .offset(offset)
     .all();
 
-  return { items: resolveLinkedInfo(db, rows), total };
+  return { items: resolveLinkedInfo(db, rows, enrich), total };
 }
 
 export function updateItem(db: DB, id: string, input: UpdateItemInput) {
-  const existing = getItem(db, id);
+  const existing = getItem(db, id, false);
   if (!existing) return null;
 
   const now = new Date().toISOString();
@@ -299,7 +299,7 @@ export function searchItems(
 
   // SAFETY: better-sqlite3 returns unknown[]; columns match items schema by migration
   const rows = stmt.all(escaped, limit) as (typeof items.$inferSelect)[];
-  return resolveLinkedInfo(db, rows);
+  return resolveLinkedInfo(db, rows, enrich);
 }
 
 export function getAllTags(sqlite: Database.Database): string[] {


### PR DESCRIPTION
## Summary

- Fix 2 code paths where `enrich` parameter was not forwarded to `resolveLinkedInfo()` (listItems non-tag branch, searchItems FTS5 branch)
- Skip enrichment in `updateItem`'s initial `getItem()` fetch (only needs row data for comparison), saving 4 DB queries per PATCH request

## Test plan

- [x] `npx vitest run server/` — 550 tests passed
- [x] `grep "resolveLinkedInfo" server/lib/items.ts` — all 6 call sites pass `enrich`

🤖 Generated with [Claude Code](https://claude.com/claude-code)