### PR TITLE
perf: use enrich=false in LINE handlers + remove redundant getItem

### DIFF
--- a/server/lib/line-commands/item-handlers.ts
+++ b/server/lib/line-commands/item-handlers.ts
@@ -1,7 +1,7 @@
 import type { CommandHandler } from "./types.js";
 import type { LineCommand } from "../line.js";
 import { resolveSessionItem } from "./shared.js";
-import { getItem, updateItem, deleteItem } from "../items.js";
+import { updateItem, deleteItem } from "../items.js";
 import { exportToObsidian } from "../export.js";
 import { getObsidianSettings } from "../settings.js";
 import { parseDate } from "../line-date.js";
@@ -25,10 +25,9 @@ const handleDue: CommandHandler = async ({ userId, command, db }) => {
   if (!dateParsed.success) return "❌ 無法辨識日期，請用 YYYY-MM-DD 或中文如『明天』『3天後』";
   const dueDate = dateParsed.clear ? null : dateParsed.date;
   updateItem(db, resolved.itemId, { due: dueDate });
-  const dueItem = getItem(db, resolved.itemId);
   return dateParsed.clear
-    ? `✅ 已清除「${dueItem!.title}」的到期日`
-    : `✅ 已設定「${dueItem!.title}」到期日為 ${dueDate}`;
+    ? `✅ 已清除「${resolved.item.title}」的到期日`
+    : `✅ 已設定「${resolved.item.title}」到期日為 ${dueDate}`;
 };
 
 const handleTag: CommandHandler = async ({ userId, command, db }) => {

--- a/server/lib/line-commands/query-handlers.ts
+++ b/server/lib/line-commands/query-handlers.ts
@@ -12,7 +12,7 @@ const handleHelp: CommandHandler = async () => HELP_TEXT;
 const handleFind: CommandHandler = async ({ userId, command, sqlite, db }) => {
   const cmd = command as Extract<LineCommand, { type: "find" }>;
   try {
-    const results = searchItems(sqlite, db, cmd.keyword, 5);
+    const results = searchItems(sqlite, db, cmd.keyword, 5, false);
     if (results.length === 0) return `🔍 找不到「${cmd.keyword}」相關的項目`;
     setSession(
       userId,
@@ -47,7 +47,7 @@ function makeListHandler(
   filters: Parameters<typeof listItems>[1],
 ): CommandHandler {
   return async ({ userId, db }) => {
-    const { items, total } = listItems(db, filters);
+    const { items, total } = listItems(db, filters, false);
     if (total === 0) return `${emoji} ${emptyMsg}`;
     setSession(
       userId,
@@ -112,7 +112,7 @@ const handleScratch = makeListHandler("📌", "暫存", "沒有暫存項目", {
 
 const handleList: CommandHandler = async ({ userId, command, db }) => {
   const cmd = command as Extract<LineCommand, { type: "list" }>;
-  const { items, total } = listItems(db, { tag: cmd.tag, limit: 5 });
+  const { items, total } = listItems(db, { tag: cmd.tag, limit: 5 }, false);
   if (total === 0) return `🏷️ 找不到標籤「${cmd.tag}」的項目`;
   setSession(
     userId,

--- a/server/lib/line-commands/shared.ts
+++ b/server/lib/line-commands/shared.ts
@@ -1,15 +1,11 @@
-import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
-import type * as schema from "../../db/schema.js";
 import { getItem } from "../items.js";
 import { getItemId } from "../line-session.js";
-import type { SessionResult } from "./types.js";
-
-type DB = BetterSQLite3Database<typeof schema>;
+import type { DB, SessionResult } from "./types.js";
 
 export function resolveSessionItem(db: DB, userId: string, index: number): SessionResult {
   const itemId = getItemId(userId, index);
   if (!itemId) return { ok: false, error: `❌ 編號 ${index} 不存在，請重新查詢` };
-  const item = getItem(db, itemId);
+  const item = getItem(db, itemId, false);
   if (!item) return { ok: false, error: "❌ 項目不存在" };
   return { ok: true, itemId, item };
 }

--- a/server/lib/line-commands/types.ts
+++ b/server/lib/line-commands/types.ts
@@ -4,7 +4,7 @@ import type * as schema from "../../db/schema.js";
 import type { LineCommand } from "../line.js";
 import type { ItemWithLinkedInfo } from "../item-enrichment.js";
 
-type DB = BetterSQLite3Database<typeof schema>;
+export type DB = BetterSQLite3Database<typeof schema>;
 
 export interface CommandContext {
   userId: string;


### PR DESCRIPTION
## Summary

Follow-up to #116 (webhook refactoring), based on /simplify review findings:

- Pass `enrich=false` to all `getItem`/`listItems`/`searchItems` calls in LINE handlers — skips 4 unnecessary SQL enrichment queries per interaction
- Remove redundant `getItem` re-fetch in `handleDue` — title already available from `resolveSessionItem`
- Export `DB` type from `types.ts` to eliminate duplicate alias in `shared.ts`

## Test plan

- [x] `npx vitest run server/routes/__tests__/webhook.test.ts` — 81 tests passed
- [x] `npx tsc --noEmit -p tsconfig.server.json` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)