### PR TITLE
fix: add error boundary to LINE command dispatcher (TD-016)

### DIFF
--- a/server/lib/line-commands/dispatcher.ts
+++ b/server/lib/line-commands/dispatcher.ts
@@ -2,6 +2,7 @@ import type { CommandContext, CommandHandler } from "./types.js";
 import { queryHandlers } from "./query-handlers.js";
 import { itemHandlers } from "./item-handlers.js";
 import { createHandlers } from "./create-handlers.js";
+import { logger } from "../logger.js";
 
 const handlers: Record<string, CommandHandler> = {
   ...queryHandlers,
@@ -12,5 +13,10 @@ const handlers: Record<string, CommandHandler> = {
 export async function dispatch(ctx: CommandContext): Promise<string | null> {
   const handler = handlers[ctx.command.type];
   if (!handler) return null;
-  return handler(ctx);
+  try {
+    return await handler(ctx);
+  } catch (err) {
+    logger.error({ err, command: ctx.command.type, userId: ctx.userId }, "LINE command failed");
+    return "❌ 操作失敗，請稍後再試";
+  }
 }


### PR DESCRIPTION
## Summary

- Add try/catch in `dispatch()` to catch unhandled exceptions from all 26 LINE command handlers
- Returns user-friendly error reply ("操作失敗") instead of webhook 500 + no response
- Logs error with command type and userId for debugging

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.server.json` passed
- [x] `npx vitest run server/routes/__tests__/webhook.test.ts` — 81 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)