### PR TITLE
chore: clean up stale test props + remove dead setSaveStatus export

### DIFF
--- a/src/components/__tests__/linked-items-section.test.tsx
+++ b/src/components/__tests__/linked-items-section.test.tsx
@@ -84,12 +84,9 @@ function makeRawItem(overrides: Partial<Item> = {}): Item {
 }
 
 const defaultProps = {
-  allTags: [] as string[],
   createTodoRequested: false,
   onCreateTodoDismiss: vi.fn(),
   onNavigate: vi.fn(),
-  onItemChange: vi.fn(),
-  onSaveStatusChange: vi.fn(),
 };
 
 function renderLinked(item: ParsedItem, propOverrides: Partial<typeof defaultProps> = {}) {
@@ -369,9 +366,8 @@ describe("LinkedItemsSection (todo mode)", () => {
     );
 
     const user = userEvent.setup();
-    const onItemChange = vi.fn();
 
-    renderLinked(makeTodoItem({ linked_note_id: "linked-note" }), { onItemChange });
+    renderLinked(makeTodoItem({ linked_note_id: "linked-note" }));
 
     await waitFor(() => {
       expect(screen.getByText("Linked Note")).toBeInTheDocument();

--- a/src/hooks/use-item-form.ts
+++ b/src/hooks/use-item-form.ts
@@ -153,7 +153,6 @@ export function useItemForm(itemId: string) {
     isDirty,
     setIsDirty,
     saveStatus,
-    setSaveStatus,
     allTags,
     saveField,
     debouncedSave,


### PR DESCRIPTION
## Summary

Follow-up to #129 (/simplify review):

- Remove 3 stale props from linked-items-section test `defaultProps` (`allTags`, `onItemChange`, `onSaveStatusChange`)
- Remove stale `onItemChange` mock in unlink test
- Remove unused `setSaveStatus` from `useItemForm` return object

## Test plan

- [x] 17 linked-items-section tests passed
- [x] 29 item-detail tests passed
- [x] `npx tsc --noEmit` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)