### PR TITLE
fix: wire isBatchPending to disable batch action buttons

### DIFF
--- a/src/components/item-list.tsx
+++ b/src/components/item-list.tsx
@@ -57,7 +57,7 @@ export function ItemList({ status, type }: ItemListProps) {
   });
 
   const state = useItemListState({ status, type, tag });
-  const { handleBatchAction } = useBatchActions(
+  const { handleBatchAction, isBatchPending } = useBatchActions(
     state.selectedIds,
     state.exitSelectionMode,
     invalidateAfterItemAndCategoryMutation,
@@ -138,6 +138,7 @@ export function ItemList({ status, type }: ItemListProps) {
               key={config.action}
               variant={config.variant ?? "ghost"}
               size="xs"
+              disabled={isBatchPending}
               onClick={() => handleBatchAction(config)}
             >
               {config.icon}


### PR DESCRIPTION
## Summary

Wire up `isBatchPending` from `useBatchActions` hook to disable batch action buttons during mutation, preventing double-click. The return value was already there but not consumed.

## Test plan

- [x] 18 item-list tests passed
- [x] `npx tsc --noEmit` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)