### PR TITLE
perf: field-aware query invalidation to reduce unnecessary refetch (TD-005)

### DIFF
--- a/src/components/fleeting-triage.tsx
+++ b/src/components/fleeting-triage.tsx
@@ -51,7 +51,7 @@ export function FleetingTriage({ onDone }: FleetingTriageProps) {
   const triageMutation = useMutation({
     mutationFn: ({ id, updates }: { id: string; updates: Record<string, unknown> }) =>
       updateItem(id, updates),
-    onSuccess: invalidateAfterItemMutation,
+    onSuccess: () => invalidateAfterItemMutation(),
   });
 
   const current = items[currentIndex];

--- a/src/components/quick-capture.tsx
+++ b/src/components/quick-capture.tsx
@@ -58,7 +58,7 @@ export function QuickCapture() {
 
   const createMutation = useMutation({
     mutationFn: createItem,
-    onSuccess: invalidateAfterItemMutation,
+    onSuccess: () => invalidateAfterItemMutation(),
   });
 
   useEffect(() => {

--- a/src/hooks/use-batch-actions.ts
+++ b/src/hooks/use-batch-actions.ts
@@ -10,7 +10,7 @@ export function useBatchActions(
 ) {
   const batchMutation = useMutation({
     mutationFn: ({ ids, action }: { ids: string[]; action: string }) => batchAction(ids, action),
-    onSuccess: invalidate,
+    onSuccess: () => invalidate(),
   });
 
   const handleBatchAction = async (config: BatchActionConfig) => {

--- a/src/hooks/use-invalidate.ts
+++ b/src/hooks/use-invalidate.ts
@@ -2,17 +2,48 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { queryKeys } from "@/lib/query-keys";
 
+// Fields that affect list query results (filtering, sorting, display)
+const LIST_FIELDS = new Set(["title", "status", "type", "priority", "due", "tags", "category_id"]);
+const TAG_FIELDS = new Set(["tags"]);
+const STATS_FIELDS = new Set(["status", "type"]);
+
 /**
  * Invalidate item-related queries after a mutation.
- * Covers: all item lists/details, tags, and stats.
+ *
+ * When `field` is provided, only invalidates queries affected by that field:
+ * - content/source/aliases → details only (lists unaffected)
+ * - title/priority/due → details + lists
+ * - tags → details + lists + tags
+ * - status/type → details + lists + stats
+ *
+ * When `field` is omitted, blanket invalidation (create/delete/batch).
  */
 export function useInvalidateAfterItemMutation() {
   const queryClient = useQueryClient();
-  return useCallback(() => {
-    queryClient.invalidateQueries({ queryKey: queryKeys.items.all });
-    queryClient.invalidateQueries({ queryKey: queryKeys.tags });
-    queryClient.invalidateQueries({ queryKey: queryKeys.stats });
-  }, [queryClient]);
+  return useCallback(
+    (field?: string) => {
+      if (!field) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.items.all });
+        queryClient.invalidateQueries({ queryKey: queryKeys.tags });
+        queryClient.invalidateQueries({ queryKey: queryKeys.stats });
+        return;
+      }
+
+      // Any field change affects detail views
+      queryClient.invalidateQueries({ queryKey: queryKeys.items.details });
+
+      if (LIST_FIELDS.has(field)) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.items.lists });
+      }
+      if (TAG_FIELDS.has(field)) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.tags });
+      }
+      if (STATS_FIELDS.has(field)) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.stats });
+      }
+    },
+    [queryClient],
+  );
 }
 
 /**
@@ -21,10 +52,31 @@ export function useInvalidateAfterItemMutation() {
  */
 export function useInvalidateAfterItemAndCategoryMutation() {
   const queryClient = useQueryClient();
-  return useCallback(() => {
-    queryClient.invalidateQueries({ queryKey: queryKeys.items.all });
-    queryClient.invalidateQueries({ queryKey: queryKeys.tags });
-    queryClient.invalidateQueries({ queryKey: queryKeys.stats });
-    queryClient.invalidateQueries({ queryKey: queryKeys.categories });
-  }, [queryClient]);
+  return useCallback(
+    (field?: string) => {
+      if (!field) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.items.all });
+        queryClient.invalidateQueries({ queryKey: queryKeys.tags });
+        queryClient.invalidateQueries({ queryKey: queryKeys.stats });
+        queryClient.invalidateQueries({ queryKey: queryKeys.categories });
+        return;
+      }
+
+      queryClient.invalidateQueries({ queryKey: queryKeys.items.details });
+
+      if (LIST_FIELDS.has(field)) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.items.lists });
+      }
+      if (TAG_FIELDS.has(field)) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.tags });
+      }
+      if (STATS_FIELDS.has(field)) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.stats });
+      }
+      if (field === "category_id") {
+        queryClient.invalidateQueries({ queryKey: queryKeys.categories });
+      }
+    },
+    [queryClient],
+  );
 }

--- a/src/hooks/use-item-form.ts
+++ b/src/hooks/use-item-form.ts
@@ -65,7 +65,7 @@ export function useItemForm(itemId: string) {
         if (!saveTimeoutRef.current) {
           setIsDirty(false);
         }
-        invalidateAfterSave();
+        invalidateAfterSave(field);
         setSaveStatus("saved");
         savedTimerRef.current = setTimeout(() => setSaveStatus("idle"), 2000);
       } catch (err) {

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -13,6 +13,8 @@ export interface ItemFilters {
 export const queryKeys = {
   items: {
     all: ["items"] as const,
+    lists: ["items", "list"] as const,
+    details: ["items", "detail"] as const,
     list: (filters: ItemFilters) => ["items", "list", filters] as const,
     detail: (id: string) => ["items", "detail", id] as const,
     linkedTodos: (noteId: string) => ["items", "linkedTodos", noteId] as const,


### PR DESCRIPTION
## Summary

- Add optional `field` parameter to `useInvalidateAfterItemMutation` and `useInvalidateAfterItemAndCategoryMutation`
- When field is provided (e.g., `"content"`, `"tags"`), only invalidates affected query types
- Content/source/aliases edits → only detail queries (no list refetch)
- Tag changes → details + lists + tags query
- Status/type changes → details + lists + stats
- No field (create/delete/batch) → blanket invalidation (backward compatible)
- Add `lists` and `details` prefix keys to `queryKeys.items` for partial matching

## Test plan

- [x] `npx tsc --noEmit` passed
- [x] 862 tests passed
- [ ] Manual: edit content → verify list API not refetched in Network tab
- [ ] Manual: change tags → verify list + tags refetched

🤖 Generated with [Claude Code](https://claude.com/claude-code)