### PR TITLE
fix: deduplicate invalidation hooks + invalidate linkedTodos on status change

### DIFF
--- a/src/hooks/use-invalidate.ts
+++ b/src/hooks/use-invalidate.ts
@@ -1,4 +1,4 @@
-import { useQueryClient } from "@tanstack/react-query";
+import { type QueryClient, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { queryKeys } from "@/lib/query-keys";
 
@@ -6,6 +6,38 @@ import { queryKeys } from "@/lib/query-keys";
 const LIST_FIELDS = new Set(["title", "status", "type", "priority", "due", "tags", "category_id"]);
 const TAG_FIELDS = new Set(["tags"]);
 const STATS_FIELDS = new Set(["status", "type"]);
+// Fields that affect linked todo counts (status changes can archive/unarchive todos)
+const LINKED_TODO_FIELDS = new Set(["status", "type", "linked_note_id"]);
+
+/**
+ * Shared field-aware invalidation logic.
+ * When `field` is provided, only invalidates queries affected by that field.
+ * When omitted, blanket invalidation (create/delete/batch).
+ */
+function invalidateItemFields(queryClient: QueryClient, field?: string) {
+  if (!field) {
+    queryClient.invalidateQueries({ queryKey: queryKeys.items.all });
+    queryClient.invalidateQueries({ queryKey: queryKeys.tags });
+    queryClient.invalidateQueries({ queryKey: queryKeys.stats });
+    return;
+  }
+
+  // Any field change affects detail views
+  queryClient.invalidateQueries({ queryKey: queryKeys.items.details });
+
+  if (LIST_FIELDS.has(field)) {
+    queryClient.invalidateQueries({ queryKey: queryKeys.items.lists });
+  }
+  if (TAG_FIELDS.has(field)) {
+    queryClient.invalidateQueries({ queryKey: queryKeys.tags });
+  }
+  if (STATS_FIELDS.has(field)) {
+    queryClient.invalidateQueries({ queryKey: queryKeys.stats });
+  }
+  if (LINKED_TODO_FIELDS.has(field)) {
+    queryClient.invalidateQueries({ queryKey: queryKeys.items.all });
+  }
+}
 
 /**
  * Invalidate item-related queries after a mutation.
@@ -14,36 +46,13 @@ const STATS_FIELDS = new Set(["status", "type"]);
  * - content/source/aliases → details only (lists unaffected)
  * - title/priority/due → details + lists
  * - tags → details + lists + tags
- * - status/type → details + lists + stats
+ * - status/type → details + lists + stats + linkedTodos
  *
  * When `field` is omitted, blanket invalidation (create/delete/batch).
  */
 export function useInvalidateAfterItemMutation() {
   const queryClient = useQueryClient();
-  return useCallback(
-    (field?: string) => {
-      if (!field) {
-        queryClient.invalidateQueries({ queryKey: queryKeys.items.all });
-        queryClient.invalidateQueries({ queryKey: queryKeys.tags });
-        queryClient.invalidateQueries({ queryKey: queryKeys.stats });
-        return;
-      }
-
-      // Any field change affects detail views
-      queryClient.invalidateQueries({ queryKey: queryKeys.items.details });
-
-      if (LIST_FIELDS.has(field)) {
-        queryClient.invalidateQueries({ queryKey: queryKeys.items.lists });
-      }
-      if (TAG_FIELDS.has(field)) {
-        queryClient.invalidateQueries({ queryKey: queryKeys.tags });
-      }
-      if (STATS_FIELDS.has(field)) {
-        queryClient.invalidateQueries({ queryKey: queryKeys.stats });
-      }
-    },
-    [queryClient],
-  );
+  return useCallback((field?: string) => invalidateItemFields(queryClient, field), [queryClient]);
 }
 
 /**
@@ -54,26 +63,8 @@ export function useInvalidateAfterItemAndCategoryMutation() {
   const queryClient = useQueryClient();
   return useCallback(
     (field?: string) => {
-      if (!field) {
-        queryClient.invalidateQueries({ queryKey: queryKeys.items.all });
-        queryClient.invalidateQueries({ queryKey: queryKeys.tags });
-        queryClient.invalidateQueries({ queryKey: queryKeys.stats });
-        queryClient.invalidateQueries({ queryKey: queryKeys.categories });
-        return;
-      }
-
-      queryClient.invalidateQueries({ queryKey: queryKeys.items.details });
-
-      if (LIST_FIELDS.has(field)) {
-        queryClient.invalidateQueries({ queryKey: queryKeys.items.lists });
-      }
-      if (TAG_FIELDS.has(field)) {
-        queryClient.invalidateQueries({ queryKey: queryKeys.tags });
-      }
-      if (STATS_FIELDS.has(field)) {
-        queryClient.invalidateQueries({ queryKey: queryKeys.stats });
-      }
-      if (field === "category_id") {
+      invalidateItemFields(queryClient, field);
+      if (!field || field === "category_id") {
         queryClient.invalidateQueries({ queryKey: queryKeys.categories });
       }
     },


### PR DESCRIPTION
## Summary

Follow-up to #133 (/simplify review):

- Extract shared `invalidateItemFields()` helper — eliminates duplicated field-routing logic between the two hooks (83→76 lines)
- Add `LINKED_TODO_FIELDS` set — status/type/linked_note_id changes now correctly invalidate linkedTodos queries (previously missed in field-specific path)

## Test plan

- [x] `npx tsc --noEmit` passed
- [x] 862 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)