### PR TITLE
test: add unit tests for route components (FG-003)

### DIFF
--- a/src/routes/__tests__/__root.test.tsx
+++ b/src/routes/__tests__/__root.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// --- Mocks ---
+
+const mockNavigate = vi.fn();
+let mockSearchParams: Record<string, unknown> = {};
+let mockPathname = "/notes/fleeting";
+
+vi.mock("@tanstack/react-router", () => ({
+  createRootRoute: (opts: { component: React.FC }) => ({
+    ...opts,
+    useSearch: () => mockSearchParams,
+    useNavigate: () => mockNavigate,
+  }),
+  useRouterState: ({ select }: { select: (s: unknown) => unknown }) =>
+    select({ location: { pathname: mockPathname, search: mockSearchParams } }),
+  Link: ({
+    children,
+    to,
+    className,
+  }: {
+    children: React.ReactNode;
+    to: string;
+    className?: string;
+  }) => (
+    <a href={to} className={className}>
+      {children}
+    </a>
+  ),
+  Outlet: () => <div data-testid="outlet" />,
+}));
+
+vi.mock("@/components/sidebar", () => ({
+  Sidebar: () => <div data-testid="sidebar" />,
+}));
+
+vi.mock("@/components/bottom-nav", () => ({
+  BottomNav: ({ onSearchClick }: { onSearchClick?: () => void }) => (
+    <div data-testid="bottom-nav" onClick={onSearchClick} />
+  ),
+}));
+
+vi.mock("@/components/offline-indicator", () => ({
+  OfflineIndicator: () => <div data-testid="offline-indicator" />,
+}));
+
+vi.mock("@/components/install-prompt", () => ({
+  InstallPrompt: () => <div data-testid="install-prompt" />,
+}));
+
+vi.mock("@/components/search-bar", () => ({
+  SearchBar: () => <div data-testid="search-bar" />,
+}));
+
+vi.mock("@/components/loading-fallback", () => ({
+  LoadingFallback: () => <div data-testid="loading-fallback" />,
+}));
+
+vi.mock("@/hooks/use-online-status", () => ({
+  useOnlineStatus: () => true,
+}));
+
+const mockGetConfig = vi.fn();
+vi.mock("@/lib/api", () => ({
+  getConfig: (...args: unknown[]) => mockGetConfig(...args),
+}));
+
+// Import after mocks are set up (hoisting ensures mocks are applied)
+import { Route } from "@/routes/__root";
+
+const RootLayout = Route.component!;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSearchParams = {};
+  mockPathname = "/notes/fleeting";
+  mockGetConfig.mockResolvedValue({ obsidian_export_enabled: false });
+});
+
+function renderRoot() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RootLayout />
+    </QueryClientProvider>,
+  );
+}
+
+describe("RootLayout", () => {
+  it("renders without crash", () => {
+    renderRoot();
+
+    expect(screen.getByTestId("sidebar")).toBeInTheDocument();
+    expect(screen.getByTestId("bottom-nav")).toBeInTheDocument();
+    expect(screen.getByTestId("offline-indicator")).toBeInTheDocument();
+    expect(screen.getByTestId("outlet")).toBeInTheDocument();
+  });
+
+  it("Escape key calls navigate with item: undefined", async () => {
+    const user = userEvent.setup();
+    renderRoot();
+
+    await user.keyboard("{Escape}");
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({ search: expect.any(Function) }),
+    );
+    const searchFn = mockNavigate.mock.calls[0][0].search;
+    expect(searchFn({ item: "some-id", tag: "idea" })).toEqual({
+      item: undefined,
+      tag: "idea",
+    });
+  });
+
+  it("hides bottom nav when item selected on list route", () => {
+    mockSearchParams = { item: "abc-123" };
+    mockPathname = "/notes/fleeting";
+    renderRoot();
+
+    expect(screen.queryByTestId("bottom-nav")).not.toBeInTheDocument();
+  });
+
+  it("shows bottom nav when no item selected", () => {
+    mockSearchParams = {};
+    mockPathname = "/notes/fleeting";
+    renderRoot();
+
+    expect(screen.getByTestId("bottom-nav")).toBeInTheDocument();
+  });
+
+  it("shows bottom nav when item selected on non-list route", () => {
+    mockSearchParams = { item: "abc-123" };
+    mockPathname = "/settings";
+    renderRoot();
+
+    expect(screen.getByTestId("bottom-nav")).toBeInTheDocument();
+  });
+});

--- a/src/routes/__tests__/notes.test.tsx
+++ b/src/routes/__tests__/notes.test.tsx
@@ -1,0 +1,69 @@
+import { screen } from "@testing-library/react";
+import { renderWithContext } from "@/test-utils";
+
+// --- Mocks ---
+
+const mockMatchRoute = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: { component: React.FC }) => ({
+    ...opts,
+  }),
+  useMatchRoute: () => mockMatchRoute,
+  Link: ({
+    children,
+    to,
+    className,
+  }: {
+    children: React.ReactNode;
+    to: string;
+    className?: string;
+  }) => (
+    <a href={to} className={className}>
+      {children}
+    </a>
+  ),
+  Outlet: () => <div data-testid="outlet" />,
+}));
+
+import { Route } from "@/routes/_list/notes";
+
+const NotesLayout = Route.component!;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockMatchRoute.mockReturnValue(false);
+});
+
+describe("NotesLayout", () => {
+  it("renders 4 status chips", () => {
+    renderWithContext(<NotesLayout />);
+
+    expect(screen.getByText("閃念")).toBeInTheDocument();
+    expect(screen.getByText("發展中")).toBeInTheDocument();
+    expect(screen.getByText("永久筆記")).toBeInTheDocument();
+    expect(screen.getByText("已匯出")).toBeInTheDocument();
+  });
+
+  it("each chip has correct to path", () => {
+    renderWithContext(<NotesLayout />);
+
+    const fleeting = screen.getByText("閃念").closest("a");
+    expect(fleeting).toHaveAttribute("href", "/notes/fleeting");
+
+    const developing = screen.getByText("發展中").closest("a");
+    expect(developing).toHaveAttribute("href", "/notes/developing");
+
+    const permanent = screen.getByText("永久筆記").closest("a");
+    expect(permanent).toHaveAttribute("href", "/notes/permanent");
+
+    const exported = screen.getByText("已匯出").closest("a");
+    expect(exported).toHaveAttribute("href", "/notes/exported");
+  });
+
+  it("renders Outlet for child routes", () => {
+    renderWithContext(<NotesLayout />);
+
+    expect(screen.getByTestId("outlet")).toBeInTheDocument();
+  });
+});

--- a/src/routes/__tests__/todos.test.tsx
+++ b/src/routes/__tests__/todos.test.tsx
@@ -1,0 +1,61 @@
+import { screen } from "@testing-library/react";
+import { renderWithContext } from "@/test-utils";
+
+// --- Mocks ---
+
+const mockMatchRoute = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (opts: { component: React.FC }) => ({
+    ...opts,
+  }),
+  useMatchRoute: () => mockMatchRoute,
+  Link: ({
+    children,
+    to,
+    className,
+  }: {
+    children: React.ReactNode;
+    to: string;
+    className?: string;
+  }) => (
+    <a href={to} className={className}>
+      {children}
+    </a>
+  ),
+  Outlet: () => <div data-testid="outlet" />,
+}));
+
+import { Route } from "@/routes/_list/todos";
+
+const TodosLayout = Route.component!;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockMatchRoute.mockReturnValue(false);
+});
+
+describe("TodosLayout", () => {
+  it("renders 2 status chips", () => {
+    renderWithContext(<TodosLayout />);
+
+    expect(screen.getByText("進行中")).toBeInTheDocument();
+    expect(screen.getByText("已完成")).toBeInTheDocument();
+  });
+
+  it("each chip has correct to path", () => {
+    renderWithContext(<TodosLayout />);
+
+    const active = screen.getByText("進行中").closest("a");
+    expect(active).toHaveAttribute("href", "/todos");
+
+    const done = screen.getByText("已完成").closest("a");
+    expect(done).toHaveAttribute("href", "/todos/done");
+  });
+
+  it("renders Outlet for child routes", () => {
+    renderWithContext(<TodosLayout />);
+
+    expect(screen.getByTestId("outlet")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Add 11 unit tests for route components that previously had zero test coverage:

- `__root.test.tsx` (5 tests): render, Esc key navigation, bottom nav visibility logic
- `notes.test.tsx` (3 tests): 4 status chips render with correct paths + Outlet
- `todos.test.tsx` (3 tests): 2 status chips render with correct paths + Outlet

Uses Tier 2/3 TanStack Router mock patterns.

## Test plan

- [x] 11 new route tests pass
- [x] 873 total tests pass
- [x] `npx tsc --noEmit` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)