### PR TITLE
fix(mcp): category tools — fix color validation, add reorder, rebuild dist

### DIFF
--- a/mcp-server/src/client.ts
+++ b/mcp-server/src/client.ts
@@ -162,6 +162,12 @@ export async function deleteCategoryApi(id: string): Promise<{ ok: boolean }> {
   return sparkleApi<{ ok: boolean }>(`/categories/${id}`, "DELETE");
 }
 
+export async function reorderCategoriesApi(
+  items: { id: string; sort_order: number }[],
+): Promise<{ ok: boolean }> {
+  return sparkleApi<{ ok: boolean }>("/categories/reorder", "PATCH", { items });
+}
+
 // --- Workflow operations ---
 
 export async function exportToObsidian(id: string): Promise<ExportResult> {

--- a/mcp-server/src/docs/instructions.ts
+++ b/mcp-server/src/docs/instructions.ts
@@ -67,12 +67,15 @@ export const SPARKLE_INSTRUCTIONS = `
 | 匯出到 Obsidian | sparkle_export_to_obsidian |
 | 知識庫概覽 | sparkle_get_stats |
 | 查看既有標籤 | sparkle_list_tags（建立新筆記前先查看，保持標籤一致性）|
+| 管理分類 | sparkle_list_categories、sparkle_create_category、sparkle_update_category、sparkle_delete_category、sparkle_reorder_categories |
+| 為項目指定分類 | sparkle_create_note / sparkle_update_note 的 category_id 參數（先用 sparkle_list_categories 查詢 UUID）|
 
 ## 行為準則
 
 - **主動探索**：使用者提到主題時，先搜尋再回應。把相關筆記的脈絡帶進對話。
 - **尊重所有權**：這是使用者的知識庫。更新筆記前確認意圖，不要擅自大幅改寫。
 - **標籤一致性**：新建或更新筆記時，先用 sparkle_list_tags 查看既有標籤，避免建立重複或不一致的標籤。
+- **分類一致性**：為項目指定分類前，先用 sparkle_list_categories 查看既有分類，避免重複建立。
 - **適時建議推進**：當你觀察到筆記已達到下一階段的標準，主動建議推進，但由使用者決定。
 - **連結思考**：發現筆記之間的關聯時，指出來。知識的價值在於連結。
 

--- a/mcp-server/src/tools/categories.ts
+++ b/mcp-server/src/tools/categories.ts
@@ -5,6 +5,7 @@ import {
   createCategoryApi,
   updateCategoryApi,
   deleteCategoryApi,
+  reorderCategoriesApi,
 } from "../client.js";
 import type { Category } from "../types.js";
 
@@ -39,11 +40,11 @@ export function registerCategoryTools(server: McpServer): void {
     "sparkle_list_categories",
     {
       title: "List Categories",
-      description: `List all categories in Sparkle, sorted by sort_order.
+      description: `List all categories in Sparkle, sorted by display order.
 
-No args required.
+Use this before assigning a category_id via sparkle_create_note or sparkle_update_note to find the correct UUID. Also useful for checking existing categories before creating a new one to avoid duplicates.
 
-Returns: Array of categories with name, color, sort_order, and metadata.`,
+Returns: Array of categories with name, color (hex), sort_order, and metadata.`,
       inputSchema: {},
       annotations: {
         readOnlyHint: true,
@@ -74,14 +75,21 @@ Returns: Array of categories with name, color, sort_order, and metadata.`,
       title: "Create Category",
       description: `Create a new category for organizing items.
 
+Before creating, use sparkle_list_categories to check if a similar category already exists. Category names must be unique. Items can be assigned to a category via category_id in sparkle_create_note or sparkle_update_note.
+
 Args:
   - name (string, required): Category name (1-50 chars, must be unique)
-  - color (string, optional): Color value (max 20 chars, e.g. "blue", "#3b82f6")
+  - color (string, optional): Hex color code (e.g. "#3b82f6"), must be #RRGGBB format. Null to leave unset.
 
 Returns: The created category with all fields.`,
       inputSchema: {
         name: z.string().min(1).max(50).describe("Category name"),
-        color: z.string().max(20).nullable().optional().describe("Color value"),
+        color: z
+          .string()
+          .regex(/^#[0-9a-fA-F]{6}$/)
+          .nullable()
+          .optional()
+          .describe("Hex color code (#RRGGBB format, e.g. #3b82f6)"),
       },
       annotations: {
         readOnlyHint: false,
@@ -114,17 +122,24 @@ Returns: The created category with all fields.`,
       title: "Update Category",
       description: `Update an existing category's name, color, or sort order.
 
+Use sparkle_list_categories to find the category UUID first. Only provided fields are updated; omitted fields remain unchanged.
+
 Args:
   - id (string, required): Category UUID
   - name (string, optional): New name (1-50 chars, must be unique)
-  - color (string, optional): New color value (max 20 chars, null to clear)
+  - color (string, optional): Hex color code (#RRGGBB format), or null to clear
   - sort_order (number, optional): New sort position (integer >= 0)
 
 Returns: The updated category with all fields.`,
       inputSchema: {
         id: z.string().uuid().describe("Category UUID"),
         name: z.string().min(1).max(50).optional().describe("New name"),
-        color: z.string().max(20).nullable().optional().describe("Color value (null to clear)"),
+        color: z
+          .string()
+          .regex(/^#[0-9a-fA-F]{6}$/)
+          .nullable()
+          .optional()
+          .describe("Hex color code (#RRGGBB format, null to clear)"),
         sort_order: z.number().int().min(0).optional().describe("Sort position"),
       },
       annotations: {
@@ -161,7 +176,9 @@ Returns: The updated category with all fields.`,
     "sparkle_delete_category",
     {
       title: "Delete Category",
-      description: `Delete a category. Items assigned to this category will have their category_id set to null (ON DELETE SET NULL).
+      description: `Delete a category permanently. Items currently assigned to this category will have their category_id set to null automatically (ON DELETE SET NULL) — they will not be deleted.
+
+Use sparkle_list_categories to find the category UUID first.
 
 Args:
   - id (string, required): Category UUID
@@ -187,6 +204,56 @@ Returns: Confirmation of deletion.`,
         return {
           content: [
             { type: "text", text: `Error deleting category: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "sparkle_reorder_categories",
+    {
+      title: "Reorder Categories",
+      description: `Set the display order of categories by providing each category's new sort_order value.
+
+Use sparkle_list_categories to get current IDs and order, then provide the new ordering. All categories in the list are updated in a single transaction.
+
+Args:
+  - items (array, required): Array of { id: string (UUID), sort_order: number (integer >= 0) }. Min 1, max 500 items.
+
+Returns: Confirmation of reorder.`,
+      inputSchema: {
+        items: z
+          .array(
+            z.object({
+              id: z.string().uuid().describe("Category UUID"),
+              sort_order: z.number().int().min(0).describe("New sort position"),
+            }),
+          )
+          .min(1)
+          .max(500)
+          .describe("Array of { id, sort_order } pairs"),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ items }) => {
+      try {
+        await reorderCategoriesApi(items);
+        return {
+          content: [
+            { type: "text", text: `Categories reordered successfully (${items.length} updated).` },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error reordering categories: ${(error as Error).message}` },
           ],
           isError: true,
         };


### PR DESCRIPTION
## Summary
- Fix color schema validation: MCP accepted any string (`max(20)`) but server requires `#RRGGBB` hex — now aligned
- Fix misleading tool descriptions: removed `"blue"` example, hex-only
- Add `sparkle_reorder_categories` tool wrapping `PATCH /api/categories/reorder`
- Add `reorderCategoriesApi` client function
- Enrich all 5 category tool descriptions with "when to use" context (MCP best practice: 3-4+ sentences)
- Update `SPARKLE_INSTRUCTIONS` with category workflow and 分類一致性 guideline
- **dist/ was missing categories module entirely** — needs `npm run build` in `mcp-server/` after merge

## Note
`mcp-server/dist/` is gitignored. After merge, run on production:
```bash
cd mcp-server && npm run build
```
Then restart Claude Code to pick up the new tools.

## Test plan
- [ ] `cd mcp-server && npx tsc --noEmit` passes
- [ ] `cd mcp-server && npm run build` succeeds
- [ ] `ls dist/tools/categories.js` exists
- [ ] `grep "registerCategoryTools" dist/index.js` shows import
- [ ] Restart Claude Code session, verify 5 category tools appear (list, create, update, delete, reorder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)