### PR TITLE
fix: extract hex color constant, align sort_order max, hoist timestamp

### DIFF
--- a/mcp-server/src/tools/categories.ts
+++ b/mcp-server/src/tools/categories.ts
@@ -9,6 +9,8 @@ import {
 } from "../client.js";
 import type { Category } from "../types.js";
 
+const HEX_COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
+
 function formatCategory(cat: Category): string {
   const color = cat.color ? ` (${cat.color})` : "";
   return `- **${cat.name}**${color} — ID: ${cat.id} | Order: ${cat.sort_order}`;
@@ -86,7 +88,7 @@ Returns: The created category with all fields.`,
         name: z.string().min(1).max(50).describe("Category name"),
         color: z
           .string()
-          .regex(/^#[0-9a-fA-F]{6}$/)
+          .regex(HEX_COLOR_REGEX)
           .nullable()
           .optional()
           .describe("Hex color code (#RRGGBB format, e.g. #3b82f6)"),
@@ -136,11 +138,11 @@ Returns: The updated category with all fields.`,
         name: z.string().min(1).max(50).optional().describe("New name"),
         color: z
           .string()
-          .regex(/^#[0-9a-fA-F]{6}$/)
+          .regex(HEX_COLOR_REGEX)
           .nullable()
           .optional()
           .describe("Hex color code (#RRGGBB format, null to clear)"),
-        sort_order: z.number().int().min(0).optional().describe("Sort position"),
+        sort_order: z.number().int().min(0).max(999999).optional().describe("Sort position"),
       },
       annotations: {
         readOnlyHint: false,
@@ -228,7 +230,7 @@ Returns: Confirmation of reorder.`,
           .array(
             z.object({
               id: z.string().uuid().describe("Category UUID"),
-              sort_order: z.number().int().min(0).describe("New sort position"),
+              sort_order: z.number().int().min(0).max(999999).describe("New sort position"),
             }),
           )
           .min(1)

--- a/server/lib/categories.ts
+++ b/server/lib/categories.ts
@@ -64,10 +64,11 @@ export function deleteCategory(db: DB, id: string): boolean {
 }
 
 export function reorderCategories(db: DB, items: { id: string; sort_order: number }[]): void {
+  const now = new Date().toISOString();
   db.transaction((tx) => {
     for (const item of items) {
       tx.update(categories)
-        .set({ sort_order: item.sort_order, modified: new Date().toISOString() })
+        .set({ sort_order: item.sort_order, modified: now })
         .where(eq(categories.id, item.id))
         .run();
     }


### PR DESCRIPTION
## Summary
- Extract `HEX_COLOR_REGEX` constant in MCP categories.ts (DRY, was duplicated 2x)
- Add `max(999999)` to `sort_order` in MCP tool schemas to match `server/schemas/categories.ts`
- Hoist `new Date()` outside reorder transaction loop for consistent `modified` timestamps

## Test plan
- [ ] `npx tsc --noEmit` passes (client + server)
- [ ] `cd mcp-server && npm run build` succeeds
- [ ] Existing category tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)