### PR TITLE
chore: remove hardcoded user paths for public repo readiness

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,10 @@ on:
     types: [completed]
     branches: [main]
 
+env:
+  # Set SPARKLE_DIR in GitHub repo Settings → Variables and Secrets → Variables
+  SPARKLE_DIR: ${{ vars.SPARKLE_DIR || '/opt/sparkle' }}
+
 jobs:
   deploy:
     if: github.event.workflow_run.conclusion == 'success'
@@ -14,17 +18,17 @@ jobs:
 
     steps:
       - name: Pull latest code
-        run: cd /home/tim/sparkle && git fetch origin main && git checkout main && git pull --ff-only origin main
+        run: cd $SPARKLE_DIR && git fetch origin main && git checkout main && git pull --ff-only origin main
 
       - name: Install dependencies
-        run: cd /home/tim/sparkle && npm ci
+        run: cd $SPARKLE_DIR && npm ci
 
       - name: Build frontend
-        run: cd /home/tim/sparkle && npm run build
+        run: cd $SPARKLE_DIR && npm run build
 
       - name: Validate migrations against production DB
         run: |
-          cd /home/tim/sparkle
+          cd $SPARKLE_DIR
           timeout 10 node --env-file=.env --import tsx -e "
             import './server/db/index.js';
             console.log('Migration validation passed');

--- a/scripts/error-summary.sh
+++ b/scripts/error-summary.sh
@@ -15,7 +15,7 @@
 #   - systemd journalctl
 #
 # 建議 cron 設定:
-#   0 * * * * /home/tim/sparkle/scripts/error-summary.sh 2>&1 | logger -t sparkle-errors
+#   0 * * * * /path/to/sparkle/scripts/error-summary.sh 2>&1 | logger -t sparkle-errors
 # ----------------------------------------------------------------------------
 set -euo pipefail
 

--- a/scripts/health-monitor.sh
+++ b/scripts/health-monitor.sh
@@ -16,7 +16,7 @@
 #   - 健康檢查正常 → 靜默退出
 #
 # 建議 cron 設定:
-#   */5 * * * * /home/tim/sparkle/scripts/health-monitor.sh 2>&1 | logger -t sparkle-health
+#   */5 * * * * /path/to/sparkle/scripts/health-monitor.sh 2>&1 | logger -t sparkle-health
 # ----------------------------------------------------------------------------
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `/home/tim/sparkle` in `deploy.yml` with `$SPARKLE_DIR` env var, sourced from GitHub repo variable with `/opt/sparkle` fallback
- Replace hardcoded paths in `error-summary.sh` and `health-monitor.sh` cron examples with generic `/path/to/sparkle`

## Test plan
- [ ] Verify CI passes
- [ ] Verify deploy workflow picks up `SPARKLE_DIR` repo variable and deploys successfully
- [ ] Verify health check passes after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)