### PR TITLE
feat(mcp): add HTTP transport with OAuth for Claude.ai connector

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -9,9 +9,13 @@
       "version": "1.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
+        "cors": "^2.8.5",
+        "express": "^5.1.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.17",
+        "@types/express": "^5.0.0",
         "@types/node": "^25.3.5",
         "tsx": "^4.19.2",
         "typescript": "^5.7.2",
@@ -879,6 +883,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -888,6 +903,26 @@
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -904,6 +939,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.3.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
@@ -912,6 +979,41 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@vitest/expect": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -6,7 +6,9 @@
   "main": "dist/index.js",
   "scripts": {
     "start": "node dist/index.js",
+    "start:http": "node dist/http.js",
     "dev": "tsx watch src/index.ts",
+    "dev:http": "tsx watch src/http.ts",
     "build": "tsc",
     "clean": "rm -rf dist",
     "test": "vitest run"
@@ -16,9 +18,13 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "cors": "^2.8.5",
+    "express": "^5.1.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^5.0.0",
     "@types/node": "^25.3.5",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",

--- a/mcp-server/src/__tests__/auth.test.ts
+++ b/mcp-server/src/__tests__/auth.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { SparkleClientsStore, SparkleAuthProvider } from "../auth.js";
+
+describe("SparkleClientsStore", () => {
+  let store: SparkleClientsStore;
+
+  beforeEach(() => {
+    store = new SparkleClientsStore();
+  });
+
+  it("returns undefined for unknown client", () => {
+    expect(store.getClient("nonexistent")).toBeUndefined();
+  });
+
+  it("registers and retrieves a client", () => {
+    const client = store.registerClient({
+      redirect_uris: [new URL("https://example.com/callback")],
+      client_name: "Test App",
+    });
+
+    expect(client.client_id).toBeDefined();
+    expect(client.client_id_issued_at).toBeDefined();
+    expect(client.client_name).toBe("Test App");
+
+    const retrieved = store.getClient(client.client_id);
+    expect(retrieved).toEqual(client);
+  });
+});
+
+describe("SparkleAuthProvider", () => {
+  let provider: SparkleAuthProvider;
+  const TEST_PIN = "test-pin-1234";
+
+  const mockClient = {
+    client_id: "test-client-id",
+    client_id_issued_at: Math.floor(Date.now() / 1000),
+    redirect_uris: [new URL("https://example.com/callback")],
+    client_name: "Test App",
+  };
+
+  const mockParams = {
+    codeChallenge: "test-challenge-abc123",
+    redirectUri: "https://example.com/callback",
+    state: "test-state",
+    scopes: ["mcp:tools"],
+  };
+
+  beforeEach(() => {
+    provider = new SparkleAuthProvider(TEST_PIN);
+  });
+
+  describe("authorize", () => {
+    it("renders PIN form HTML", async () => {
+      let sentHtml = "";
+      const mockRes = {
+        setHeader: () => {},
+        send: (html: string) => {
+          sentHtml = html;
+        },
+      } as any;
+
+      await provider.authorize(mockClient, mockParams, mockRes);
+
+      expect(sentHtml).toContain("Sparkle MCP 授權");
+      expect(sentHtml).toContain('name="pin"');
+      expect(sentHtml).toContain('name="pending_id"');
+      expect(sentHtml).toContain("Test App");
+    });
+  });
+
+  describe("completeAuthorization", () => {
+    it("rejects invalid pending ID", () => {
+      let statusCode = 0;
+      let sentBody = "";
+      const mockRes = {
+        status: (code: number) => ({
+          send: (body: string) => {
+            statusCode = code;
+            sentBody = body;
+          },
+        }),
+      } as any;
+
+      provider.completeAuthorization("invalid-id", TEST_PIN, mockRes);
+      expect(statusCode).toBe(400);
+      expect(sentBody).toContain("過期或無效");
+    });
+
+    it("rejects wrong PIN", async () => {
+      // First create a pending auth
+      let pendingId = "";
+      const authorizeRes = {
+        setHeader: () => {},
+        send: (html: string) => {
+          const match = html.match(/value="([^"]+)"/);
+          if (match) pendingId = match[1];
+        },
+      } as any;
+      await provider.authorize(mockClient, mockParams, authorizeRes);
+
+      let statusCode = 0;
+      let sentBody = "";
+      const submitRes = {
+        status: (code: number) => ({
+          send: (body: string) => {
+            statusCode = code;
+            sentBody = body;
+          },
+        }),
+      } as any;
+
+      provider.completeAuthorization(pendingId, "wrong-pin", submitRes);
+      expect(statusCode).toBe(403);
+      expect(sentBody).toContain("PIN 錯誤");
+    });
+
+    it("redirects with auth code on correct PIN", async () => {
+      let pendingId = "";
+      const authorizeRes = {
+        setHeader: () => {},
+        send: (html: string) => {
+          const match = html.match(/value="([^"]+)"/);
+          if (match) pendingId = match[1];
+        },
+      } as any;
+      await provider.authorize(mockClient, mockParams, authorizeRes);
+
+      let redirectUrl = "";
+      const submitRes = {
+        redirect: (url: string) => {
+          redirectUrl = url;
+        },
+      } as any;
+
+      provider.completeAuthorization(pendingId, TEST_PIN, submitRes);
+
+      expect(redirectUrl).toContain("https://example.com/callback");
+      expect(redirectUrl).toContain("code=");
+      expect(redirectUrl).toContain("state=test-state");
+    });
+  });
+
+  describe("challengeForAuthorizationCode", () => {
+    it("returns the stored code challenge", async () => {
+      const code = await createAuthCode(provider, mockClient, mockParams);
+      const challenge = await provider.challengeForAuthorizationCode(mockClient, code);
+      expect(challenge).toBe("test-challenge-abc123");
+    });
+
+    it("throws for invalid code", async () => {
+      await expect(provider.challengeForAuthorizationCode(mockClient, "invalid")).rejects.toThrow(
+        "Invalid authorization code",
+      );
+    });
+  });
+
+  describe("exchangeAuthorizationCode", () => {
+    it("returns access token for valid code", async () => {
+      const code = await createAuthCode(provider, mockClient, mockParams);
+      const tokens = await provider.exchangeAuthorizationCode(mockClient, code);
+
+      expect(tokens.access_token).toBeDefined();
+      expect(tokens.token_type).toBe("bearer");
+      expect(tokens.expires_in).toBe(3600);
+      expect(tokens.scope).toBe("mcp:tools");
+    });
+
+    it("rejects reuse of the same code", async () => {
+      const code = await createAuthCode(provider, mockClient, mockParams);
+      await provider.exchangeAuthorizationCode(mockClient, code);
+
+      await expect(provider.exchangeAuthorizationCode(mockClient, code)).rejects.toThrow(
+        "Invalid authorization code",
+      );
+    });
+
+    it("rejects code from different client", async () => {
+      const code = await createAuthCode(provider, mockClient, mockParams);
+      const otherClient = { ...mockClient, client_id: "other-client" };
+
+      await expect(provider.exchangeAuthorizationCode(otherClient, code)).rejects.toThrow(
+        "not issued to this client",
+      );
+    });
+  });
+
+  describe("verifyAccessToken", () => {
+    it("returns AuthInfo for valid token", async () => {
+      const code = await createAuthCode(provider, mockClient, mockParams);
+      const tokens = await provider.exchangeAuthorizationCode(mockClient, code);
+      const authInfo = await provider.verifyAccessToken(tokens.access_token);
+
+      expect(authInfo.clientId).toBe("test-client-id");
+      expect(authInfo.scopes).toEqual(["mcp:tools"]);
+      expect(authInfo.expiresAt).toBeDefined();
+    });
+
+    it("throws for invalid token", async () => {
+      await expect(provider.verifyAccessToken("invalid")).rejects.toThrow("Invalid token");
+    });
+  });
+
+  describe("revokeToken", () => {
+    it("revokes a token so it becomes invalid", async () => {
+      const code = await createAuthCode(provider, mockClient, mockParams);
+      const tokens = await provider.exchangeAuthorizationCode(mockClient, code);
+
+      // Token works before revocation
+      await expect(provider.verifyAccessToken(tokens.access_token)).resolves.toBeDefined();
+
+      // Revoke
+      await provider.revokeToken!(mockClient, { token: tokens.access_token });
+
+      // Token no longer works
+      await expect(provider.verifyAccessToken(tokens.access_token)).rejects.toThrow(
+        "Invalid token",
+      );
+    });
+  });
+
+  describe("cleanup", () => {
+    it("removes expired tokens", async () => {
+      const code = await createAuthCode(provider, mockClient, mockParams);
+      const tokens = await provider.exchangeAuthorizationCode(mockClient, code);
+
+      // Manually expire the token by accessing internal state
+      const tokenMap = (provider as any).tokens as Map<string, any>;
+      const tokenData = tokenMap.get(tokens.access_token)!;
+      tokenData.expiresAt = Date.now() - 1000;
+
+      provider.cleanup();
+
+      await expect(provider.verifyAccessToken(tokens.access_token)).rejects.toThrow();
+    });
+  });
+});
+
+// --- Helper ---
+
+/**
+ * Simulates the full authorize → completeAuthorization flow, returns the auth code.
+ */
+async function createAuthCode(
+  provider: SparkleAuthProvider,
+  client: any,
+  params: any,
+): Promise<string> {
+  let pendingId = "";
+  const authorizeRes = {
+    setHeader: () => {},
+    send: (html: string) => {
+      const match = html.match(/value="([^"]+)"/);
+      if (match) pendingId = match[1];
+    },
+  } as any;
+
+  await provider.authorize(client, params, authorizeRes);
+
+  let code = "";
+  const submitRes = {
+    redirect: (url: string) => {
+      const parsed = new URL(url);
+      code = parsed.searchParams.get("code")!;
+    },
+  } as any;
+
+  provider.completeAuthorization(pendingId, "test-pin-1234", submitRes);
+  return code;
+}

--- a/mcp-server/src/auth.ts
+++ b/mcp-server/src/auth.ts
@@ -1,0 +1,302 @@
+import { randomUUID } from "node:crypto";
+import type { Response } from "express";
+import type { OAuthRegisteredClientsStore } from "@modelcontextprotocol/sdk/server/auth/clients.js";
+import type {
+  OAuthServerProvider,
+  AuthorizationParams,
+} from "@modelcontextprotocol/sdk/server/auth/provider.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type {
+  OAuthClientInformationFull,
+  OAuthTokens,
+  OAuthTokenRevocationRequest,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import { InvalidRequestError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
+
+// --- Clients Store ---
+
+export class SparkleClientsStore implements OAuthRegisteredClientsStore {
+  private clients = new Map<string, OAuthClientInformationFull>();
+
+  getClient(clientId: string): OAuthClientInformationFull | undefined {
+    return this.clients.get(clientId);
+  }
+
+  registerClient(
+    client: Omit<OAuthClientInformationFull, "client_id" | "client_id_issued_at">,
+  ): OAuthClientInformationFull {
+    const full: OAuthClientInformationFull = {
+      ...client,
+      client_id: randomUUID(),
+      client_id_issued_at: Math.floor(Date.now() / 1000),
+    };
+    this.clients.set(full.client_id, full);
+    return full;
+  }
+}
+
+// --- Auth Provider ---
+
+interface PendingAuth {
+  client: OAuthClientInformationFull;
+  params: AuthorizationParams;
+  createdAt: number;
+}
+
+interface StoredCode {
+  client: OAuthClientInformationFull;
+  params: AuthorizationParams;
+  createdAt: number;
+}
+
+interface StoredToken {
+  clientId: string;
+  scopes: string[];
+  expiresAt: number;
+  resource?: URL;
+}
+
+const TOKEN_EXPIRY_MS = 60 * 60 * 1000; // 1 hour
+const CODE_EXPIRY_MS = 10 * 60 * 1000; // 10 minutes
+const PENDING_AUTH_EXPIRY_MS = 5 * 60 * 1000; // 5 minutes
+
+export class SparkleAuthProvider implements OAuthServerProvider {
+  readonly clientsStore = new SparkleClientsStore();
+  private codes = new Map<string, StoredCode>();
+  private tokens = new Map<string, StoredToken>();
+  private pendingAuths = new Map<string, PendingAuth>();
+
+  private readonly pin: string;
+
+  constructor(pin: string) {
+    this.pin = pin;
+  }
+
+  /**
+   * Renders an HTML form asking for the PIN.
+   * The form POSTs to /authorize/submit with the pending auth ID.
+   */
+  async authorize(
+    client: OAuthClientInformationFull,
+    params: AuthorizationParams,
+    res: Response,
+  ): Promise<void> {
+    const pendingId = randomUUID();
+    this.pendingAuths.set(pendingId, {
+      client,
+      params,
+      createdAt: Date.now(),
+    });
+
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    res.send(`<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Sparkle MCP — 授權</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 400px; margin: 80px auto; padding: 0 20px; }
+    h1 { font-size: 1.4em; }
+    .info { color: #666; margin: 1em 0; }
+    input[type=password] { width: 100%; padding: 10px; font-size: 1em; border: 1px solid #ccc; border-radius: 6px; box-sizing: border-box; }
+    button { margin-top: 12px; padding: 10px 24px; font-size: 1em; background: #2563eb; color: white; border: none; border-radius: 6px; cursor: pointer; }
+    button:hover { background: #1d4ed8; }
+    .error { color: #dc2626; margin-top: 8px; }
+  </style>
+</head>
+<body>
+  <h1>Sparkle MCP 授權</h1>
+  <p class="info">應用程式「${escapeHtml(client.client_name || client.client_id)}」要求存取你的 Sparkle 知識庫。</p>
+  <form method="POST" action="/authorize/submit">
+    <input type="hidden" name="pending_id" value="${pendingId}">
+    <label for="pin">請輸入 PIN：</label>
+    <input type="password" id="pin" name="pin" required autofocus>
+    <button type="submit">允許存取</button>
+  </form>
+</body>
+</html>`);
+  }
+
+  /**
+   * Called by our custom /authorize/submit route after PIN validation.
+   * Generates an auth code and redirects to the client's redirect_uri.
+   */
+  completeAuthorization(pendingId: string, pin: string, res: Response): void {
+    const pending = this.pendingAuths.get(pendingId);
+    if (!pending) {
+      res.status(400).send(errorPage("授權請求已過期或無效。請重新開始。"));
+      return;
+    }
+
+    if (Date.now() - pending.createdAt > PENDING_AUTH_EXPIRY_MS) {
+      this.pendingAuths.delete(pendingId);
+      res.status(400).send(errorPage("授權請求已過期。請重新開始。"));
+      return;
+    }
+
+    if (pin !== this.pin) {
+      res.status(403).send(errorPage("PIN 錯誤。請返回重試。"));
+      return;
+    }
+
+    this.pendingAuths.delete(pendingId);
+
+    const code = randomUUID();
+    this.codes.set(code, {
+      client: pending.client,
+      params: pending.params,
+      createdAt: Date.now(),
+    });
+
+    const { redirectUri, state } = pending.params;
+    if (!pending.client.redirect_uris.some((uri) => uri.toString() === redirectUri)) {
+      throw new InvalidRequestError("Unregistered redirect_uri");
+    }
+
+    const targetUrl = new URL(redirectUri);
+    targetUrl.searchParams.set("code", code);
+    if (state !== undefined) {
+      targetUrl.searchParams.set("state", state);
+    }
+    res.redirect(targetUrl.toString());
+  }
+
+  async challengeForAuthorizationCode(
+    _client: OAuthClientInformationFull,
+    authorizationCode: string,
+  ): Promise<string> {
+    const codeData = this.codes.get(authorizationCode);
+    if (!codeData) {
+      throw new Error("Invalid authorization code");
+    }
+    return codeData.params.codeChallenge;
+  }
+
+  async exchangeAuthorizationCode(
+    client: OAuthClientInformationFull,
+    authorizationCode: string,
+    _codeVerifier?: string,
+    _redirectUri?: string,
+    resource?: URL,
+  ): Promise<OAuthTokens> {
+    const codeData = this.codes.get(authorizationCode);
+    if (!codeData) {
+      throw new Error("Invalid authorization code");
+    }
+
+    if (codeData.client.client_id !== client.client_id) {
+      throw new Error("Authorization code was not issued to this client");
+    }
+
+    if (Date.now() - codeData.createdAt > CODE_EXPIRY_MS) {
+      this.codes.delete(authorizationCode);
+      throw new Error("Authorization code has expired");
+    }
+
+    this.codes.delete(authorizationCode);
+
+    const accessToken = randomUUID();
+    const expiresAt = Date.now() + TOKEN_EXPIRY_MS;
+    this.tokens.set(accessToken, {
+      clientId: client.client_id,
+      scopes: codeData.params.scopes || [],
+      expiresAt,
+      resource,
+    });
+
+    return {
+      access_token: accessToken,
+      token_type: "bearer",
+      expires_in: Math.floor(TOKEN_EXPIRY_MS / 1000),
+      scope: (codeData.params.scopes || []).join(" "),
+    };
+  }
+
+  async exchangeRefreshToken(
+    _client: OAuthClientInformationFull,
+    _refreshToken: string,
+    _scopes?: string[],
+    _resource?: URL,
+  ): Promise<OAuthTokens> {
+    throw new Error("Refresh tokens are not supported. Please re-authorize.");
+  }
+
+  async verifyAccessToken(token: string): Promise<AuthInfo> {
+    const tokenData = this.tokens.get(token);
+    if (!tokenData) {
+      throw new Error("Invalid token");
+    }
+
+    if (Date.now() > tokenData.expiresAt) {
+      this.tokens.delete(token);
+      throw new Error("Token has expired");
+    }
+
+    return {
+      token,
+      clientId: tokenData.clientId,
+      scopes: tokenData.scopes,
+      expiresAt: Math.floor(tokenData.expiresAt / 1000),
+      resource: tokenData.resource,
+    };
+  }
+
+  async revokeToken(
+    _client: OAuthClientInformationFull,
+    request: OAuthTokenRevocationRequest,
+  ): Promise<void> {
+    this.tokens.delete(request.token);
+  }
+
+  /**
+   * Clean up expired entries to prevent memory leaks.
+   */
+  cleanup(): void {
+    const now = Date.now();
+    for (const [id, pending] of this.pendingAuths) {
+      if (now - pending.createdAt > PENDING_AUTH_EXPIRY_MS) {
+        this.pendingAuths.delete(id);
+      }
+    }
+    for (const [code, data] of this.codes) {
+      if (now - data.createdAt > CODE_EXPIRY_MS) {
+        this.codes.delete(code);
+      }
+    }
+    for (const [token, data] of this.tokens) {
+      if (now > data.expiresAt) {
+        this.tokens.delete(token);
+      }
+    }
+  }
+}
+
+// --- Helpers ---
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function errorPage(message: string): string {
+  return `<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Sparkle MCP — 錯誤</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 400px; margin: 80px auto; padding: 0 20px; }
+    .error { color: #dc2626; }
+  </style>
+</head>
+<body>
+  <h1>Sparkle MCP</h1>
+  <p class="error">${escapeHtml(message)}</p>
+</body>
+</html>`;
+}

--- a/mcp-server/src/http.ts
+++ b/mcp-server/src/http.ts
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+
+import { randomUUID } from "node:crypto";
+import express from "express";
+import cors from "cors";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { mcpAuthRouter } from "@modelcontextprotocol/sdk/server/auth/router.js";
+import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import { createSparkleServer } from "./server.js";
+import { SparkleAuthProvider } from "./auth.js";
+
+// --- Env validation ---
+
+if (!process.env.SPARKLE_AUTH_TOKEN) {
+  console.error("ERROR: SPARKLE_AUTH_TOKEN environment variable is required");
+  process.exit(1);
+}
+
+if (!process.env.MCP_AUTH_PIN) {
+  console.error("ERROR: MCP_AUTH_PIN environment variable is required");
+  process.exit(1);
+}
+
+const MCP_HTTP_PORT = parseInt(process.env.MCP_HTTP_PORT || "3001", 10);
+const MCP_ISSUER_URL = process.env.MCP_ISSUER_URL || `http://localhost:${MCP_HTTP_PORT}`;
+
+// --- OAuth provider ---
+
+const provider = new SparkleAuthProvider(process.env.MCP_AUTH_PIN);
+
+// --- Express app ---
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
+
+// OAuth routes (/.well-known/*, /authorize, /token, /register, /revoke)
+app.use(
+  mcpAuthRouter({
+    provider,
+    issuerUrl: new URL(MCP_ISSUER_URL),
+    scopesSupported: ["mcp:tools"],
+    resourceName: "Sparkle MCP Server",
+  }),
+);
+
+// Custom PIN submission handler (not part of SDK's OAuth router)
+app.post("/authorize/submit", (req, res) => {
+  const { pending_id, pin } = req.body;
+  if (!pending_id || !pin) {
+    res.status(400).send("Missing required fields");
+    return;
+  }
+  provider.completeAuthorization(pending_id, pin, res);
+});
+
+// --- MCP transport ---
+
+const authMiddleware = requireBearerAuth({ verifier: provider });
+const transports = new Map<string, StreamableHTTPServerTransport>();
+
+// POST /mcp — handle MCP requests
+app.post("/mcp", authMiddleware, async (req, res) => {
+  const sessionId = req.headers["mcp-session-id"] as string | undefined;
+
+  try {
+    if (sessionId && transports.has(sessionId)) {
+      const transport = transports.get(sessionId)!;
+      await transport.handleRequest(req, res, req.body);
+      return;
+    }
+
+    if (!sessionId && isInitializeRequest(req.body)) {
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (id) => {
+          transports.set(id, transport);
+        },
+      });
+
+      transport.onclose = () => {
+        const sid = transport.sessionId;
+        if (sid) transports.delete(sid);
+      };
+
+      const server = createSparkleServer();
+      await server.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+      return;
+    }
+
+    res.status(400).json({
+      jsonrpc: "2.0",
+      error: { code: -32000, message: "Bad Request: No valid session ID provided" },
+      id: null,
+    });
+  } catch (error) {
+    console.error("Error handling MCP request:", error);
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: "2.0",
+        error: { code: -32603, message: "Internal server error" },
+        id: null,
+      });
+    }
+  }
+});
+
+// GET /mcp — SSE stream
+app.get("/mcp", authMiddleware, async (req, res) => {
+  const sessionId = req.headers["mcp-session-id"] as string | undefined;
+  if (!sessionId || !transports.has(sessionId)) {
+    res.status(400).send("Invalid or missing session ID");
+    return;
+  }
+  await transports.get(sessionId)!.handleRequest(req, res);
+});
+
+// DELETE /mcp — session termination
+app.delete("/mcp", authMiddleware, async (req, res) => {
+  const sessionId = req.headers["mcp-session-id"] as string | undefined;
+  if (!sessionId || !transports.has(sessionId)) {
+    res.status(400).send("Invalid or missing session ID");
+    return;
+  }
+  try {
+    await transports.get(sessionId)!.handleRequest(req, res);
+  } catch (error) {
+    console.error("Error handling session termination:", error);
+    if (!res.headersSent) {
+      res.status(500).send("Error processing session termination");
+    }
+  }
+});
+
+// --- Cleanup & lifecycle ---
+
+// Periodically clean up expired OAuth state and stale sessions
+const CLEANUP_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
+const SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+const sessionCreatedAt = new Map<string, number>();
+
+// Patch session tracking into transport creation
+const originalSet = transports.set.bind(transports);
+transports.set = (key: string, value: StreamableHTTPServerTransport) => {
+  sessionCreatedAt.set(key, Date.now());
+  return originalSet(key, value);
+};
+const originalDelete = transports.delete.bind(transports);
+transports.delete = (key: string) => {
+  sessionCreatedAt.delete(key);
+  return originalDelete(key);
+};
+
+setInterval(() => {
+  provider.cleanup();
+
+  const now = Date.now();
+  for (const [sessionId, createdAt] of sessionCreatedAt) {
+    if (now - createdAt > SESSION_MAX_AGE_MS) {
+      const transport = transports.get(sessionId);
+      if (transport) {
+        transport.close().catch(() => {});
+        transports.delete(sessionId);
+      }
+    }
+  }
+}, CLEANUP_INTERVAL_MS);
+
+// Graceful shutdown
+async function shutdown(): Promise<void> {
+  console.log("Shutting down MCP HTTP server...");
+  for (const [sessionId, transport] of transports) {
+    try {
+      await transport.close();
+      transports.delete(sessionId);
+    } catch (error) {
+      console.error(`Error closing transport for session ${sessionId}:`, error);
+    }
+  }
+  process.exit(0);
+}
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+
+// --- Start ---
+
+app.listen(MCP_HTTP_PORT, () => {
+  console.log(`Sparkle MCP HTTP server listening on port ${MCP_HTTP_PORT}`);
+  console.log(`Issuer URL: ${MCP_ISSUER_URL}`);
+});

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,33 +1,7 @@
 #!/usr/bin/env node
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { registerSearchTools } from "./tools/search.js";
-import { registerReadTools } from "./tools/read.js";
-import { registerWriteTools } from "./tools/write.js";
-import { registerCategoryTools } from "./tools/categories.js";
-import { registerWorkflowTools } from "./tools/workflow.js";
-import { registerMetaTools } from "./tools/meta.js";
-import { registerGuideTools } from "./tools/guide.js";
-import { SPARKLE_INSTRUCTIONS } from "./docs/instructions.js";
-import { registerDocResources } from "./docs/resources.js";
-
-const server = new McpServer(
-  { name: "sparkle", version: "1.0.0" },
-  { instructions: SPARKLE_INSTRUCTIONS },
-);
-
-// Register all tools
-registerSearchTools(server);
-registerReadTools(server);
-registerWriteTools(server);
-registerCategoryTools(server);
-registerWorkflowTools(server);
-registerMetaTools(server);
-registerGuideTools(server);
-
-// Register documentation resources
-registerDocResources(server);
+import { createSparkleServer } from "./server.js";
 
 // Start stdio transport
 async function main(): Promise<void> {
@@ -36,6 +10,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  const server = createSparkleServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error("Sparkle MCP server running via stdio");

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -1,0 +1,28 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerSearchTools } from "./tools/search.js";
+import { registerReadTools } from "./tools/read.js";
+import { registerWriteTools } from "./tools/write.js";
+import { registerCategoryTools } from "./tools/categories.js";
+import { registerWorkflowTools } from "./tools/workflow.js";
+import { registerMetaTools } from "./tools/meta.js";
+import { registerGuideTools } from "./tools/guide.js";
+import { SPARKLE_INSTRUCTIONS } from "./docs/instructions.js";
+import { registerDocResources } from "./docs/resources.js";
+
+export function createSparkleServer(): McpServer {
+  const server = new McpServer(
+    { name: "sparkle", version: "1.0.0" },
+    { instructions: SPARKLE_INSTRUCTIONS },
+  );
+
+  registerSearchTools(server);
+  registerReadTools(server);
+  registerWriteTools(server);
+  registerCategoryTools(server);
+  registerWorkflowTools(server);
+  registerMetaTools(server);
+  registerGuideTools(server);
+  registerDocResources(server);
+
+  return server;
+}


### PR DESCRIPTION
## Summary

- Extract shared `createSparkleServer()` factory from `index.ts` into `server.ts` — used by both stdio and HTTP transports
- Implement `OAuthServerProvider` with PIN-gated authorization, in-memory token store (1hr expiry)
- Add Express HTTP entry point (`http.ts`) with `StreamableHTTPServerTransport` + `mcpAuthRouter()` on port 3001
- 15 unit tests for OAuth provider (clients store, auth flow, token lifecycle, cleanup)

Infra (systemd service, CF Tunnel config) will follow in a separate PR.

## Test plan

- [x] All 61 existing tests pass (`npx vitest run`)
- [x] 15 new auth tests pass
- [x] Type-check clean (`tsc --noEmit`)
- [x] HTTP server starts and serves OAuth metadata at `/.well-known/oauth-authorization-server`
- [x] Existing stdio transport unaffected (`npm run dev` still works)
- [ ] Manual: Claude.ai custom connector connects after infra PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)