### PR TITLE
feat(ops): add systemd service and deploy workflow for MCP HTTP server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Build frontend
         run: cd $SPARKLE_DIR && npm run build
 
+      - name: Build MCP server
+        run: cd $SPARKLE_DIR/mcp-server && npm ci && npm run build
+
       - name: Validate migrations against production DB
         run: |
           cd $SPARKLE_DIR
@@ -38,8 +41,8 @@ jobs:
             exit 1
           }
 
-      - name: Restart service
-        run: sudo systemctl restart sparkle
+      - name: Restart services
+        run: sudo systemctl restart sparkle sparkle-mcp-http
 
       - name: Health check
         run: |

--- a/scripts/install-services.sh
+++ b/scripts/install-services.sh
@@ -82,6 +82,13 @@ sed -e "s|YOUR_USER|$SPARKLE_USER|g" \
     "$SERVICE_DIR/sparkle.service" > /etc/systemd/system/sparkle.service
 echo "✅ 已安裝 sparkle.service"
 
+# Install MCP HTTP service (for Claude.ai connector)
+sed -e "s|YOUR_USER|$SPARKLE_USER|g" \
+    -e "s|NODE_BIN_DIR|$NODE_BIN_DIR|g" \
+    -e "s|SPARKLE_DIR|$PROJECT_DIR|g" \
+    "$SERVICE_DIR/sparkle-mcp-http.service" > /etc/systemd/system/sparkle-mcp-http.service
+echo "✅ 已安裝 sparkle-mcp-http.service"
+
 # 確保防火牆腳本可執行
 chmod +x "$PROJECT_DIR/scripts/firewall.sh" "$PROJECT_DIR/scripts/firewall-cleanup.sh"
 
@@ -98,6 +105,7 @@ systemctl daemon-reload
 
 # 啟用開機自動啟動
 systemctl enable sparkle.service
+systemctl enable sparkle-mcp-http.service
 if [ "$INSTALL_TUNNEL" = true ]; then
   systemctl enable sparkle-tunnel.service
 fi
@@ -134,6 +142,7 @@ fi
 # 啟動服務（使用 restart 確保冪等）
 if [ "$START_SERVICES" = true ]; then
   systemctl restart sparkle.service
+  systemctl restart sparkle-mcp-http.service
   if [ "$INSTALL_TUNNEL" = true ]; then
     systemctl restart sparkle-tunnel.service
   fi
@@ -142,6 +151,8 @@ if [ "$START_SERVICES" = true ]; then
   echo "✅ 安裝完成！服務狀態："
   echo ""
   systemctl status sparkle.service --no-pager -l | head -5
+  echo ""
+  systemctl status sparkle-mcp-http.service --no-pager -l | head -5
 
   if [ "$INSTALL_TUNNEL" = true ]; then
     echo ""
@@ -157,9 +168,10 @@ echo ""
 echo "常用指令："
 echo "  查看狀態:  sudo systemctl status sparkle"
 echo "  查看 log:  journalctl -u sparkle -f"
+echo "  MCP log:   journalctl -u sparkle-mcp-http -f"
 echo "  重啟:      sudo systemctl restart sparkle"
 if [ "$INSTALL_TUNNEL" = true ]; then
-  echo "  重啟全部:  sudo systemctl restart sparkle sparkle-tunnel"
+  echo "  重啟全部:  sudo systemctl restart sparkle sparkle-mcp-http sparkle-tunnel"
 fi
 echo ""
 echo "💡 WSL2 mirrored 模式下不需要 port forwarding"

--- a/scripts/systemd/sparkle-mcp-http.service
+++ b/scripts/systemd/sparkle-mcp-http.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Sparkle MCP HTTP Server (Claude.ai connector)
+After=network.target sparkle.service
+Wants=sparkle.service
+
+[Service]
+Type=simple
+# TODO: Change to your Linux username
+User=YOUR_USER
+WorkingDirectory=SPARKLE_DIR/mcp-server
+Environment=PATH=NODE_BIN_DIR:/usr/bin
+EnvironmentFile=-SPARKLE_DIR/.env
+ExecStart=NODE_BIN_DIR/node --env-file=SPARKLE_DIR/.env dist/http.js
+MemoryMax=256M
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Add `sparkle-mcp-http.service` systemd unit (depends on sparkle.service, auto-restart)
- Update `install-services.sh` to install/enable/start MCP HTTP service
- Update `deploy.yml` to build mcp-server dist and restart sparkle-mcp-http on deploy

## Test plan

- [x] Service running: `systemctl status sparkle-mcp-http` shows active
- [x] Public URL responds: `curl https://sparkle-mcp.kalthor.cc/.well-known/oauth-authorization-server` returns 200
- [x] Claude.ai connector works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)