### PR TITLE
fix(mcp): use JWT tokens for restart-safe auth with 1-year expiry

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -11,6 +11,7 @@
         "@modelcontextprotocol/sdk": "^1.12.1",
         "cors": "^2.8.5",
         "express": "^5.1.0",
+        "jose": "^6.1.3",
         "zod": "^4.3.6"
       },
       "devDependencies": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -20,6 +20,7 @@
     "@modelcontextprotocol/sdk": "^1.12.1",
     "cors": "^2.8.5",
     "express": "^5.1.0",
+    "jose": "^6.1.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/mcp-server/src/__tests__/auth.test.ts
+++ b/mcp-server/src/__tests__/auth.test.ts
@@ -1,5 +1,8 @@
+// @vitest-environment node
 import { describe, it, expect, beforeEach } from "vitest";
 import { SparkleClientsStore, SparkleAuthProvider } from "../auth.js";
+
+const TEST_PIN = "test-pin-1234";
 
 describe("SparkleClientsStore", () => {
   let store: SparkleClientsStore;
@@ -29,7 +32,6 @@ describe("SparkleClientsStore", () => {
 
 describe("SparkleAuthProvider", () => {
   let provider: SparkleAuthProvider;
-  const TEST_PIN = "test-pin-1234";
 
   const mockClient = {
     client_id: "test-client-id",
@@ -161,7 +163,7 @@ describe("SparkleAuthProvider", () => {
 
       expect(tokens.access_token).toBeDefined();
       expect(tokens.token_type).toBe("bearer");
-      expect(tokens.expires_in).toBe(3600);
+      expect(tokens.expires_in).toBe(365 * 24 * 60 * 60);
       expect(tokens.scope).toBe("mcp:tools");
     });
 
@@ -196,7 +198,9 @@ describe("SparkleAuthProvider", () => {
     });
 
     it("throws for invalid token", async () => {
-      await expect(provider.verifyAccessToken("invalid")).rejects.toThrow("Invalid token");
+      await expect(provider.verifyAccessToken("invalid")).rejects.toThrow(
+        "Invalid or expired token",
+      );
     });
   });
 
@@ -213,24 +217,24 @@ describe("SparkleAuthProvider", () => {
 
       // Token no longer works
       await expect(provider.verifyAccessToken(tokens.access_token)).rejects.toThrow(
-        "Invalid token",
+        "Token has been revoked",
       );
     });
   });
 
   describe("cleanup", () => {
-    it("removes expired tokens", async () => {
-      const code = await createAuthCode(provider, mockClient, mockParams);
-      const tokens = await provider.exchangeAuthorizationCode(mockClient, code);
+    it("cleans up expired pending auths and codes", () => {
+      // Access internal maps to verify cleanup works
+      const pendingAuths = (provider as any).pendingAuths as Map<string, any>;
+      const codes = (provider as any).codes as Map<string, any>;
 
-      // Manually expire the token by accessing internal state
-      const tokenMap = (provider as any).tokens as Map<string, any>;
-      const tokenData = tokenMap.get(tokens.access_token)!;
-      tokenData.expiresAt = Date.now() - 1000;
+      pendingAuths.set("old-pending", { createdAt: 0, attempts: 0 });
+      codes.set("old-code", { createdAt: 0 });
 
       provider.cleanup();
 
-      await expect(provider.verifyAccessToken(tokens.access_token)).rejects.toThrow();
+      expect(pendingAuths.has("old-pending")).toBe(false);
+      expect(codes.has("old-code")).toBe(false);
     });
   });
 });
@@ -264,6 +268,6 @@ async function createAuthCode(
     },
   } as any;
 
-  provider.completeAuthorization(pendingId, "test-pin-1234", submitRes);
+  provider.completeAuthorization(pendingId, TEST_PIN, submitRes);
   return code;
 }

--- a/mcp-server/src/auth.ts
+++ b/mcp-server/src/auth.ts
@@ -1,4 +1,10 @@
-import { randomUUID, timingSafeEqual } from "node:crypto";
+import {
+  randomUUID,
+  timingSafeEqual,
+  createHmac,
+  type KeyObject,
+  createSecretKey,
+} from "node:crypto";
 import type { Response } from "express";
 import type { OAuthRegisteredClientsStore } from "@modelcontextprotocol/sdk/server/auth/clients.js";
 import type {
@@ -11,6 +17,7 @@ import type {
   OAuthTokens,
   OAuthTokenRevocationRequest,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { SignJWT, jwtVerify, type JWTPayload } from "jose";
 // --- Clients Store ---
 
 const MAX_CLIENTS = 20;
@@ -55,27 +62,31 @@ interface StoredCode {
   createdAt: number;
 }
 
-interface StoredToken {
-  clientId: string;
-  scopes: string[];
-  expiresAt: number;
-  resource?: URL;
-}
-
-const TOKEN_EXPIRY_MS = 60 * 60 * 1000; // 1 hour
+const TOKEN_EXPIRY_SECONDS = 365 * 24 * 60 * 60; // 1 year (effectively no expiry)
 const CODE_EXPIRY_MS = 10 * 60 * 1000; // 10 minutes
 const PENDING_AUTH_EXPIRY_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Derive a stable signing key from the PIN.
+ * Same PIN = same key across restarts → tokens survive restarts.
+ */
+function deriveSigningKey(pin: string): KeyObject {
+  const buf = createHmac("sha256", "sparkle-mcp-jwt-key").update(pin).digest();
+  return createSecretKey(buf);
+}
 
 export class SparkleAuthProvider implements OAuthServerProvider {
   readonly clientsStore = new SparkleClientsStore();
   private codes = new Map<string, StoredCode>();
-  private tokens = new Map<string, StoredToken>();
+  private revokedTokens = new Set<string>(); // JTI of revoked tokens
   private pendingAuths = new Map<string, PendingAuth>();
 
   private readonly pin: string;
+  private readonly jwtKey: KeyObject;
 
   constructor(pin: string) {
     this.pin = pin;
+    this.jwtKey = deriveSigningKey(pin);
   }
 
   /**
@@ -211,20 +222,23 @@ export class SparkleAuthProvider implements OAuthServerProvider {
 
     this.codes.delete(authorizationCode);
 
-    const accessToken = randomUUID();
-    const expiresAt = Date.now() + TOKEN_EXPIRY_MS;
-    this.tokens.set(accessToken, {
-      clientId: client.client_id,
-      scopes: codeData.params.scopes || [],
-      expiresAt,
-      resource,
-    });
+    const scopes = codeData.params.scopes || [];
+    const accessToken = await new SignJWT({
+      sub: client.client_id,
+      scope: scopes.join(" "),
+      ...(resource ? { aud: resource.toString() } : {}),
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setJti(randomUUID())
+      .setIssuedAt()
+      .setExpirationTime(`${TOKEN_EXPIRY_SECONDS}s`)
+      .sign(this.jwtKey);
 
     return {
       access_token: accessToken,
       token_type: "bearer",
-      expires_in: Math.floor(TOKEN_EXPIRY_MS / 1000),
-      scope: (codeData.params.scopes || []).join(" "),
+      expires_in: TOKEN_EXPIRY_SECONDS,
+      scope: scopes.join(" "),
     };
   }
 
@@ -238,22 +252,37 @@ export class SparkleAuthProvider implements OAuthServerProvider {
   }
 
   async verifyAccessToken(token: string): Promise<AuthInfo> {
-    const tokenData = this.tokens.get(token);
-    if (!tokenData) {
-      throw new Error("Invalid token");
+    let payload: JWTPayload;
+    try {
+      const result = await jwtVerify(token, this.jwtKey, { algorithms: ["HS256"] });
+      payload = result.payload;
+    } catch {
+      throw new Error("Invalid or expired token");
     }
 
-    if (Date.now() > tokenData.expiresAt) {
-      this.tokens.delete(token);
-      throw new Error("Token has expired");
+    if (payload.jti && this.revokedTokens.has(payload.jti)) {
+      throw new Error("Token has been revoked");
+    }
+
+    if (!payload.sub) {
+      throw new Error("Invalid token: missing sub claim");
+    }
+
+    let resource: URL | undefined;
+    if (payload.aud) {
+      try {
+        resource = new URL(payload.aud as string);
+      } catch {
+        // Malformed aud claim — ignore rather than crash
+      }
     }
 
     return {
       token,
-      clientId: tokenData.clientId,
-      scopes: tokenData.scopes,
-      expiresAt: Math.floor(tokenData.expiresAt / 1000),
-      resource: tokenData.resource,
+      clientId: payload.sub,
+      scopes: payload.scope ? (payload.scope as string).split(" ") : [],
+      expiresAt: payload.exp,
+      ...(resource ? { resource } : {}),
     };
   }
 
@@ -261,11 +290,24 @@ export class SparkleAuthProvider implements OAuthServerProvider {
     _client: OAuthClientInformationFull,
     request: OAuthTokenRevocationRequest,
   ): Promise<void> {
-    this.tokens.delete(request.token);
+    // Decode JTI without verification — revocation doesn't need signature check
+    try {
+      const [, payloadB64] = request.token.split(".");
+      if (payloadB64) {
+        const payload = JSON.parse(Buffer.from(payloadB64, "base64url").toString());
+        if (payload.jti) {
+          this.revokedTokens.add(payload.jti);
+        }
+      }
+    } catch {
+      // Malformed token, nothing to revoke
+    }
   }
 
   /**
    * Clean up expired entries to prevent memory leaks.
+   * Note: JWT tokens are stateless and don't need cleanup.
+   * Only in-memory state (pending auths, auth codes, revocation set) needs cleanup.
    */
   cleanup(): void {
     const now = Date.now();
@@ -279,11 +321,8 @@ export class SparkleAuthProvider implements OAuthServerProvider {
         this.codes.delete(code);
       }
     }
-    for (const [token, data] of this.tokens) {
-      if (now > data.expiresAt) {
-        this.tokens.delete(token);
-      }
-    }
+    // Revoked tokens set is bounded by MAX_SESSIONS * token lifetime.
+    // For a personal server this stays tiny. No cleanup needed.
   }
 }
 


### PR DESCRIPTION
## Summary

Replace in-memory UUID tokens with JWT (jose HS256). Signing key derived from MCP_AUTH_PIN — tokens survive service restarts and deploys.

- JWT with 1-year expiry (authenticate once, done)
- jose added as explicit dependency
- Strict sub claim validation, safe aud URL parsing
- Optimized revoke: decode-only without signature verification
- Tests updated: node environment for jose crypto

## Test plan

- [x] 15 auth tests pass
- [x] Type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)