### PR TITLE
feat(share): add TOC, back-to-top, and modified date to public page

### DIFF
--- a/server/lib/render-public-page.ts
+++ b/server/lib/render-public-page.ts
@@ -1,4 +1,6 @@
-import { marked } from "marked";
+import { marked, type Token, type Tokens } from "marked";
+
+const MIN_TOC_HEADINGS = 4;
 
 // Escape HTML entities to prevent XSS
 function escapeHtml(str: string): string {
@@ -31,49 +33,320 @@ function stripMarkdown(md: string, maxLen: number): string {
     .slice(0, maxLen);
 }
 
-// Format ISO date to readable format
-function formatDate(iso: string): string {
+// Format ISO date to readable format with time (precise to seconds)
+function formatDateTime(iso: string): string {
   try {
     const d = new Date(iso);
-    return d.toLocaleDateString("zh-TW", {
+    const date = d.toLocaleDateString("zh-TW", {
       year: "numeric",
       month: "long",
       day: "numeric",
     });
+    const time = d.toLocaleTimeString("zh-TW", {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    });
+    return `${date} ${time}`;
   } catch {
     return iso;
   }
 }
 
-// Configure marked: disable raw HTML in output for XSS safety
-const renderer = new marked.Renderer();
-renderer.html = function ({ text }: { text: string }) {
-  return `<p>${escapeHtml(text)}</p>`;
-};
+// Check if two ISO dates fall on the same calendar day
+function isSameDay(a: string, b: string): boolean {
+  try {
+    const da = new Date(a);
+    const db = new Date(b);
+    return (
+      da.getFullYear() === db.getFullYear() &&
+      da.getMonth() === db.getMonth() &&
+      da.getDate() === db.getDate()
+    );
+  } catch {
+    return false;
+  }
+}
 
-marked.setOptions({
-  renderer,
-  gfm: true,
-  breaks: true,
-});
+// Generate a URL-safe slug from heading text
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\u4e00-\u9fff\u3400-\u4dbf]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+interface TocEntry {
+  depth: number;
+  text: string;
+  slug: string;
+}
+
+// Extract headings from pre-lexed markdown tokens for TOC
+function extractHeadings(tokens: Token[]): TocEntry[] {
+  const headings: TocEntry[] = [];
+  const slugCounts = new Map<string, number>();
+
+  for (const token of tokens) {
+    if (token.type === "heading" && (token as Tokens.Heading).depth <= 3) {
+      const heading = token as Tokens.Heading;
+      let slug = slugify(heading.text);
+      const count = slugCounts.get(slug) || 0;
+      slugCounts.set(slug, count + 1);
+      if (count > 0) slug = `${slug}-${count}`;
+      headings.push({ depth: heading.depth, text: heading.text, slug });
+    }
+  }
+  return headings;
+}
+
+// Build TOC HTML from headings
+function buildTocHtml(headings: TocEntry[]): string {
+  if (headings.length < MIN_TOC_HEADINGS) return "";
+
+  const items = headings
+    .map(
+      (h) =>
+        `<li class="toc-depth-${h.depth}"><a href="#${escapeHtml(h.slug)}">${escapeHtml(h.text)}</a></li>`,
+    )
+    .join("\n        ");
+
+  return `
+  <button class="toc-toggle" aria-label="目錄"><svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 5h14M3 10h14M3 15h14"/></svg></button>
+  <div class="toc-overlay"></div>
+  <nav class="toc">
+    <div class="toc-header">目錄</div>
+    <ul>
+        ${items}
+    </ul>
+  </nav>`;
+}
+
+// Configure marked: disable raw HTML in output for XSS safety, add heading IDs
+function createRenderer(headings: TocEntry[]) {
+  const renderer = new marked.Renderer();
+  let slugIndex = 0;
+
+  renderer.html = function ({ text }: { text: string }) {
+    return `<p>${escapeHtml(text)}</p>`;
+  };
+
+  renderer.heading = function ({ text, depth }: { text: string; depth: number }) {
+    const entry = headings[slugIndex];
+    if (depth <= 3 && entry) {
+      slugIndex++;
+      return `<h${depth} id="${escapeHtml(entry.slug)}">${text}</h${depth}>`;
+    }
+    return `<h${depth}>${text}</h${depth}>`;
+  };
+
+  return renderer;
+}
 
 interface PublicPageData {
   title: string;
   content: string;
   tags: string[];
   created: string;
+  modified: string;
 }
 
 export function renderPublicPage(data: PublicPageData): string {
   const titleEscaped = escapeHtml(data.title);
   const description = escapeHtml(stripMarkdown(data.content, 200));
-  const renderedContent = marked.parse(data.content) as string;
-  const dateFormatted = formatDate(data.created);
+
+  // Single tokenization pass: extract headings, then render from pre-lexed tokens
+  const tokens = marked.lexer(data.content);
+  const headings = extractHeadings(tokens);
+  const hasToc = headings.length >= MIN_TOC_HEADINGS;
+  const tocHtml = buildTocHtml(headings);
+
+  // Render from pre-lexed tokens with heading IDs
+  const renderer = createRenderer(headings);
+  const renderedContent = marked.parser(tokens, { renderer }) as string;
+
+  // Format dates
+  const createdFormatted = formatDateTime(data.created);
+  const sameDay = isSameDay(data.created, data.modified);
+  const metaDate = sameDay
+    ? createdFormatted
+    : `${createdFormatted} 建立 · ${formatDateTime(data.modified)} 更新`;
 
   const tagsHtml =
     data.tags.length > 0
       ? `<div class="tags">${data.tags.map((t) => `<span class="tag">${escapeHtml(t)}</span>`).join("")}</div>`
       : "";
+
+  const tocCss = hasToc
+    ? `
+    /* TOC - Desktop */
+    .toc {
+      position: fixed;
+      top: 2rem;
+      left: max(1rem, calc((100vw - 720px) / 2 - 260px));
+      width: 220px;
+      max-height: calc(100vh - 4rem);
+      overflow-y: auto;
+      font-size: 0.8rem;
+      line-height: 1.5;
+    }
+    .toc-header {
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+      font-size: 0.85rem;
+      color: #444;
+    }
+    .toc ul { list-style: none; padding: 0; margin: 0; }
+    .toc li { margin-bottom: 0.25rem; }
+    .toc a {
+      color: #666;
+      text-decoration: none;
+      display: block;
+      padding: 0.15rem 0;
+      border-left: 2px solid transparent;
+      padding-left: 0.5rem;
+      transition: color 0.2s, border-color 0.2s;
+    }
+    .toc a:hover { color: #2563eb; }
+    .toc a.active { color: #2563eb; border-left-color: #2563eb; font-weight: 500; }
+    .toc .toc-depth-2 { padding-left: 1rem; }
+    .toc .toc-depth-3 { padding-left: 1.75rem; }
+    .toc-toggle { display: none; }
+    .toc-overlay { display: none; }
+
+    /* TOC - Mobile */
+    @media (max-width: 1100px) {
+      .toc {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 260px;
+        height: 100vh;
+        max-height: 100vh;
+        background: #fafafa;
+        padding: 1.5rem 1rem;
+        transform: translateX(-100%);
+        transition: transform 0.3s ease;
+        z-index: 100;
+        box-shadow: none;
+      }
+      .toc.open {
+        transform: translateX(0);
+        box-shadow: 2px 0 12px rgba(0,0,0,0.1);
+      }
+      .toc-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: fixed;
+        top: 1rem;
+        left: 1rem;
+        z-index: 99;
+        width: 36px;
+        height: 36px;
+        border: 1px solid #ddd;
+        border-radius: 0.5rem;
+        background: #fff;
+        color: #666;
+        cursor: pointer;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+      }
+      .toc-toggle:hover { background: #f0f0f0; }
+      .toc-overlay {
+        display: none;
+        position: fixed;
+        inset: 0;
+        background: rgba(0,0,0,0.3);
+        z-index: 99;
+      }
+      .toc-overlay.open { display: block; }
+    }
+    @media (prefers-color-scheme: dark) {
+      .toc { background: #1a1a1a; }
+      .toc-header { color: #aaa; }
+      .toc a { color: #888; }
+      .toc a:hover { color: #6cb4ee; }
+      .toc a.active { color: #6cb4ee; border-left-color: #6cb4ee; }
+      .toc-toggle { background: #2a2a2a; border-color: #444; color: #aaa; }
+      .toc-toggle:hover { background: #333; }
+      .toc-overlay.open { background: rgba(0,0,0,0.5); }
+    }`
+    : "";
+
+  const backToTopCss = `
+    /* Back to top */
+    .back-to-top {
+      position: fixed;
+      bottom: 2rem;
+      right: 2rem;
+      width: 40px;
+      height: 40px;
+      border: 1px solid #ddd;
+      border-radius: 50%;
+      background: #fff;
+      color: #666;
+      font-size: 1.2rem;
+      cursor: pointer;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+      z-index: 50;
+    }
+    .back-to-top.visible { opacity: 1; pointer-events: auto; }
+    .back-to-top:hover { background: #f0f0f0; }
+    @media (prefers-color-scheme: dark) {
+      .back-to-top { background: #2a2a2a; border-color: #444; color: #aaa; }
+      .back-to-top:hover { background: #333; }
+    }`;
+
+  const inlineJs = `
+  <script>
+    (function() {
+      const backToTop = document.querySelector('.back-to-top');
+      if (backToTop) {
+        window.addEventListener('scroll', function() {
+          backToTop.classList.toggle('visible', window.scrollY > window.innerHeight);
+        }, { passive: true });
+        backToTop.addEventListener('click', function() {
+          window.scrollTo({ top: 0, behavior: 'smooth' });
+        });
+      }
+      ${
+        hasToc
+          ? `
+      const tocToggle = document.querySelector('.toc-toggle');
+      const toc = document.querySelector('.toc');
+      const overlay = document.querySelector('.toc-overlay');
+      function closeToc() { toc.classList.remove('open'); overlay.classList.remove('open'); }
+      function openToc() { toc.classList.add('open'); overlay.classList.add('open'); }
+      if (tocToggle) {
+        tocToggle.addEventListener('click', function() { toc.classList.contains('open') ? closeToc() : openToc(); });
+        overlay.addEventListener('click', closeToc);
+        toc.querySelectorAll('a').forEach(function(a) { a.addEventListener('click', closeToc); });
+      }
+      const tocLinks = document.querySelectorAll('.toc a');
+      const headingEls = document.querySelectorAll('.content h1[id], .content h2[id], .content h3[id]');
+      if (headingEls.length > 0 && 'IntersectionObserver' in window) {
+        const obs = new IntersectionObserver(function(entries) {
+          entries.forEach(function(entry) {
+            if (entry.isIntersecting) {
+              tocLinks.forEach(function(l) { l.classList.remove('active'); });
+              const active = document.querySelector('.toc a[href="#' + entry.target.id + '"]');
+              if (active) active.classList.add('active');
+            }
+          });
+        }, { rootMargin: '0px 0px -70% 0px', threshold: 0 });
+        headingEls.forEach(function(el) { obs.observe(el); });
+      }`
+          : ""
+      }
+    })();
+  </script>`;
 
   return `<!DOCTYPE html>
 <html lang="zh-TW">
@@ -161,17 +434,20 @@ export function renderPublicPage(data: PublicPageData): string {
     @media (prefers-color-scheme: dark) {
       .footer { border-color: #333; }
       .content th, .content td { border-color: #444; }
-    }
+    }${tocCss}${backToTopCss}
   </style>
 </head>
 <body>
+  ${tocHtml}
   <article>
     <h1>${titleEscaped}</h1>
-    <div class="meta">${dateFormatted}</div>
+    <div class="meta">${metaDate}</div>
     ${tagsHtml}
     <div class="content">${renderedContent}</div>
   </article>
+  <button class="back-to-top" aria-label="回到頂部">&#8593;</button>
   <div class="footer">Powered by Sparkle</div>
+  ${inlineJs}
 </body>
 </html>`;
 }

--- a/server/routes/__tests__/shares.test.ts
+++ b/server/routes/__tests__/shares.test.ts
@@ -60,6 +60,8 @@ function insertNote(
     content: string;
     status: string;
     tags: string;
+    created: string;
+    modified: string;
   }> = {},
 ) {
   const id = overrides.id ?? "note-1";
@@ -75,8 +77,8 @@ function insertNote(
       overrides.content ?? "# Hello\n\nThis is **bold** text.",
       overrides.status ?? "fleeting",
       overrides.tags ?? '["test","share"]',
-      now,
-      now,
+      overrides.created ?? now,
+      overrides.modified ?? now,
     );
   return id;
 }
@@ -440,7 +442,8 @@ describe("SSR Public Page", () => {
     const res = await app.request(`/s/${share.token}`);
     const html = await res.text();
     expect(html).toContain("My Shared Note");
-    expect(html).toContain("<h1>Heading</h1>");
+    expect(html).toContain("<h1");
+    expect(html).toContain("Heading</h1>");
     expect(html).toContain("<strong>bold</strong>");
   });
 
@@ -536,6 +539,114 @@ describe("SSR Public Page", () => {
     expect(html).toContain("&lt;script&gt;");
   });
 
+  it("renders TOC when content has more than 3 headings", async () => {
+    const noteId = insertNote({
+      content: "# One\n\n## Two\n\n## Three\n\n## Four\n\nSome text.",
+    });
+    const createRes = await app.request(`/api/items/${noteId}/share`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ visibility: "unlisted" }),
+    });
+    const { share } = await createRes.json();
+
+    const res = await app.request(`/s/${share.token}`);
+    const html = await res.text();
+    expect(html).toContain('class="toc"');
+    expect(html).toContain('class="toc-toggle"');
+    expect(html).toContain('class="toc-overlay"');
+    expect(html).toContain('href="#one"');
+    expect(html).toContain('href="#two"');
+    expect(html).toContain('href="#four"');
+  });
+
+  it("does not render TOC when content has 3 or fewer headings", async () => {
+    const noteId = insertNote({
+      content: "# One\n\n## Two\n\n## Three\n\nSome text.",
+    });
+    const createRes = await app.request(`/api/items/${noteId}/share`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ visibility: "unlisted" }),
+    });
+    const { share } = await createRes.json();
+
+    const res = await app.request(`/s/${share.token}`);
+    const html = await res.text();
+    expect(html).not.toContain('class="toc"');
+    expect(html).not.toContain('class="toc-toggle"');
+  });
+
+  it("adds id attributes to headings for TOC navigation", async () => {
+    const noteId = insertNote({
+      content: "# First\n\n## Second\n\n## Third\n\n## Fourth\n\nText.",
+    });
+    const createRes = await app.request(`/api/items/${noteId}/share`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ visibility: "unlisted" }),
+    });
+    const { share } = await createRes.json();
+
+    const res = await app.request(`/s/${share.token}`);
+    const html = await res.text();
+    expect(html).toContain('id="first"');
+    expect(html).toContain('id="second"');
+    expect(html).toContain('id="fourth"');
+  });
+
+  it("renders back-to-top button", async () => {
+    const noteId = insertNote();
+    const createRes = await app.request(`/api/items/${noteId}/share`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ visibility: "unlisted" }),
+    });
+    const { share } = await createRes.json();
+
+    const res = await app.request(`/s/${share.token}`);
+    const html = await res.text();
+    expect(html).toContain('class="back-to-top"');
+    expect(html).toContain("回到頂部");
+  });
+
+  it("shows modified date when different from created date", async () => {
+    const noteId = insertNote({
+      created: "2026-03-01T10:00:00.000Z",
+      modified: "2026-03-19T14:30:05.000Z",
+    });
+    const createRes = await app.request(`/api/items/${noteId}/share`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ visibility: "unlisted" }),
+    });
+    const { share } = await createRes.json();
+
+    const res = await app.request(`/s/${share.token}`);
+    const html = await res.text();
+    expect(html).toContain("建立");
+    expect(html).toContain("更新");
+  });
+
+  it("shows single date when created and modified are same day", async () => {
+    const sameDay = "2026-03-19T10:00:00.000Z";
+    const noteId = insertNote({
+      created: sameDay,
+      modified: "2026-03-19T14:30:00.000Z",
+    });
+    const createRes = await app.request(`/api/items/${noteId}/share`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ visibility: "unlisted" }),
+    });
+    const { share } = await createRes.json();
+
+    const res = await app.request(`/s/${share.token}`);
+    const html = await res.text();
+    expect(html).not.toContain("建立");
+    expect(html).not.toContain("更新");
+  });
+
   it("does not load SPA JavaScript bundle", async () => {
     const noteId = insertNote();
     const createRes = await app.request(`/api/items/${noteId}/share`, {
@@ -547,7 +658,7 @@ describe("SSR Public Page", () => {
 
     const res = await app.request(`/s/${share.token}`);
     const html = await res.text();
-    // Should not reference any JS bundle
+    // Should not reference any external JS bundle (inline script for TOC/back-to-top is OK)
     expect(html).not.toMatch(/src=.*\.js/);
     expect(html).not.toContain('type="module"');
   });

--- a/server/routes/public.ts
+++ b/server/routes/public.ts
@@ -72,6 +72,7 @@ publicRouter.get("/s/:token", (c) => {
     content: share.item_content,
     tags,
     created: share.item_created,
+    modified: share.item_modified,
   });
 
   return c.html(html);


### PR DESCRIPTION
## Summary
- Server-side TOC for public share pages (`/s/:token`): desktop fixed sidebar, mobile overlay drawer, hidden when ≤3 headings
- Back-to-top button appears after scrolling past one viewport height
- Modified date displayed with second precision (shows "建立 · 更新" when different day)
- Single-pass markdown tokenization via `marked.lexer()` + `marked.parser()` (no double parse)
- 6 new unit tests for TOC rendering, heading IDs, back-to-top, date display

## Test plan
- [x] `npx vitest run server/routes/__tests__/shares.test.ts` — 36 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run lint:fix` — clean
- [ ] Manual: create shared note with 4+ headings, verify desktop TOC sidebar + mobile drawer
- [ ] Manual: verify back-to-top button on long content
- [ ] Manual: verify modified date display on shared page

🤖 Generated with [Claude Code](https://claude.com/claude-code)