### PR TITLE
feat(mcp): add Obsidian vault read/write tools

### DIFF
--- a/mcp-server/src/__tests__/tools.test.ts
+++ b/mcp-server/src/__tests__/tools.test.ts
@@ -13,12 +13,22 @@ vi.mock("../client.js", () => ({
   exportToObsidian: vi.fn(),
 }));
 
+// Mock vault module
+vi.mock("../vault.js", () => ({
+  readVaultFileBySparkleId: vi.fn(),
+  readVaultFileByPath: vi.fn(),
+  writeVaultFileBySparkleId: vi.fn(),
+  writeVaultFileByPath: vi.fn(),
+}));
+
 import * as client from "../client.js";
+import * as vault from "../vault.js";
 import { registerReadTools } from "../tools/read.js";
 import { registerSearchTools } from "../tools/search.js";
 import { registerWriteTools } from "../tools/write.js";
 import { registerWorkflowTools } from "../tools/workflow.js";
 import { registerMetaTools } from "../tools/meta.js";
+import { registerVaultTools } from "../tools/vault.js";
 
 const searchItems = vi.mocked(client.searchItems);
 const getItem = vi.mocked(client.getItem);
@@ -28,6 +38,10 @@ const updateItem = vi.mocked(client.updateItem);
 const getStats = vi.mocked(client.getStats);
 const getTags = vi.mocked(client.getTags);
 const exportToObsidian = vi.mocked(client.exportToObsidian);
+const readVaultFileBySparkleId = vi.mocked(vault.readVaultFileBySparkleId);
+const readVaultFileByPath = vi.mocked(vault.readVaultFileByPath);
+const writeVaultFileBySparkleId = vi.mocked(vault.writeVaultFileBySparkleId);
+const writeVaultFileByPath = vi.mocked(vault.writeVaultFileByPath);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -307,5 +321,128 @@ describe("sparkle_list_tags", () => {
     expect(result.isError).toBeUndefined();
     expect(result.content[0].text).toContain("Found 2 tags:");
     expect(result.content[0].text).toContain("- ai");
+  });
+});
+
+// --- Vault tools ---
+
+const makeVaultFile = (overrides: Partial<import("../types.js").VaultFile> = {}): import("../types.js").VaultFile => ({
+  path: "0_Inbox/Test Note.md",
+  content: '---\nsparkle_id: "abc-123"\ntags:\n  - test\n---\n\n# Test Note\n\nBody here.',
+  frontmatter: { sparkle_id: "abc-123", tags: ["test"] },
+  body: "# Test Note\n\nBody here.",
+  ...overrides,
+});
+
+describe("sparkle_read_obsidian", () => {
+  function getHandler() {
+    const server = makeMockServer();
+    registerVaultTools(server as never);
+    return server.getHandler("sparkle_read_obsidian");
+  }
+
+  it("returns formatted vault file on success", async () => {
+    const handler = getHandler();
+    readVaultFileBySparkleId.mockResolvedValue(makeVaultFile());
+
+    const result = await handler({ sparkle_id: "abc-123" });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("0_Inbox/Test Note.md");
+    expect(result.content[0].text).toContain("abc-123");
+    expect(result.content[0].text).toContain("Body here.");
+  });
+
+  it("returns error when file not found", async () => {
+    const handler = getHandler();
+    readVaultFileBySparkleId.mockRejectedValue(new Error("No vault file found with sparkle_id: xyz"));
+
+    const result = await handler({ sparkle_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("No vault file found");
+  });
+});
+
+describe("sparkle_write_obsidian", () => {
+  function getHandler() {
+    const server = makeMockServer();
+    registerVaultTools(server as never);
+    return server.getHandler("sparkle_write_obsidian");
+  }
+
+  it("returns success with path", async () => {
+    const handler = getHandler();
+    writeVaultFileBySparkleId.mockResolvedValue("0_Inbox/Test Note.md");
+
+    const result = await handler({
+      sparkle_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      content: "# Updated content",
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("0_Inbox/Test Note.md");
+    expect(result.content[0].text).toContain("updated successfully");
+  });
+
+  it("returns error on failure", async () => {
+    const handler = getHandler();
+    writeVaultFileBySparkleId.mockRejectedValue(new Error("No vault file found"));
+
+    const result = await handler({
+      sparkle_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      content: "content",
+    });
+    expect(result.isError).toBe(true);
+  });
+});
+
+describe("sparkle_read_obsidian_by_path", () => {
+  function getHandler() {
+    const server = makeMockServer();
+    registerVaultTools(server as never);
+    return server.getHandler("sparkle_read_obsidian_by_path");
+  }
+
+  it("returns formatted vault file", async () => {
+    const handler = getHandler();
+    readVaultFileByPath.mockResolvedValue(makeVaultFile({ path: "Projects/note.md" }));
+
+    const result = await handler({ path: "Projects/note.md" });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("Projects/note.md");
+  });
+
+  it("returns error for nonexistent file", async () => {
+    const handler = getHandler();
+    readVaultFileByPath.mockRejectedValue(new Error("File not found: nope.md"));
+
+    const result = await handler({ path: "nope.md" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("File not found");
+  });
+});
+
+describe("sparkle_write_obsidian_by_path", () => {
+  function getHandler() {
+    const server = makeMockServer();
+    registerVaultTools(server as never);
+    return server.getHandler("sparkle_write_obsidian_by_path");
+  }
+
+  it("returns success with path", async () => {
+    const handler = getHandler();
+    writeVaultFileByPath.mockResolvedValue("new/note.md");
+
+    const result = await handler({ path: "new/note.md", content: "# New" });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("new/note.md");
+    expect(result.content[0].text).toContain("written successfully");
+  });
+
+  it("returns error on path traversal", async () => {
+    const handler = getHandler();
+    writeVaultFileByPath.mockRejectedValue(new Error("outside the vault"));
+
+    const result = await handler({ path: "../../../etc/passwd.md", content: "bad" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("outside the vault");
   });
 });

--- a/mcp-server/src/__tests__/vault.test.ts
+++ b/mcp-server/src/__tests__/vault.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock fs wrapper (used by vault.ts instead of node:fs directly)
+vi.mock("../fs.js", () => ({
+  readFileSync: vi.fn(),
+  readdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+// Mock client
+vi.mock("../client.js", () => ({
+  getSettings: vi.fn(),
+}));
+
+import { readFileSync, readdirSync, writeFileSync, existsSync, mkdirSync } from "../fs.js";
+import { getSettings } from "../client.js";
+import {
+  parseFrontmatter,
+  extractBody,
+  resolveVaultPath,
+  getVaultPath,
+  findBySparkleId,
+  readVaultFileByPath,
+  writeVaultFileByPath,
+  _resetCache,
+  _resetIndex,
+} from "../vault.js";
+
+const mockReadFileSync = vi.mocked(readFileSync);
+const mockReaddirSync = vi.mocked(readdirSync);
+const mockWriteFileSync = vi.mocked(writeFileSync);
+const mockExistsSync = vi.mocked(existsSync);
+const mockMkdirSync = vi.mocked(mkdirSync);
+const mockGetSettings = vi.mocked(getSettings);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _resetCache();
+  _resetIndex();
+});
+
+// --- parseFrontmatter ---
+
+describe("parseFrontmatter", () => {
+  it("parses basic key-value pairs", () => {
+    const content = `---
+sparkle_id: "cbe1a447-dd5a-405f-8959-f1bd8f699046"
+created: 2026-03-17T14:00:00
+origin: web
+---
+
+# Title`;
+    const fm = parseFrontmatter(content);
+    expect(fm.sparkle_id).toBe("cbe1a447-dd5a-405f-8959-f1bd8f699046");
+    expect(fm.created).toBe("2026-03-17T14:00:00");
+    expect(fm.origin).toBe("web");
+  });
+
+  it("parses YAML arrays (tags, aliases)", () => {
+    const content = `---
+tags:
+  - ai
+  - research
+aliases:
+  - "ML"
+  - "machine learning"
+---
+
+Body`;
+    const fm = parseFrontmatter(content);
+    expect(fm.tags).toEqual(["ai", "research"]);
+    expect(fm.aliases).toEqual(["ML", "machine learning"]);
+  });
+
+  it("returns empty object for content without frontmatter", () => {
+    expect(parseFrontmatter("# Just a heading\n\nBody")).toEqual({});
+    expect(parseFrontmatter("")).toEqual({});
+  });
+
+  it("handles quoted values with escaped characters", () => {
+    const content = `---
+category: "My \\"Category\\""
+source: "https://example.com"
+---`;
+    const fm = parseFrontmatter(content);
+    expect(fm.category).toBe('My \\"Category\\"');
+    expect(fm.source).toBe("https://example.com");
+  });
+
+  it("handles mixed quoted and unquoted values", () => {
+    const content = `---
+sparkle_id: "abc-123"
+priority: high
+due: 2026-03-15
+---`;
+    const fm = parseFrontmatter(content);
+    expect(fm.sparkle_id).toBe("abc-123");
+    expect(fm.priority).toBe("high");
+    expect(fm.due).toBe("2026-03-15");
+  });
+});
+
+// --- extractBody ---
+
+describe("extractBody", () => {
+  it("removes frontmatter and trims", () => {
+    const content = `---
+sparkle_id: "abc"
+---
+
+# Title
+
+Body content here.`;
+    expect(extractBody(content)).toBe("# Title\n\nBody content here.");
+  });
+
+  it("returns full content when no frontmatter", () => {
+    expect(extractBody("# Title\n\nBody")).toBe("# Title\n\nBody");
+  });
+});
+
+// --- resolveVaultPath ---
+
+describe("resolveVaultPath", () => {
+  it("resolves valid relative paths", () => {
+    const result = resolveVaultPath("/vault", "notes/test.md");
+    expect(result).toBe("/vault/notes/test.md");
+  });
+
+  it("blocks path traversal with ..", () => {
+    expect(() => resolveVaultPath("/vault", "../etc/passwd")).toThrow("outside the vault");
+    expect(() => resolveVaultPath("/vault", "notes/../../etc/passwd")).toThrow(
+      "outside the vault",
+    );
+  });
+
+  it("allows vault root itself", () => {
+    const result = resolveVaultPath("/vault", ".");
+    expect(result).toBe("/vault");
+  });
+});
+
+// --- getVaultPath ---
+
+describe("getVaultPath", () => {
+  it("fetches and caches vault path from settings", async () => {
+    mockGetSettings.mockResolvedValue({
+      obsidian_enabled: "true",
+      obsidian_vault_path: "/my/vault",
+    });
+
+    const path1 = await getVaultPath();
+    const path2 = await getVaultPath();
+
+    expect(path1).toBe("/my/vault");
+    expect(path2).toBe("/my/vault");
+    expect(mockGetSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when Obsidian is not enabled", async () => {
+    mockGetSettings.mockResolvedValue({
+      obsidian_enabled: "false",
+      obsidian_vault_path: "/my/vault",
+    });
+
+    await expect(getVaultPath()).rejects.toThrow("not enabled");
+  });
+
+  it("throws when vault path is empty", async () => {
+    mockGetSettings.mockResolvedValue({
+      obsidian_enabled: "true",
+      obsidian_vault_path: "",
+    });
+
+    await expect(getVaultPath()).rejects.toThrow("not configured");
+  });
+});
+
+// --- findBySparkleId ---
+
+describe("findBySparkleId", () => {
+  const VAULT = "/my/vault";
+
+  function setupVault() {
+    mockGetSettings.mockResolvedValue({
+      obsidian_enabled: "true",
+      obsidian_vault_path: VAULT,
+    });
+  }
+
+  function mockDirEntries(entries: { name: string; isDir: boolean }[]) {
+    mockReaddirSync.mockReturnValue(
+      entries.map((e) => ({
+        name: e.name,
+        isDirectory: () => e.isDir,
+        isFile: () => !e.isDir,
+      })) as never,
+    );
+  }
+
+  it("finds file by sparkle_id after index build", async () => {
+    setupVault();
+    mockDirEntries([{ name: "note.md", isDir: false }]);
+    mockReadFileSync.mockReturnValue(`---\nsparkle_id: "abc-123"\n---\n\n# Note`);
+    mockExistsSync.mockReturnValue(true);
+
+    const result = await findBySparkleId("abc-123");
+    expect(result).not.toBeNull();
+    expect(result!.path).toBe("/my/vault/note.md");
+    expect(result!.content).toContain("abc-123");
+  });
+
+  it("returns null when sparkle_id not found", async () => {
+    setupVault();
+    mockDirEntries([{ name: "note.md", isDir: false }]);
+    mockReadFileSync.mockReturnValue(`---\nsparkle_id: "other-id"\n---\n\n# Note`);
+
+    const result = await findBySparkleId("abc-123");
+    expect(result).toBeNull();
+  });
+
+  it("skips dotfiles and dotdirectories", async () => {
+    setupVault();
+    mockDirEntries([
+      { name: ".obsidian", isDir: true },
+      { name: ".DS_Store", isDir: false },
+      { name: "note.md", isDir: false },
+    ]);
+    mockReadFileSync.mockReturnValue(`---\nsparkle_id: "abc-123"\n---\n\n# Note`);
+    mockExistsSync.mockReturnValue(true);
+
+    const result = await findBySparkleId("abc-123");
+    expect(result).not.toBeNull();
+    expect(result!.path).toBe("/my/vault/note.md");
+    // .DS_Store is not a .md file, .obsidian starts with dot — only note.md is read
+    // Called twice: once during buildIndex scan, once to return content
+    expect(mockReadFileSync).toHaveBeenCalledTimes(2);
+  });
+});
+
+// --- readVaultFileByPath ---
+
+describe("readVaultFileByPath", () => {
+  it("reads and parses a vault file", async () => {
+    mockGetSettings.mockResolvedValue({
+      obsidian_enabled: "true",
+      obsidian_vault_path: "/vault",
+    });
+    mockReadFileSync.mockReturnValue(
+      `---\nsparkle_id: "abc"\ntags:\n  - test\n---\n\n# Title\n\nBody`,
+    );
+
+    const file = await readVaultFileByPath("notes/test.md");
+    expect(file.path).toBe("notes/test.md");
+    expect(file.frontmatter.sparkle_id).toBe("abc");
+    expect(file.frontmatter.tags).toEqual(["test"]);
+    expect(file.body).toBe("# Title\n\nBody");
+  });
+
+  it("throws when file not found", async () => {
+    mockGetSettings.mockResolvedValue({
+      obsidian_enabled: "true",
+      obsidian_vault_path: "/vault",
+    });
+    const enoent = new Error("ENOENT: no such file") as NodeJS.ErrnoException;
+    enoent.code = "ENOENT";
+    mockReadFileSync.mockImplementation(() => {
+      throw enoent;
+    });
+
+    await expect(readVaultFileByPath("nonexistent.md")).rejects.toThrow("File not found");
+  });
+});
+
+// --- writeVaultFileByPath ---
+
+describe("writeVaultFileByPath", () => {
+  it("writes content and creates parent dirs", async () => {
+    mockGetSettings.mockResolvedValue({
+      obsidian_enabled: "true",
+      obsidian_vault_path: "/vault",
+    });
+    mockExistsSync.mockReturnValue(false);
+
+    const result = await writeVaultFileByPath("new/folder/note.md", "# New Note");
+    expect(result).toBe("new/folder/note.md");
+    expect(mockMkdirSync).toHaveBeenCalledWith("/vault/new/folder", { recursive: true });
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      "/vault/new/folder/note.md",
+      "# New Note",
+      "utf-8",
+    );
+  });
+
+  it("updates sparkle_id index when writing a file with sparkle_id", async () => {
+    mockGetSettings.mockResolvedValue({
+      obsidian_enabled: "true",
+      obsidian_vault_path: "/vault",
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('---\nsparkle_id: "new-id"\n---\n\n# Note');
+
+    await writeVaultFileByPath(
+      "note.md",
+      '---\nsparkle_id: "new-id"\n---\n\n# Note',
+    );
+
+    // findBySparkleId should find it from the index without full rebuild
+    const found = await findBySparkleId("new-id");
+    expect(found).not.toBeNull();
+    expect(found!.path).toBe("/vault/note.md");
+  });
+});

--- a/mcp-server/src/client.ts
+++ b/mcp-server/src/client.ts
@@ -168,6 +168,12 @@ export async function reorderCategoriesApi(
   return sparkleApi<{ ok: boolean }>("/categories/reorder", "PATCH", { items });
 }
 
+// --- Settings ---
+
+export async function getSettings(): Promise<Record<string, string>> {
+  return sparkleApi<Record<string, string>>("/settings");
+}
+
 // --- Workflow operations ---
 
 export async function exportToObsidian(id: string): Promise<ExportResult> {

--- a/mcp-server/src/docs/content.ts
+++ b/mcp-server/src/docs/content.ts
@@ -370,6 +370,90 @@ sparkle_update_note(id: "...", type: "note")
 - **已匯出筆記修改標題或內容**：狀態自動回退為 permanent`,
   },
 
+  "obsidian-vault": {
+    title: "Obsidian Vault 存取",
+    description: "Sparkle MCP + obsidian-skills 的互補架構、安裝指引與常見工作流",
+    content: `# Obsidian Vault 存取
+
+## 架構
+
+Sparkle MCP 與 obsidian-skills 互補：
+
+| 層 | 負責 | 來源 |
+|---|---|---|
+| **obsidian-skills** | Obsidian 格式知識（Markdown 語法、.base、.canvas） | kepano（外部） |
+| **Sparkle MCP** | 知識管理流程 + vault 讀寫 API | Sparkle |
+
+Sparkle MCP vault tools 做「薄」— 只提供 raw 讀寫，不內建格式驗證。格式正確性由 AI + obsidian-skills 保證。
+
+## 安裝指引
+
+### 必要條件
+
+1. **Sparkle settings 啟用 Obsidian 整合** — 設定 vault path、啟用匯出
+2. **安裝 obsidian-skills（格式知識）**：
+   - 必裝：\`obsidian-markdown\`（Obsidian Flavored Markdown 語法）
+   - 選裝：\`obsidian-bases\`（.base 資料庫視圖）、\`json-canvas\`（.canvas 圖譜）、\`defuddle\`（網頁擷取）
+   - 不裝：\`obsidian-cli\`（read/create/search 已由 Sparkle MCP vault tools 取代）
+
+### 安裝方式
+
+Claude Code: \`/install-skill kepano/obsidian-skills\`
+Claude.ai: 透過 plugin marketplace 安裝
+
+## 工具一覽
+
+| 工具 | 用途 |
+|------|------|
+| \`sparkle_read_obsidian\` | 按 sparkle_id 讀取已匯出的筆記 |
+| \`sparkle_write_obsidian\` | 按 sparkle_id 更新已匯出的筆記 |
+| \`sparkle_read_obsidian_by_path\` | 按相對路徑讀取 vault 任意 .md 檔 |
+| \`sparkle_write_obsidian_by_path\` | 按相對路徑寫入 .md 檔（自動建目錄） |
+
+## sparkle_id 定位
+
+匯出時，Sparkle 在 YAML frontmatter 寫入 \`sparkle_id\`（UUID）。vault tools 透過掃描 frontmatter 定位檔案，不依賴路徑。使用者在 Obsidian 裡搬移、改名都不影響定位。
+
+## 常見工作流
+
+### 匯出後讀回
+
+\`\`\`
+sparkle_export_to_obsidian(id)  → 匯出到 vault
+sparkle_read_obsidian(id)       → 讀回 vault 中的版本
+\`\`\`
+
+### 更新已匯出的筆記
+
+\`\`\`
+sparkle_read_obsidian(id)       → 取得目前內容
+（AI 修改內容，遵循 obsidian-skills 格式）
+sparkle_write_obsidian(id, content) → 寫回
+\`\`\`
+
+### 存取非 Sparkle 的 vault 檔案
+
+\`\`\`
+sparkle_read_obsidian_by_path("Projects/my-note.md")
+sparkle_write_obsidian_by_path("Projects/new-note.md", content)
+\`\`\`
+
+### 比對 Sparkle 與 vault 差異
+
+匯出後使用者可能在 Obsidian 裡編輯，AI 可同時讀取兩邊比對：
+\`\`\`
+sparkle_get_note(id)            → Sparkle DB 版本
+sparkle_read_obsidian(id)       → Vault 版本
+（AI 做 diff 比對）
+\`\`\`
+
+## 工具選擇原則
+
+- 讀寫 vault → 使用 Sparkle MCP vault tools（維持 sparkle_id 追蹤）
+- 格式參考 → 參照 obsidian-skills（Markdown 語法、frontmatter 慣例）
+- Sparkle DB 操作 → 使用 Sparkle MCP 既有工具（create/update/search/advance/export）`,
+  },
+
   tips: {
     title: "最佳實踐",
     description: "標籤策略、別名用法、知識組織與定期維護建議",

--- a/mcp-server/src/docs/instructions.ts
+++ b/mcp-server/src/docs/instructions.ts
@@ -69,6 +69,8 @@ export const SPARKLE_INSTRUCTIONS = `
 | 查看既有標籤 | sparkle_list_tags（建立新筆記前先查看，保持標籤一致性）|
 | 管理分類 | sparkle_list_categories、sparkle_create_category、sparkle_update_category、sparkle_delete_category、sparkle_reorder_categories |
 | 為項目指定分類 | sparkle_create_note / sparkle_update_note 的 category_id 參數（先用 sparkle_list_categories 查詢 UUID）|
+| 讀取 vault 檔案 | sparkle_read_obsidian（按 sparkle_id）、sparkle_read_obsidian_by_path（按路徑）|
+| 修改 vault 檔案 | sparkle_write_obsidian（按 sparkle_id）、sparkle_write_obsidian_by_path（按路徑）|
 
 ## 行為準則
 
@@ -78,6 +80,14 @@ export const SPARKLE_INSTRUCTIONS = `
 - **分類一致性**：為項目指定分類前，先用 sparkle_list_categories 查看既有分類，避免重複建立。
 - **適時建議推進**：當你觀察到筆記已達到下一階段的標準，主動建議推進，但由使用者決定。
 - **連結思考**：發現筆記之間的關聯時，指出來。知識的價值在於連結。
+
+## Obsidian Vault 存取
+
+Sparkle MCP 可直接讀寫 Obsidian vault 中的 .md 檔案（需在 Sparkle settings 啟用 Obsidian 整合）。
+
+搭配 [obsidian-skills](https://github.com/kepano/obsidian-skills) 使用以確保 Obsidian Markdown 格式正確（wikilinks、callouts、frontmatter 等）。建議安裝 obsidian-markdown skill，不需安裝 obsidian-cli（其 read/create/search 功能已由 Sparkle MCP vault tools 取代）。
+
+**工具選擇**：讀寫 vault 內容請使用 Sparkle MCP vault tools（維持 sparkle_id 連結追蹤）。obsidian-skills 提供格式參考，但實際讀寫操作應透過 MCP 工具進行。
 
 如需更深入的主題說明，可讀取 sparkle://docs/* resources 或使用 sparkle_guide tool 查詢特定主題的詳細指引。
 `.trim();

--- a/mcp-server/src/fs.ts
+++ b/mcp-server/src/fs.ts
@@ -1,0 +1,12 @@
+/**
+ * Thin re-export of node:fs functions used by vault.ts.
+ * Exists solely to make these functions mockable in tests
+ * (ESM native modules can't be mocked directly by Vitest).
+ */
+export {
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+} from "node:fs";

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -6,6 +6,7 @@ import { registerCategoryTools } from "./tools/categories.js";
 import { registerWorkflowTools } from "./tools/workflow.js";
 import { registerMetaTools } from "./tools/meta.js";
 import { registerGuideTools } from "./tools/guide.js";
+import { registerVaultTools } from "./tools/vault.js";
 import { SPARKLE_INSTRUCTIONS } from "./docs/instructions.js";
 import { registerDocResources } from "./docs/resources.js";
 
@@ -22,6 +23,7 @@ export function createSparkleServer(): McpServer {
   registerWorkflowTools(server);
   registerMetaTools(server);
   registerGuideTools(server);
+  registerVaultTools(server);
   registerDocResources(server);
 
   return server;

--- a/mcp-server/src/tools/vault.ts
+++ b/mcp-server/src/tools/vault.ts
@@ -1,0 +1,194 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import {
+  readVaultFileBySparkleId,
+  readVaultFileByPath,
+  writeVaultFileBySparkleId,
+  writeVaultFileByPath,
+} from "../vault.js";
+import type { VaultFile } from "../types.js";
+
+function formatVaultFile(file: VaultFile): string {
+  const lines: string[] = [`**Path:** ${file.path}`];
+
+  // Frontmatter summary
+  const fm = file.frontmatter;
+  if (fm.sparkle_id) lines.push(`**Sparkle ID:** ${fm.sparkle_id}`);
+  if (fm.tags && Array.isArray(fm.tags) && fm.tags.length > 0) {
+    lines.push(`**Tags:** ${fm.tags.join(", ")}`);
+  }
+  if (fm.category) lines.push(`**Category:** ${fm.category}`);
+  if (fm.created) lines.push(`**Created:** ${fm.created}`);
+  if (fm.modified) lines.push(`**Modified:** ${fm.modified}`);
+
+  lines.push("", "---", "", file.body);
+  return lines.join("\n");
+}
+
+export function registerVaultTools(server: McpServer): void {
+  server.registerTool(
+    "sparkle_read_obsidian",
+    {
+      title: "Read Vault File by Sparkle ID",
+      description: `Read an exported note from the Obsidian vault using its sparkle_id (written in YAML frontmatter during export).
+
+Use this to read back notes that were exported via sparkle_export_to_obsidian. The file is located by scanning vault .md files for matching sparkle_id frontmatter, regardless of file path or name changes in Obsidian.
+
+Args:
+  - sparkle_id (string): The Sparkle note UUID
+
+Returns: File path, frontmatter summary, and full body content.
+Requires Obsidian integration to be enabled in Sparkle settings.`,
+      inputSchema: {
+        sparkle_id: z.string().uuid().describe("Sparkle note UUID"),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({ sparkle_id }) => {
+      try {
+        const file = await readVaultFileBySparkleId(sparkle_id);
+        return {
+          content: [{ type: "text", text: formatVaultFile(file) }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: `Error: ${(error as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "sparkle_write_obsidian",
+    {
+      title: "Write Vault File by Sparkle ID",
+      description: `Update an exported note in the Obsidian vault using its sparkle_id.
+
+Locates the file by sparkle_id frontmatter and replaces its entire content. Use sparkle_read_obsidian first to get the current content, then modify and write back.
+
+For correct Obsidian Markdown formatting (wikilinks, callouts, etc.), follow obsidian-skills conventions.
+
+Args:
+  - sparkle_id (string): The Sparkle note UUID
+  - content (string): Full file content to write (including frontmatter)
+
+Returns: Confirmation with file path.`,
+      inputSchema: {
+        sparkle_id: z.string().uuid().describe("Sparkle note UUID"),
+        content: z.string().min(1).describe("Full file content to write"),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({ sparkle_id, content }) => {
+      try {
+        const path = await writeVaultFileBySparkleId(sparkle_id, content);
+        return {
+          content: [{ type: "text", text: `File updated successfully.\n\n**Path:** ${path}` }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: `Error: ${(error as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "sparkle_read_obsidian_by_path",
+    {
+      title: "Read Vault File by Path",
+      description: `Read any .md file from the Obsidian vault by its relative path.
+
+Use this to access vault files that were not exported from Sparkle (no sparkle_id), or when you know the exact path.
+
+Args:
+  - path (string): Relative path from vault root (e.g. "Projects/my-note.md")
+
+Returns: File path, frontmatter summary (if any), and full body content.`,
+      inputSchema: {
+        path: z
+          .string()
+          .min(1)
+          .describe("Relative path from vault root (e.g. 'folder/note.md')"),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({ path }) => {
+      try {
+        const file = await readVaultFileByPath(path);
+        return {
+          content: [{ type: "text", text: formatVaultFile(file) }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: `Error: ${(error as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "sparkle_write_obsidian_by_path",
+    {
+      title: "Write Vault File by Path",
+      description: `Write or create a .md file in the Obsidian vault by relative path.
+
+Creates parent directories if they don't exist. If the file already exists, it will be overwritten.
+
+For correct Obsidian Markdown formatting (wikilinks, callouts, frontmatter), follow obsidian-skills conventions.
+
+Args:
+  - path (string): Relative path from vault root, must end with .md
+  - content (string): Full file content to write
+
+Returns: Confirmation with file path.`,
+      inputSchema: {
+        path: z
+          .string()
+          .min(1)
+          .regex(/\.md$/, "Path must end with .md")
+          .describe("Relative path from vault root, must end with .md"),
+        content: z.string().min(1).describe("Full file content to write"),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({ path, content }) => {
+      try {
+        const resultPath = await writeVaultFileByPath(path, content);
+        return {
+          content: [
+            { type: "text", text: `File written successfully.\n\n**Path:** ${resultPath}` },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: `Error: ${(error as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -61,6 +61,33 @@ export interface ExportResult {
   path: string;
 }
 
+/** Parsed frontmatter from an Obsidian vault .md file */
+export interface VaultFrontmatter {
+  sparkle_id?: string;
+  category?: string;
+  tags?: string[];
+  aliases?: string[];
+  source?: string;
+  created?: string;
+  modified?: string;
+  origin?: string;
+  priority?: string;
+  due?: string;
+  [key: string]: unknown;
+}
+
+/** A file read from the Obsidian vault */
+export interface VaultFile {
+  /** Relative path from vault root */
+  path: string;
+  /** Full file content including frontmatter */
+  content: string;
+  /** Parsed frontmatter key-value pairs */
+  frontmatter: VaultFrontmatter;
+  /** Content without frontmatter block */
+  body: string;
+}
+
 /** Parse JSON array fields into actual arrays */
 export function parseTags(item: SparkleItem): string[] {
   try { return JSON.parse(item.tags) as string[]; } catch { return []; }

--- a/mcp-server/src/vault.ts
+++ b/mcp-server/src/vault.ts
@@ -1,0 +1,242 @@
+import { readFileSync, readdirSync, writeFileSync, existsSync, mkdirSync } from "./fs.js";
+import { resolve, join, relative, dirname } from "node:path";
+import { getSettings } from "./client.js";
+import type { VaultFrontmatter, VaultFile } from "./types.js";
+
+// --- Settings cache ---
+
+let cachedVaultPath: string | null = null;
+let cacheTimestamp = 0;
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+export async function getVaultPath(): Promise<string> {
+  const now = Date.now();
+  if (cachedVaultPath && now - cacheTimestamp < CACHE_TTL_MS) {
+    return cachedVaultPath;
+  }
+  const settings = await getSettings();
+  if (settings.obsidian_enabled !== "true") {
+    throw new Error(
+      "Obsidian integration is not enabled. Configure it in Sparkle settings.",
+    );
+  }
+  if (!settings.obsidian_vault_path) {
+    throw new Error(
+      "Obsidian vault path is not configured. Set it in Sparkle settings.",
+    );
+  }
+  cachedVaultPath = settings.obsidian_vault_path;
+  cacheTimestamp = now;
+  return cachedVaultPath;
+}
+
+/** Reset the settings cache (for testing) */
+export function _resetCache(): void {
+  cachedVaultPath = null;
+  cacheTimestamp = 0;
+}
+
+// --- Path security ---
+
+export function resolveVaultPath(vaultRoot: string, relativePath: string): string {
+  const resolvedRoot = resolve(vaultRoot);
+  const resolved = resolve(vaultRoot, relativePath);
+  if (resolved !== resolvedRoot && !resolved.startsWith(resolvedRoot + "/")) {
+    throw new Error(`Path "${relativePath}" resolves outside the vault. Access denied.`);
+  }
+  return resolved;
+}
+
+// --- Frontmatter parsing (internal — for sparkle_id lookup and list summaries) ---
+// Handles the YAML subset produced by Sparkle's generateFrontmatter():
+// scalar values (quoted/unquoted), YAML arrays (  - item).
+
+const FRONTMATTER_REGEX = /^---\n([\s\S]*?)\n---/;
+
+export function parseFrontmatter(content: string): VaultFrontmatter {
+  const match = content.match(FRONTMATTER_REGEX);
+  if (!match) return {};
+
+  const fm: VaultFrontmatter = {};
+  const lines = match[1].split("\n");
+  let pendingList: { key: string; items: string[] } | null = null;
+
+  for (const line of lines) {
+    // Array item: "  - value" or '  - "value"'
+    const arrayItemMatch = line.match(/^\s+-\s+(.+)/);
+    if (arrayItemMatch && pendingList) {
+      const val = arrayItemMatch[1].replace(/^["']|["']$/g, "");
+      pendingList.items.push(val);
+      continue;
+    }
+
+    // Flush previous array
+    if (pendingList) {
+      fm[pendingList.key] = pendingList.items;
+      pendingList = null;
+    }
+
+    // Key-value pair: "key: value" or "key:"
+    const kvMatch = line.match(/^(\w[\w_]*)\s*:\s*(.*)/);
+    if (kvMatch) {
+      const key = kvMatch[1];
+      const rawVal = kvMatch[2].trim();
+      if (rawVal === "" || rawVal === "|") {
+        // Empty value — start of array or multiline
+        pendingList = { key, items: [] };
+      } else {
+        // Strip surrounding quotes
+        fm[key] = rawVal.replace(/^["']|["']$/g, "");
+      }
+    }
+  }
+
+  // Flush last array
+  if (pendingList) {
+    fm[pendingList.key] = pendingList.items;
+  }
+
+  return fm;
+}
+
+export function extractBody(content: string): string {
+  return content.replace(FRONTMATTER_REGEX, "").trim();
+}
+
+// --- sparkle_id index ---
+
+const sparkleIdIndex = new Map<string, string>(); // sparkle_id -> absolute path
+let indexBuilt = false;
+
+function walkSync(dir: string, callback: (filePath: string) => void): void {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith(".")) continue;
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkSync(fullPath, callback);
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      callback(fullPath);
+    }
+  }
+}
+
+function buildIndex(vaultRoot: string): void {
+  sparkleIdIndex.clear();
+  walkSync(vaultRoot, (filePath) => {
+    try {
+      const content = readFileSync(filePath, "utf-8");
+      const fm = parseFrontmatter(content);
+      if (fm.sparkle_id && typeof fm.sparkle_id === "string") {
+        sparkleIdIndex.set(fm.sparkle_id, filePath);
+      }
+    } catch {
+      /* skip unreadable files */
+    }
+  });
+  indexBuilt = true;
+}
+
+/** Find a vault file by sparkle_id. Returns path and cached content if available. */
+export async function findBySparkleId(
+  sparkleId: string,
+): Promise<{ path: string; content: string } | null> {
+  const vaultRoot = await getVaultPath();
+
+  // Check cache first
+  if (indexBuilt) {
+    const cached = sparkleIdIndex.get(sparkleId);
+    if (cached && existsSync(cached)) {
+      // Verify the file still has this sparkle_id
+      const content = readFileSync(cached, "utf-8");
+      const fm = parseFrontmatter(content);
+      if (fm.sparkle_id === sparkleId) return { path: cached, content };
+    }
+  }
+
+  // Cache miss or stale: rebuild
+  buildIndex(vaultRoot);
+  const found = sparkleIdIndex.get(sparkleId);
+  if (!found) return null;
+  const content = readFileSync(found, "utf-8");
+  return { path: found, content };
+}
+
+/** Reset the sparkle_id index (for testing) */
+export function _resetIndex(): void {
+  sparkleIdIndex.clear();
+  indexBuilt = false;
+}
+
+// --- Read/write operations ---
+
+export async function readVaultFileBySparkleId(sparkleId: string): Promise<VaultFile> {
+  const result = await findBySparkleId(sparkleId);
+  if (!result) {
+    throw new Error(`No vault file found with sparkle_id: ${sparkleId}`);
+  }
+  const vaultRoot = await getVaultPath();
+  return {
+    path: relative(vaultRoot, result.path),
+    content: result.content,
+    frontmatter: parseFrontmatter(result.content),
+    body: extractBody(result.content),
+  };
+}
+
+export async function readVaultFileByPath(relativePath: string): Promise<VaultFile> {
+  const vaultRoot = await getVaultPath();
+  const absPath = resolveVaultPath(vaultRoot, relativePath);
+  try {
+    const content = readFileSync(absPath, "utf-8");
+    return {
+      path: relativePath,
+      content,
+      frontmatter: parseFrontmatter(content),
+      body: extractBody(content),
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`File not found: ${relativePath}`);
+    }
+    throw error;
+  }
+}
+
+export async function writeVaultFileBySparkleId(
+  sparkleId: string,
+  content: string,
+): Promise<string> {
+  const result = await findBySparkleId(sparkleId);
+  if (!result) {
+    throw new Error(`No vault file found with sparkle_id: ${sparkleId}`);
+  }
+  writeFileSync(result.path, content, "utf-8");
+  // Update index if sparkle_id changed
+  const fm = parseFrontmatter(content);
+  if (fm.sparkle_id && fm.sparkle_id !== sparkleId) {
+    sparkleIdIndex.delete(sparkleId);
+    sparkleIdIndex.set(fm.sparkle_id, result.path);
+  }
+  const vaultRoot = await getVaultPath();
+  return relative(vaultRoot, result.path);
+}
+
+export async function writeVaultFileByPath(
+  relativePath: string,
+  content: string,
+): Promise<string> {
+  const vaultRoot = await getVaultPath();
+  const absPath = resolveVaultPath(vaultRoot, relativePath);
+  // Create parent directories if needed
+  const dir = dirname(absPath);
+  if (dir && !existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(absPath, content, "utf-8");
+  // Update sparkle_id index
+  const fm = parseFrontmatter(content);
+  if (fm.sparkle_id && typeof fm.sparkle_id === "string") {
+    sparkleIdIndex.set(fm.sparkle_id, absPath);
+  }
+  return relativePath;
+}


### PR DESCRIPTION
## Summary

- Add 4 MCP tools for direct filesystem access to the Obsidian vault (Phase 1 of FG-004)
  - `sparkle_read_obsidian` / `sparkle_write_obsidian` — locate by `sparkle_id` frontmatter
  - `sparkle_read_obsidian_by_path` / `sparkle_write_obsidian_by_path` — by relative path
- Vault path from Sparkle settings API with 5-min TTL cache; sparkle_id lazy index; path traversal guard
- Instructions updated with obsidian-skills integration guidance; new `obsidian-vault` guide topic
- 28 new tests (20 vault core + 8 tool handler)

## Architecture decisions

- **MCP vault tools 做薄** — raw read/write only, no format validation (delegated to obsidian-skills)
- **Direct filesystem access** — new pattern for MCP server (existing tools all go through HTTP API)
- **`fs.ts` wrapper** — thin re-export of `node:fs` for ESM testability (Vitest can't mock native modules)
- **`findBySparkleId` returns content** — eliminates double file read (review finding)
- **No `existsSync` pre-check** — catch `ENOENT` directly (TOCTOU fix from review)

## Test plan

- [x] `cd mcp-server && npx vitest run` — 89 tests pass (28 new)
- [x] `npm run build` — TypeScript compiles clean
- [ ] Manual: configure vault path in settings → export a note → read back via `sparkle_read_obsidian` → move file in Obsidian → read again (sparkle_id still locates it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)