### PR TITLE
feat(mcp): add Obsidian vault search and list tools

### DIFF
--- a/mcp-server/src/__tests__/tools.test.ts
+++ b/mcp-server/src/__tests__/tools.test.ts
@@ -19,6 +19,8 @@ vi.mock("../vault.js", () => ({
   readVaultFileByPath: vi.fn(),
   writeVaultFileBySparkleId: vi.fn(),
   writeVaultFileByPath: vi.fn(),
+  searchVault: vi.fn(),
+  listVault: vi.fn(),
 }));
 
 import * as client from "../client.js";
@@ -42,6 +44,8 @@ const readVaultFileBySparkleId = vi.mocked(vault.readVaultFileBySparkleId);
 const readVaultFileByPath = vi.mocked(vault.readVaultFileByPath);
 const writeVaultFileBySparkleId = vi.mocked(vault.writeVaultFileBySparkleId);
 const writeVaultFileByPath = vi.mocked(vault.writeVaultFileByPath);
+const mockSearchVault = vi.mocked(vault.searchVault);
+const mockListVault = vi.mocked(vault.listVault);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -444,5 +448,88 @@ describe("sparkle_write_obsidian_by_path", () => {
     const result = await handler({ path: "../../../etc/passwd.md", content: "bad" });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("outside the vault");
+  });
+});
+
+describe("sparkle_search_obsidian", () => {
+  function getHandler() {
+    const server = makeMockServer();
+    registerVaultTools(server as never);
+    return server.getHandler("sparkle_search_obsidian");
+  }
+
+  it("returns formatted search results", async () => {
+    const handler = getHandler();
+    mockSearchVault.mockResolvedValue([
+      {
+        path: "notes/research.md",
+        frontmatter: { sparkle_id: "abc-123", tags: ["ai", "ml"] },
+        matches: [
+          {
+            line: 5,
+            text: "This is about machine learning",
+            context_before: ["## Introduction"],
+            context_after: ["and deep learning"],
+          },
+        ],
+      },
+    ]);
+
+    const result = await handler({ query: "machine", limit: 20 });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain('1 file(s) matching "machine"');
+    expect(result.content[0].text).toContain("notes/research.md");
+    expect(result.content[0].text).toContain("sparkle_id: abc-123");
+    expect(result.content[0].text).toContain("machine learning");
+  });
+
+  it("returns friendly message when no results", async () => {
+    const handler = getHandler();
+    mockSearchVault.mockResolvedValue([]);
+
+    const result = await handler({ query: "nonexistent", limit: 20 });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain('No results found for "nonexistent"');
+  });
+});
+
+describe("sparkle_list_obsidian", () => {
+  function getHandler() {
+    const server = makeMockServer();
+    registerVaultTools(server as never);
+    return server.getHandler("sparkle_list_obsidian");
+  }
+
+  it("returns formatted file list", async () => {
+    const handler = getHandler();
+    mockListVault.mockResolvedValue({
+      files: [
+        { path: "notes/idea.md", frontmatter: { sparkle_id: "abc-123", tags: ["ai"] } },
+        { path: "projects/plan.md", frontmatter: {} },
+      ],
+      directories: [],
+    });
+
+    const result = await handler({ recursive: true, limit: 50 });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("Files:** (2)");
+    expect(result.content[0].text).toContain("notes/idea.md");
+    expect(result.content[0].text).toContain("sparkle_id: abc-123");
+    expect(result.content[0].text).toContain("projects/plan.md");
+    expect(result.content[0].text).toContain("(no frontmatter)");
+  });
+
+  it("includes directories in non-recursive mode", async () => {
+    const handler = getHandler();
+    mockListVault.mockResolvedValue({
+      files: [{ path: "note.md", frontmatter: {} }],
+      directories: ["Projects", "Archive"],
+    });
+
+    const result = await handler({ recursive: false, limit: 50 });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("Directories:** (2)");
+    expect(result.content[0].text).toContain("Projects/");
+    expect(result.content[0].text).toContain("Archive/");
   });
 });

--- a/mcp-server/src/__tests__/vault.test.ts
+++ b/mcp-server/src/__tests__/vault.test.ts
@@ -24,6 +24,8 @@ import {
   findBySparkleId,
   readVaultFileByPath,
   writeVaultFileByPath,
+  searchVault,
+  listVault,
   _resetCache,
   _resetIndex,
 } from "../vault.js";
@@ -311,5 +313,184 @@ describe("writeVaultFileByPath", () => {
     const found = await findBySparkleId("new-id");
     expect(found).not.toBeNull();
     expect(found!.path).toBe("/vault/note.md");
+  });
+});
+
+// --- searchVault ---
+
+describe("searchVault", () => {
+  const VAULT = "/my/vault";
+
+  function setupVault() {
+    mockGetSettings.mockResolvedValue({
+      obsidian_enabled: "true",
+      obsidian_vault_path: VAULT,
+    });
+  }
+
+  function mockDirEntries(entries: { name: string; isDir: boolean }[]) {
+    mockReaddirSync.mockReturnValue(
+      entries.map((e) => ({
+        name: e.name,
+        isDirectory: () => e.isDir,
+        isFile: () => !e.isDir,
+      })) as never,
+    );
+  }
+
+  it("finds matches with context lines", async () => {
+    setupVault();
+    mockDirEntries([{ name: "note.md", isDir: false }]);
+    mockReadFileSync.mockReturnValue(
+      "---\nsparkle_id: \"abc\"\n---\n\nline one\nline two\nfind me here\nline four\nline five",
+    );
+
+    const results = await searchVault("find me");
+    expect(results).toHaveLength(1);
+    expect(results[0].path).toBe("note.md");
+    expect(results[0].matches).toHaveLength(1);
+    expect(results[0].matches[0].line).toBe(7);
+    expect(results[0].matches[0].text).toBe("find me here");
+    expect(results[0].matches[0].context_before).toEqual(["line one", "line two"]);
+    expect(results[0].matches[0].context_after).toEqual(["line four", "line five"]);
+    expect(results[0].frontmatter.sparkle_id).toBe("abc");
+  });
+
+  it("performs case-insensitive search", async () => {
+    setupVault();
+    mockDirEntries([{ name: "note.md", isDir: false }]);
+    mockReadFileSync.mockReturnValue("# Title\n\nHello WORLD");
+
+    const results = await searchVault("hello world");
+    expect(results).toHaveLength(1);
+    expect(results[0].matches[0].text).toBe("Hello WORLD");
+  });
+
+  it("respects path option for subdirectory search", async () => {
+    setupVault();
+    mockDirEntries([{ name: "sub.md", isDir: false }]);
+    mockReadFileSync.mockReturnValue("match here");
+
+    const results = await searchVault("match", { path: "Projects" });
+    expect(results).toHaveLength(1);
+    // readdirSync should have been called with the resolved subdirectory
+    expect(mockReaddirSync).toHaveBeenCalledWith(
+      "/my/vault/Projects",
+      expect.objectContaining({ withFileTypes: true }),
+    );
+  });
+
+  it("respects limit option", async () => {
+    setupVault();
+    // Return 3 files but set limit to 2
+    mockReaddirSync.mockReturnValue([
+      { name: "a.md", isDirectory: () => false, isFile: () => true },
+      { name: "b.md", isDirectory: () => false, isFile: () => true },
+      { name: "c.md", isDirectory: () => false, isFile: () => true },
+    ] as never);
+    mockReadFileSync.mockReturnValue("matching content");
+
+    const results = await searchVault("matching", { limit: 2 });
+    expect(results).toHaveLength(2);
+  });
+
+  it("returns empty array when no matches", async () => {
+    setupVault();
+    mockDirEntries([{ name: "note.md", isDir: false }]);
+    mockReadFileSync.mockReturnValue("nothing interesting here");
+
+    const results = await searchVault("nonexistent");
+    expect(results).toHaveLength(0);
+  });
+});
+
+// --- listVault ---
+
+describe("listVault", () => {
+  const VAULT = "/my/vault";
+
+  function setupVault() {
+    mockGetSettings.mockResolvedValue({
+      obsidian_enabled: "true",
+      obsidian_vault_path: VAULT,
+    });
+  }
+
+  it("lists all files recursively by default", async () => {
+    setupVault();
+    // walkSync calls readdirSync recursively — mock root then subdir
+    mockReaddirSync
+      .mockReturnValueOnce([
+        { name: "note.md", isDirectory: () => false, isFile: () => true },
+        { name: "sub", isDirectory: () => true, isFile: () => false },
+      ] as never)
+      .mockReturnValueOnce([
+        { name: "deep.md", isDirectory: () => false, isFile: () => true },
+      ] as never);
+    mockReadFileSync.mockReturnValue('---\nsparkle_id: "abc"\n---\n\n# Note');
+
+    const result = await listVault();
+    expect(result.files).toHaveLength(2);
+    expect(result.directories).toHaveLength(0);
+    // Files should be sorted by path
+    expect(result.files[0].path).toBe("note.md");
+    expect(result.files[1].path).toBe("sub/deep.md");
+    expect(result.files[0].frontmatter.sparkle_id).toBe("abc");
+  });
+
+  it("lists files non-recursively with directories", async () => {
+    setupVault();
+    mockReaddirSync.mockReturnValue([
+      { name: "note.md", isDirectory: () => false, isFile: () => true },
+      { name: "Projects", isDirectory: () => true, isFile: () => false },
+      { name: "Archive", isDirectory: () => true, isFile: () => false },
+    ] as never);
+    mockReadFileSync.mockReturnValue("# Simple note");
+
+    const result = await listVault({ recursive: false });
+    expect(result.files).toHaveLength(1);
+    expect(result.files[0].path).toBe("note.md");
+    expect(result.directories).toEqual(["Archive", "Projects"]);
+  });
+
+  it("skips dotfiles and dotdirectories", async () => {
+    setupVault();
+    mockReaddirSync.mockReturnValue([
+      { name: ".obsidian", isDirectory: () => true, isFile: () => false },
+      { name: ".DS_Store", isDirectory: () => false, isFile: () => true },
+      { name: "note.md", isDirectory: () => false, isFile: () => true },
+    ] as never);
+    mockReadFileSync.mockReturnValue("# Note");
+
+    const result = await listVault({ recursive: false });
+    expect(result.files).toHaveLength(1);
+    expect(result.directories).toHaveLength(0);
+  });
+
+  it("respects limit option", async () => {
+    setupVault();
+    mockReaddirSync.mockReturnValue([
+      { name: "a.md", isDirectory: () => false, isFile: () => true },
+      { name: "b.md", isDirectory: () => false, isFile: () => true },
+      { name: "c.md", isDirectory: () => false, isFile: () => true },
+    ] as never);
+    mockReadFileSync.mockReturnValue("content");
+
+    const result = await listVault({ limit: 2 });
+    expect(result.files).toHaveLength(2);
+  });
+
+  it("respects path option", async () => {
+    setupVault();
+    mockReaddirSync.mockReturnValue([
+      { name: "note.md", isDirectory: () => false, isFile: () => true },
+    ] as never);
+    mockReadFileSync.mockReturnValue("content");
+
+    await listVault({ path: "Projects", recursive: false });
+    expect(mockReaddirSync).toHaveBeenCalledWith(
+      "/my/vault/Projects",
+      expect.objectContaining({ withFileTypes: true }),
+    );
   });
 });

--- a/mcp-server/src/docs/content.ts
+++ b/mcp-server/src/docs/content.ts
@@ -409,6 +409,8 @@ Claude.ai: 透過 plugin marketplace 安裝
 | \`sparkle_write_obsidian\` | 按 sparkle_id 更新已匯出的筆記 |
 | \`sparkle_read_obsidian_by_path\` | 按相對路徑讀取 vault 任意 .md 檔 |
 | \`sparkle_write_obsidian_by_path\` | 按相對路徑寫入 .md 檔（自動建目錄） |
+| \`sparkle_search_obsidian\` | 全文搜尋 vault 中的 .md 檔案 |
+| \`sparkle_list_obsidian\` | 列出 vault 檔案與目錄結構 |
 
 ## sparkle_id 定位
 
@@ -436,6 +438,20 @@ sparkle_write_obsidian(id, content) → 寫回
 \`\`\`
 sparkle_read_obsidian_by_path("Projects/my-note.md")
 sparkle_write_obsidian_by_path("Projects/new-note.md", content)
+\`\`\`
+
+### 搜尋 vault 內容
+
+\`\`\`
+sparkle_search_obsidian("關鍵字")                    → 全文搜尋 vault
+sparkle_search_obsidian("topic", path: "Projects/")  → 限制在子目錄搜尋
+\`\`\`
+
+### 瀏覽 vault 結構
+
+\`\`\`
+sparkle_list_obsidian()                              → 列出整個 vault
+sparkle_list_obsidian(path: "Projects/", recursive: false) → 只看一層目錄
 \`\`\`
 
 ### 比對 Sparkle 與 vault 差異

--- a/mcp-server/src/docs/instructions.ts
+++ b/mcp-server/src/docs/instructions.ts
@@ -71,6 +71,8 @@ export const SPARKLE_INSTRUCTIONS = `
 | 為項目指定分類 | sparkle_create_note / sparkle_update_note 的 category_id 參數（先用 sparkle_list_categories 查詢 UUID）|
 | 讀取 vault 檔案 | sparkle_read_obsidian（按 sparkle_id）、sparkle_read_obsidian_by_path（按路徑）|
 | 修改 vault 檔案 | sparkle_write_obsidian（按 sparkle_id）、sparkle_write_obsidian_by_path（按路徑）|
+| 搜尋 vault 內容 | sparkle_search_obsidian（全文搜尋 vault .md 檔案）|
+| 列出 vault 檔案 | sparkle_list_obsidian（列出 vault 檔案與目錄結構）|
 
 ## 行為準則
 

--- a/mcp-server/src/tools/vault.ts
+++ b/mcp-server/src/tools/vault.ts
@@ -5,8 +5,15 @@ import {
   readVaultFileByPath,
   writeVaultFileBySparkleId,
   writeVaultFileByPath,
+  searchVault,
+  listVault,
 } from "../vault.js";
-import type { VaultFile } from "../types.js";
+import type {
+  VaultFile,
+  VaultFrontmatter,
+  VaultSearchResult,
+  VaultListResult,
+} from "../types.js";
 
 function formatVaultFile(file: VaultFile): string {
   const lines: string[] = [`**Path:** ${file.path}`];
@@ -191,4 +198,174 @@ Returns: Confirmation with file path.`,
       }
     },
   );
+
+  server.registerTool(
+    "sparkle_search_obsidian",
+    {
+      title: "Search Vault",
+      description: `Full-text search across .md files in the Obsidian vault.
+
+Returns matching lines with surrounding context (2 lines before/after) and frontmatter summary for each file.
+
+Args:
+  - query (string): Search term (case-insensitive substring match)
+  - path (string, optional): Restrict search to a subdirectory (e.g. "Projects/")
+  - limit (number, optional): Max number of files to return (default 20, max 100)
+
+Returns: Matching files with line numbers, context, and frontmatter metadata.
+Requires Obsidian integration to be enabled in Sparkle settings.`,
+      inputSchema: {
+        query: z.string().min(1).describe("Search term (case-insensitive)"),
+        path: z
+          .string()
+          .optional()
+          .describe("Restrict search to subdirectory (e.g. 'Projects/')"),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .default(20)
+          .describe("Max files to return (default 20)"),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({ query, path, limit }) => {
+      try {
+        const results = await searchVault(query, { path, limit });
+        return {
+          content: [{ type: "text", text: formatSearchResults(results, query) }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: `Error: ${(error as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
+    "sparkle_list_obsidian",
+    {
+      title: "List Vault Files",
+      description: `List .md files in the Obsidian vault with frontmatter summaries.
+
+When recursive is false, also shows subdirectory names for navigation.
+
+Args:
+  - path (string, optional): Subdirectory to list (default: vault root)
+  - recursive (boolean, optional): List all nested files (default true)
+  - limit (number, optional): Max files to return (default 50, max 200)
+
+Returns: File list with sparkle_id, tags, and modified date from frontmatter.
+Requires Obsidian integration to be enabled in Sparkle settings.`,
+      inputSchema: {
+        path: z
+          .string()
+          .optional()
+          .describe("Subdirectory to list (default: vault root)"),
+        recursive: z
+          .boolean()
+          .default(true)
+          .describe("List all nested files (default true)"),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(200)
+          .default(50)
+          .describe("Max files to return (default 50)"),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async ({ path, recursive, limit }) => {
+      try {
+        const result = await listVault({ path, recursive, limit });
+        return {
+          content: [{ type: "text", text: formatListResult(result) }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: `Error: ${(error as Error).message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function formatFrontmatterSummary(fm: VaultFrontmatter): string {
+  const parts: string[] = [];
+  if (fm.sparkle_id) parts.push(`sparkle_id: ${fm.sparkle_id}`);
+  if (fm.tags && Array.isArray(fm.tags) && fm.tags.length > 0) {
+    parts.push(`tags: ${fm.tags.join(", ")}`);
+  }
+  if (fm.category) parts.push(`category: ${fm.category}`);
+  if (fm.modified) parts.push(`modified: ${fm.modified}`);
+  return parts.length > 0 ? parts.join(" | ") : "(no frontmatter)";
+}
+
+function formatSearchResults(results: VaultSearchResult[], query: string): string {
+  if (results.length === 0) {
+    return `No results found for "${query}".`;
+  }
+
+  const lines: string[] = [`Found ${results.length} file(s) matching "${query}":`];
+
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    lines.push("", "---", "");
+    lines.push(`**${i + 1}. ${r.path}**`);
+    lines.push(formatFrontmatterSummary(r.frontmatter));
+
+    for (const m of r.matches) {
+      lines.push("");
+      for (let j = 0; j < m.context_before.length; j++) {
+        lines.push(`  ${m.line - m.context_before.length + j}: ${m.context_before[j]}`);
+      }
+      lines.push(`> ${m.line}: ${m.text}`);
+      for (let j = 0; j < m.context_after.length; j++) {
+        lines.push(`  ${m.line + 1 + j}: ${m.context_after[j]}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function formatListResult(result: VaultListResult): string {
+  const lines: string[] = [];
+
+  if (result.directories.length > 0) {
+    lines.push(`**Directories:** (${result.directories.length})`);
+    for (const dir of result.directories) {
+      lines.push(`- ${dir}/`);
+    }
+    lines.push("");
+  }
+
+  lines.push(`**Files:** (${result.files.length})`);
+
+  if (result.files.length === 0) {
+    lines.push("(none)");
+  } else {
+    for (let i = 0; i < result.files.length; i++) {
+      const f = result.files[i];
+      lines.push(`${i + 1}. ${f.path}`);
+      lines.push(`   ${formatFrontmatterSummary(f.frontmatter)}`);
+    }
+  }
+
+  return lines.join("\n");
 }

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -88,6 +88,33 @@ export interface VaultFile {
   body: string;
 }
 
+/** A single search match within a vault file */
+export interface VaultSearchMatch {
+  line: number;
+  text: string;
+  context_before: string[];
+  context_after: string[];
+}
+
+/** Search result for a vault file containing matches */
+export interface VaultSearchResult {
+  path: string;
+  frontmatter: VaultFrontmatter;
+  matches: VaultSearchMatch[];
+}
+
+/** A file entry in vault listing */
+export interface VaultListEntry {
+  path: string;
+  frontmatter: VaultFrontmatter;
+}
+
+/** Result of listing vault contents */
+export interface VaultListResult {
+  files: VaultListEntry[];
+  directories: string[];
+}
+
 /** Parse JSON array fields into actual arrays */
 export function parseTags(item: SparkleItem): string[] {
   try { return JSON.parse(item.tags) as string[]; } catch { return []; }

--- a/mcp-server/src/vault.ts
+++ b/mcp-server/src/vault.ts
@@ -1,7 +1,14 @@
 import { readFileSync, readdirSync, writeFileSync, existsSync, mkdirSync } from "./fs.js";
 import { resolve, join, relative, dirname } from "node:path";
 import { getSettings } from "./client.js";
-import type { VaultFrontmatter, VaultFile } from "./types.js";
+import type {
+  VaultFrontmatter,
+  VaultFile,
+  VaultSearchMatch,
+  VaultSearchResult,
+  VaultListEntry,
+  VaultListResult,
+} from "./types.js";
 
 // --- Settings cache ---
 
@@ -239,4 +246,105 @@ export async function writeVaultFileByPath(
     sparkleIdIndex.set(fm.sparkle_id, absPath);
   }
   return relativePath;
+}
+
+// --- Search and list operations ---
+
+export async function searchVault(
+  query: string,
+  options?: { path?: string; limit?: number },
+): Promise<VaultSearchResult[]> {
+  const vaultRoot = await getVaultPath();
+  const searchRoot = options?.path
+    ? resolveVaultPath(vaultRoot, options.path)
+    : vaultRoot;
+  const limit = options?.limit ?? 20;
+  const queryLower = query.toLowerCase();
+
+  const results: VaultSearchResult[] = [];
+
+  walkSync(searchRoot, (filePath) => {
+    if (results.length >= limit) return;
+
+    try {
+      const content = readFileSync(filePath, "utf-8");
+      const lines = content.split("\n");
+      const matches: VaultSearchMatch[] = [];
+
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i].toLowerCase().includes(queryLower)) {
+          matches.push({
+            line: i + 1,
+            text: lines[i],
+            context_before: lines.slice(Math.max(0, i - 2), i),
+            context_after: lines.slice(i + 1, i + 3),
+          });
+        }
+      }
+
+      if (matches.length > 0) {
+        results.push({
+          path: relative(vaultRoot, filePath),
+          frontmatter: parseFrontmatter(content),
+          matches,
+        });
+      }
+    } catch {
+      /* skip unreadable files */
+    }
+  });
+
+  return results;
+}
+
+export async function listVault(
+  options?: { path?: string; recursive?: boolean; limit?: number },
+): Promise<VaultListResult> {
+  const vaultRoot = await getVaultPath();
+  const listRoot = options?.path
+    ? resolveVaultPath(vaultRoot, options.path)
+    : vaultRoot;
+  const recursive = options?.recursive ?? true;
+  const limit = options?.limit ?? 50;
+
+  const files: VaultListEntry[] = [];
+  const directories: string[] = [];
+
+  if (recursive) {
+    walkSync(listRoot, (filePath) => {
+      if (files.length >= limit) return;
+      try {
+        const content = readFileSync(filePath, "utf-8");
+        files.push({
+          path: relative(vaultRoot, filePath),
+          frontmatter: parseFrontmatter(content),
+        });
+      } catch {
+        /* skip unreadable files */
+      }
+    });
+  } else {
+    for (const entry of readdirSync(listRoot, { withFileTypes: true })) {
+      if (entry.name.startsWith(".")) continue;
+      const fullPath = join(listRoot, entry.name);
+      if (entry.isDirectory()) {
+        directories.push(relative(vaultRoot, fullPath));
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        if (files.length >= limit) continue;
+        try {
+          const content = readFileSync(fullPath, "utf-8");
+          files.push({
+            path: relative(vaultRoot, fullPath),
+            frontmatter: parseFrontmatter(content),
+          });
+        } catch {
+          /* skip unreadable files */
+        }
+      }
+    }
+  }
+
+  files.sort((a, b) => a.path.localeCompare(b.path));
+
+  return { files, directories: directories.sort() };
 }


### PR DESCRIPTION
## Summary
- Add `sparkle_search_obsidian` tool for full-text search across vault .md files with context lines and frontmatter summaries
- Add `sparkle_list_obsidian` tool for listing vault files/directories with frontmatter metadata
- Phase 2 of FG-004 (vault access), building on read/write tools from #152

## Test plan
- [x] 10 new unit tests (5 searchVault + 5 listVault in vault.test.ts)
- [x] 4 new tool handler tests (2 search + 2 list in tools.test.ts)
- [x] All 103 MCP server tests pass
- [x] TypeScript build succeeds
- [ ] Manual: search vault with keyword, verify context lines
- [ ] Manual: list vault recursive/non-recursive, verify directory listing
- [ ] Manual: search with path filter, verify subdirectory restriction

🤖 Generated with [Claude Code](https://claude.com/claude-code)