### PR TITLE
fix(mcp): restore sparkle_list_notes in instructions and fix error casting

### DIFF
--- a/mcp-server/src/docs/instructions.ts
+++ b/mcp-server/src/docs/instructions.ts
@@ -59,7 +59,7 @@ export const SPARKLE_INSTRUCTIONS = `
 
 | 情境 | 工具 |
 |------|------|
-| 搜尋相關筆記 | sparkle_search（Sparkle DB）、sparkle_search_obsidian（vault）、sparkle_search_all（同時搜兩邊）|
+| 搜尋相關筆記 | sparkle_search（Sparkle DB）、sparkle_search_obsidian（vault）、sparkle_search_all（同時搜兩邊）、sparkle_list_notes（篩選列表）|
 | 讀取完整內容 | sparkle_get_note |
 | 新建項目 | sparkle_create_note |
 | 更新內容 | sparkle_update_note（短筆記用全文替換；長筆記用 old_content 局部編輯）|

--- a/mcp-server/src/tools/search.ts
+++ b/mcp-server/src/tools/search.ts
@@ -112,9 +112,13 @@ Returns: Results grouped by source — [Sparkle] for database items, [Vault] for
       if (sections.length === 0) {
         const errors: string[] = [];
         if (sparkleResult.status === "rejected")
-          errors.push(`Sparkle: ${(sparkleResult.reason as Error).message}`);
+          errors.push(
+            `Sparkle: ${sparkleResult.reason instanceof Error ? sparkleResult.reason.message : String(sparkleResult.reason)}`,
+          );
         if (vaultResult.status === "rejected")
-          errors.push(`Vault: ${(vaultResult.reason as Error).message}`);
+          errors.push(
+            `Vault: ${vaultResult.reason instanceof Error ? vaultResult.reason.message : String(vaultResult.reason)}`,
+          );
         if (errors.length > 0) {
           return {
             content: [{ type: "text", text: `Search failed:\n${errors.join("\n")}` }],


### PR DESCRIPTION
## Summary
- Restore `sparkle_list_notes` accidentally dropped from search tools table in instructions.ts during #154
- Fix unsafe `as Error` cast on `Promise.allSettled` rejection reasons — use `instanceof Error` check with `String()` fallback

## Test plan
- [x] All 107 MCP server tests pass
- [x] TypeScript build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)