### PR TITLE
refactor(mcp): extract formatToolError utility for consistent error handling

### DIFF
--- a/mcp-server/src/__tests__/tools.test.ts
+++ b/mcp-server/src/__tests__/tools.test.ts
@@ -2,16 +2,20 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { makeItem, makeMockServer } from "./helpers.js";
 
 // Mock client module
-vi.mock("../client.js", () => ({
-  searchItems: vi.fn(),
-  getItem: vi.fn(),
-  listItems: vi.fn(),
-  createItem: vi.fn(),
-  updateItem: vi.fn(),
-  getStats: vi.fn(),
-  getTags: vi.fn(),
-  exportToObsidian: vi.fn(),
-}));
+vi.mock("../client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../client.js")>();
+  return {
+    ...actual,
+    searchItems: vi.fn(),
+    getItem: vi.fn(),
+    listItems: vi.fn(),
+    createItem: vi.fn(),
+    updateItem: vi.fn(),
+    getStats: vi.fn(),
+    getTags: vi.fn(),
+    exportToObsidian: vi.fn(),
+  };
+});
 
 // Mock vault module
 vi.mock("../vault.js", () => ({
@@ -606,5 +610,19 @@ describe("sparkle_list_obsidian", () => {
     expect(result.content[0].text).toContain("Directories:** (2)");
     expect(result.content[0].text).toContain("Projects/");
     expect(result.content[0].text).toContain("Archive/");
+  });
+});
+
+describe("error handling", () => {
+  it("includes HTTP status for SparkleApiError", async () => {
+    const server = makeMockServer();
+    registerReadTools(server as never);
+    const handler = server.getHandler("sparkle_get_note");
+
+    getItem.mockRejectedValue(new client.SparkleApiError("Not Found", 404));
+
+    const result = await handler({ id: "a4662876-1234-5678-9abc-def012345678" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe("Error (HTTP 404): Not Found");
   });
 });

--- a/mcp-server/src/__tests__/utils.test.ts
+++ b/mcp-server/src/__tests__/utils.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { formatToolError } from "../utils.js";
+import { SparkleApiError } from "../client.js";
+
+describe("formatToolError", () => {
+  it("formats SparkleApiError with HTTP status", () => {
+    const error = new SparkleApiError("Not Found", 404);
+    const result = formatToolError(error);
+    expect(result).toEqual({
+      content: [{ type: "text", text: "Error (HTTP 404): Not Found" }],
+      isError: true,
+    });
+  });
+
+  it("formats generic Error", () => {
+    const error = new Error("Something went wrong");
+    const result = formatToolError(error);
+    expect(result).toEqual({
+      content: [{ type: "text", text: "Error: Something went wrong" }],
+      isError: true,
+    });
+  });
+
+  it("formats non-Error values", () => {
+    const result = formatToolError("string error");
+    expect(result).toEqual({
+      content: [{ type: "text", text: "Error: string error" }],
+      isError: true,
+    });
+  });
+});

--- a/mcp-server/src/tools/categories.ts
+++ b/mcp-server/src/tools/categories.ts
@@ -8,6 +8,7 @@ import {
   reorderCategoriesApi,
 } from "../client.js";
 import type { Category } from "../types.js";
+import { formatToolError } from "../utils.js";
 
 const HEX_COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
 
@@ -63,10 +64,7 @@ Returns: Array of categories with name, color (hex), sort_order, and metadata.`,
           content: [{ type: "text", text }],
         };
       } catch (error) {
-        return {
-          content: [{ type: "text", text: `Error listing categories: ${(error as Error).message}` }],
-          isError: true,
-        };
+        return formatToolError(error);
       }
     },
   );
@@ -108,12 +106,7 @@ Returns: The created category with all fields.`,
           content: [{ type: "text", text }],
         };
       } catch (error) {
-        return {
-          content: [
-            { type: "text", text: `Error creating category: ${(error as Error).message}` },
-          ],
-          isError: true,
-        };
+        return formatToolError(error);
       }
     },
   );
@@ -164,12 +157,7 @@ Returns: The updated category with all fields.`,
           content: [{ type: "text", text }],
         };
       } catch (error) {
-        return {
-          content: [
-            { type: "text", text: `Error updating category: ${(error as Error).message}` },
-          ],
-          isError: true,
-        };
+        return formatToolError(error);
       }
     },
   );
@@ -203,12 +191,7 @@ Returns: Confirmation of deletion.`,
           content: [{ type: "text", text: "Category deleted successfully." }],
         };
       } catch (error) {
-        return {
-          content: [
-            { type: "text", text: `Error deleting category: ${(error as Error).message}` },
-          ],
-          isError: true,
-        };
+        return formatToolError(error);
       }
     },
   );
@@ -253,12 +236,7 @@ Returns: Confirmation of reorder.`,
           ],
         };
       } catch (error) {
-        return {
-          content: [
-            { type: "text", text: `Error reordering categories: ${(error as Error).message}` },
-          ],
-          isError: true,
-        };
+        return formatToolError(error);
       }
     },
   );

--- a/mcp-server/src/tools/meta.ts
+++ b/mcp-server/src/tools/meta.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getStats, getTags } from "../client.js";
 import { formatStats, formatTags } from "../format.js";
+import { formatToolError } from "../utils.js";
 
 export function registerMetaTools(server: McpServer): void {
   server.registerTool(
@@ -28,10 +29,7 @@ Returns: Zettelkasten note counts (fleeting/developing/permanent), GTD todo coun
           content: [{ type: "text", text }],
         };
       } catch (error) {
-        return {
-          content: [{ type: "text", text: `Error: ${(error as Error).message}` }],
-          isError: true,
-        };
+        return formatToolError(error);
       }
     },
   );
@@ -61,10 +59,7 @@ Returns: Array of tag names. Use these for filtering with sparkle_list_notes or 
           content: [{ type: "text", text }],
         };
       } catch (error) {
-        return {
-          content: [{ type: "text", text: `Error: ${(error as Error).message}` }],
-          isError: true,
-        };
+        return formatToolError(error);
       }
     },
   );

--- a/mcp-server/src/tools/read.ts
+++ b/mcp-server/src/tools/read.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { getItem, listItems } from "../client.js";
 import { formatItem, formatItemList } from "../format.js";
+import { formatToolError } from "../utils.js";
 
 export function registerReadTools(server: McpServer): void {
   server.registerTool(
@@ -33,10 +34,7 @@ If prefix matches multiple items, returns error with candidate IDs.`,
           content: [{ type: "text", text }],
         };
       } catch (error) {
-        return {
-          content: [{ type: "text", text: `Error: ${(error as Error).message}` }],
-          isError: true,
-        };
+        return formatToolError(error);
       }
     },
   );
@@ -98,10 +96,7 @@ Returns: List of items with total count and pagination info.`,
           content: [{ type: "text", text }],
         };
       } catch (error) {
-        return {
-          content: [{ type: "text", text: `Error: ${(error as Error).message}` }],
-          isError: true,
-        };
+        return formatToolError(error);
       }
     },
   );

--- a/mcp-server/src/tools/search.ts
+++ b/mcp-server/src/tools/search.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { searchItems } from "../client.js";
 import { formatItemList } from "../format.js";
+import { formatToolError } from "../utils.js";
 import { searchVault } from "../vault.js";
 import { formatSearchResults } from "./vault.js";
 
@@ -39,10 +40,7 @@ Returns: List of matching items with title, status, tags, and metadata.`,
           content: [{ type: "text", text }],
         };
       } catch (error) {
-        return {
-          content: [{ type: "text", text: `Error searching: ${(error as Error).message}` }],
-          isError: true,
-        };
+        return formatToolError(error);
       }
     },
   );

--- a/mcp-server/src/tools/vault.ts
+++ b/mcp-server/src/tools/vault.ts
@@ -14,6 +14,7 @@ import type {
   VaultSearchResult,
   VaultListResult,
 } from "../types.js";
+import { formatToolError } from "../utils.js";
 
 function formatVaultFile(file: VaultFile): string {
   const lines: string[] = [`**Path:** ${file.path}`];
@@ -63,10 +64,7 @@ Requires Obsidian integration to be enabled in Sparkle settings.`,
           content: [{ type: "text", text: formatVaultFile(file) }],
         };
       } catch (error) {
-        return {
-          content: [{ type: "text", text: `Error: ${(error as Error).message}` }],
-          isError: true,
-        };
+        return formatToolError(error);
       }
     },
   );
@@ -104,10 +102,7 @@ Returns: Confirmation with file path.`,
           content: [{ type: "text", text: `File updated successfully.\n\n**Path:** ${path}` }],
         };
       } catch (error) {
-        return {
-          content: [{ type: "text", text: `Error: ${(error as Error).message}` }],
-          isError: true,
-        };
+        return formatToolError(error);
       }
     },
   );
@@ -144,10 +139,7 @@ Returns: File path, frontmatter summary (if any), and full body content.`,
           content: [{ type: "text", text: formatVaultFile(file) }],
         };
       } catch (error) {
-        return {
-          content: [{ type: "text", text: `Error: ${(error as Error).message}` }],
-          isError: true,
-        };
+        return formatToolError(error);
       }
     },
   );
@@ -191,10 +183,7 @@ Returns: Confirmation with file path.`,
           ],
         };
       } catch (error) {
-        return {
-          content: [{ type: "text", text: `Error: ${(error as Error).message}` }],
-          isError: true,
-        };
+        return formatToolError(error);
       }
     },
   );
@@ -242,10 +231,7 @@ Requires Obsidian integration to be enabled in Sparkle settings.`,
           content: [{ type: "text", text: formatSearchResults(results, query) }],
         };
       } catch (error) {
-        return {
-          content: [{ type: "text", text: `Error: ${(error as Error).message}` }],
-          isError: true,
-        };
+        return formatToolError(error);
       }
     },
   );
@@ -296,10 +282,7 @@ Requires Obsidian integration to be enabled in Sparkle settings.`,
           content: [{ type: "text", text: formatListResult(result) }],
         };
       } catch (error) {
-        return {
-          content: [{ type: "text", text: `Error: ${(error as Error).message}` }],
-          isError: true,
-        };
+        return formatToolError(error);
       }
     },
   );

--- a/mcp-server/src/tools/workflow.ts
+++ b/mcp-server/src/tools/workflow.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { getItem, updateItem, exportToObsidian } from "../client.js";
 import { formatItem } from "../format.js";
+import { formatToolError } from "../utils.js";
 
 export function registerWorkflowTools(server: McpServer): void {
   server.registerTool(
@@ -61,10 +62,7 @@ Returns: The updated note.`,
           content: [{ type: "text", text }],
         };
       } catch (error) {
-        return {
-          content: [{ type: "text", text: `Error: ${(error as Error).message}` }],
-          isError: true,
-        };
+        return formatToolError(error);
       }
     },
   );

--- a/mcp-server/src/tools/write.ts
+++ b/mcp-server/src/tools/write.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { createItem, getItem, updateItem } from "../client.js";
 import { formatItem } from "../format.js";
+import { formatToolError } from "../utils.js";
 
 export function registerWriteTools(server: McpServer): void {
   server.registerTool(
@@ -64,10 +65,7 @@ Returns: The created item with all fields including generated ID and timestamps.
           content: [{ type: "text", text }],
         };
       } catch (error) {
-        return {
-          content: [{ type: "text", text: `Error creating note: ${(error as Error).message}` }],
-          isError: true,
-        };
+        return formatToolError(error);
       }
     },
   );
@@ -169,10 +167,7 @@ Content editing modes:
           content: [{ type: "text", text }],
         };
       } catch (error) {
-        return {
-          content: [{ type: "text", text: `Error updating note: ${(error as Error).message}` }],
-          isError: true,
-        };
+        return formatToolError(error);
       }
     },
   );

--- a/mcp-server/src/utils.ts
+++ b/mcp-server/src/utils.ts
@@ -1,0 +1,18 @@
+import { SparkleApiError } from "./client.js";
+
+export function formatToolError(error: unknown): {
+  content: { type: "text"; text: string }[];
+  isError: true;
+} {
+  if (error instanceof SparkleApiError) {
+    return {
+      content: [{ type: "text", text: `Error (HTTP ${error.status}): ${error.message}` }],
+      isError: true,
+    };
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    content: [{ type: "text", text: `Error: ${message}` }],
+    isError: true,
+  };
+}


### PR DESCRIPTION
## Summary
- New `mcp-server/src/utils.ts` with `formatToolError()` — handles `SparkleApiError` (includes HTTP status code), generic `Error`, and non-Error values
- Migrated 17 catch blocks across 7 tool files to use the shared utility
- Kept `workflow.ts` export tool's custom guidance message ("Make sure the note is permanent...")
- `guide.ts` unchanged (no try/catch)

## Quality Items
- Fixes TD-019 (Low): Standardize MCP error handling
- Fixes TD-024 (Low): Surface HTTP status in MCP tool errors

## Test plan
- [x] 3 unit tests for `formatToolError` (SparkleApiError, generic Error, non-Error)
- [x] 1 integration test: SparkleApiError HTTP status propagation through tool handler
- [x] All 96 MCP tests pass
- [x] MCP server builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)