### PR TITLE
feat(mcp): add list filters (category, order) and pagination info

### DIFF
--- a/mcp-server/src/__tests__/format.test.ts
+++ b/mcp-server/src/__tests__/format.test.ts
@@ -128,6 +128,26 @@ describe("formatItemList", () => {
     expect(result).toContain("high");
     expect(result).toContain("(due: 2026-02-28)");
   });
+
+  it("appends pagination footer when pagination is provided", () => {
+    const items = [makeItem({ title: "A" }), makeItem({ title: "B" })];
+    const result = formatItemList(items, 10, { offset: 0, limit: 2 });
+    expect(result).toContain("Offset: 0 | Limit: 2 | Has more: yes | Next offset: 2");
+  });
+
+  it("does not include pagination footer when pagination is omitted", () => {
+    const items = [makeItem({ title: "A" })];
+    const result = formatItemList(items, 1);
+    expect(result).not.toContain("Offset:");
+    expect(result).not.toContain("Has more:");
+  });
+
+  it("shows has more as no when at the end", () => {
+    const items = [makeItem({ title: "A" }), makeItem({ title: "B" })];
+    const result = formatItemList(items, 5, { offset: 4, limit: 2 });
+    expect(result).toContain("Has more: no");
+    expect(result).toContain("Next offset: 6");
+  });
 });
 
 describe("formatStats", () => {

--- a/mcp-server/src/__tests__/tools.test.ts
+++ b/mcp-server/src/__tests__/tools.test.ts
@@ -158,6 +158,55 @@ describe("sparkle_search_all", () => {
   });
 });
 
+describe("sparkle_list_notes", () => {
+  function getListHandler() {
+    const server = makeMockServer();
+    registerReadTools(server as never);
+    return server.getHandler("sparkle_list_notes");
+  }
+
+  it("passes category_id and order to listItems", async () => {
+    const handler = getListHandler();
+    listItems.mockResolvedValue({ items: [], total: 0 });
+
+    await handler({
+      type: "note",
+      sort: "created",
+      order: "asc",
+      category_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      limit: 50,
+      offset: 0,
+    });
+    expect(listItems).toHaveBeenCalledWith({
+      status: undefined,
+      tag: undefined,
+      type: "note",
+      category_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      sort: "created",
+      order: "asc",
+      limit: 50,
+      offset: 0,
+    });
+  });
+
+  it("includes pagination footer in output", async () => {
+    const handler = getListHandler();
+    listItems.mockResolvedValue({
+      items: [makeItem({ title: "Note 1" })],
+      total: 5,
+    });
+
+    const result = await handler({
+      type: "note",
+      sort: "created",
+      order: "desc",
+      limit: 1,
+      offset: 0,
+    });
+    expect(result.content[0].text).toContain("Offset: 0 | Limit: 1 | Has more: yes | Next offset: 1");
+  });
+});
+
 describe("sparkle_get_note", () => {
   function getReadHandler() {
     const server = makeMockServer();

--- a/mcp-server/src/format.ts
+++ b/mcp-server/src/format.ts
@@ -53,7 +53,11 @@ export function formatItem(item: SparkleItem): string {
 }
 
 /** Format a list of items as a compact markdown list */
-export function formatItemList(items: SparkleItem[], total: number): string {
+export function formatItemList(
+  items: SparkleItem[],
+  total: number,
+  pagination?: { offset: number; limit: number },
+): string {
   if (items.length === 0) return "No items found.";
 
   const lines: string[] = [`Found ${total} items (showing ${items.length}):\n`];
@@ -65,6 +69,13 @@ export function formatItemList(items: SparkleItem[], total: number): string {
     const catStr = item.category_name ? ` 📁${item.category_name}` : "";
     lines.push(`- **${item.title}** — ${item.status}${priorityStr}${dueStr}${catStr}${tagStr}`);
     lines.push(`  ID: ${item.id} | Type: ${item.type} | Modified: ${item.modified}`);
+  }
+  if (pagination) {
+    const hasMore = pagination.offset + pagination.limit < total;
+    const nextOffset = pagination.offset + pagination.limit;
+    lines.push(
+      `\nOffset: ${pagination.offset} | Limit: ${pagination.limit} | Has more: ${hasMore ? "yes" : "no"} | Next offset: ${nextOffset}`,
+    );
   }
   return lines.join("\n");
 }

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerSearchTools } from "./tools/search.js";
 import { registerReadTools } from "./tools/read.js";
@@ -10,9 +11,12 @@ import { registerVaultTools } from "./tools/vault.js";
 import { SPARKLE_INSTRUCTIONS } from "./docs/instructions.js";
 import { registerDocResources } from "./docs/resources.js";
 
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json") as { version: string };
+
 export function createSparkleServer(): McpServer {
   const server = new McpServer(
-    { name: "sparkle", version: "1.0.0" },
+    { name: "sparkle", version: pkg.version },
     { instructions: SPARKLE_INSTRUCTIONS },
   );
 

--- a/mcp-server/src/tools/read.ts
+++ b/mcp-server/src/tools/read.ts
@@ -53,7 +53,9 @@ Args:
   - status (string, optional): Filter by status
   - tag (string, optional): Filter by tag name
   - type (string, optional): "note", "todo", or "scratch", default "note"
+  - category_id (string, optional): Filter by category UUID
   - sort (string, optional): "created", "modified", "priority", or "due" (default: "created")
+  - order (string, optional): "asc" or "desc" (default: "desc")
   - limit (number, optional): Max results 1-100, default 50
   - offset (number, optional): Pagination offset, default 0
 
@@ -74,10 +76,12 @@ Returns: List of items with total count and pagination info.`,
           .describe("Filter by status"),
         tag: z.string().optional().describe("Filter by tag name"),
         type: z.enum(["note", "todo", "scratch"]).default("note").describe("Item type"),
+        category_id: z.string().uuid().optional().describe("Filter by category UUID"),
         sort: z
           .enum(["created", "modified", "priority", "due"])
           .default("created")
           .describe("Sort field"),
+        order: z.enum(["asc", "desc"]).default("desc").describe("Sort order"),
         limit: z.number().int().min(1).max(100).default(50).describe("Max results"),
         offset: z.number().int().min(0).default(0).describe("Pagination offset"),
       },
@@ -88,10 +92,10 @@ Returns: List of items with total count and pagination info.`,
         openWorldHint: false,
       },
     },
-    async ({ status, tag, type, sort, limit, offset }) => {
+    async ({ status, tag, type, category_id, sort, order, limit, offset }) => {
       try {
-        const data = await listItems({ status, tag, type, sort, limit, offset });
-        const text = formatItemList(data.items, data.total);
+        const data = await listItems({ status, tag, type, category_id, sort, order, limit, offset });
+        const text = formatItemList(data.items, data.total, { offset, limit });
         return {
           content: [{ type: "text", text }],
         };


### PR DESCRIPTION
## Summary
- **TD-027**: Replace hardcoded version `"1.0.0"` in `mcp-server/src/server.ts` with dynamic version from `package.json` via `createRequire`
- **FG-006**: Add `category_id` (UUID) and `order` (`asc`/`desc`) filters to `sparkle_list_notes` tool, passing them through to `listItems()`
- **FG-007**: Add optional pagination footer to `formatItemList` showing offset, limit, has more (yes/no), and next offset

## Test plan
- [x] 3 new tests in `format.test.ts`: pagination footer present, absent when omitted, has more = no at end
- [x] 2 new tests in `tools.test.ts`: category_id/order params passed correctly, pagination footer in output
- [x] All 116 MCP server tests pass
- [x] `tsc --noEmit` passes for both client and MCP server
- [x] `npm run build` in mcp-server succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)