### PR TITLE
fix(export): collision timestamp seconds, timezone offset, idempotent guard

### DIFF
--- a/server/lib/__tests__/export.test.ts
+++ b/server/lib/__tests__/export.test.ts
@@ -246,9 +246,8 @@ describe("generateFrontmatter", () => {
     expect(catIndex).toBeLessThan(tagsIndex);
   });
 
-  it("uses local time without Z suffix", () => {
+  it("uses local time with timezone offset (no Z suffix)", () => {
     const fm = generateFrontmatter(makeItem());
-    // Should not have Z suffix in created/modified
     const lines = fm.split("\n");
     const createdLine = lines.find((l) => l.startsWith("created:"));
     const modifiedLine = lines.find((l) => l.startsWith("modified:"));
@@ -256,6 +255,9 @@ describe("generateFrontmatter", () => {
     expect(modifiedLine).toBeDefined();
     expect(createdLine).not.toContain("Z");
     expect(modifiedLine).not.toContain("Z");
+    // Should contain timezone offset like +08:00 or -05:00
+    expect(createdLine).toMatch(/[+-]\d{2}:\d{2}$/);
+    expect(modifiedLine).toMatch(/[+-]\d{2}:\d{2}$/);
   });
 
   // --- YAML escaping (DEF-021) ---
@@ -403,7 +405,7 @@ describe("exportToObsidian", () => {
 
     // Should have a timestamp suffix instead of the original filename
     expect(result.path).not.toBe("0_Inbox/Collision.md");
-    expect(result.path).toMatch(/^0_Inbox\/Collision \(\d{8}-\d{4}\)\.md$/);
+    expect(result.path).toMatch(/^0_Inbox\/Collision \(\d{8}-\d{6}\)\.md$/);
   });
 
   it("overwrites existing file in overwrite mode", () => {
@@ -433,5 +435,69 @@ describe("exportToObsidian", () => {
     config.vaultPath = "";
     const item = makeItem({ title: "No Vault" });
     expect(() => exportToObsidian(item, config)).toThrow("Obsidian vault path is not configured");
+  });
+
+  // --- Idempotent export guard (FG-005) ---
+
+  it("new mode + sparkle_id match → returns skipped and does not modify existing file", () => {
+    config.exportMode = "new";
+    const item = makeItem({ id: "unique-sparkle-id-1", title: "Original Title" });
+
+    // Pre-create a file with matching sparkle_id but different filename
+    const inboxDir = join(tempDir, "0_Inbox");
+    mkdirSync(inboxDir, { recursive: true });
+    const existingContent =
+      '---\nsparkle_id: "unique-sparkle-id-1"\n---\n\n# Old Title\n\nOld body\n';
+    writeFileSync(join(inboxDir, "Old Title.md"), existingContent, "utf-8");
+
+    const result = exportToObsidian(item, config);
+
+    expect(result.skipped).toBe(true);
+    expect(result.path).toBe("0_Inbox/Old Title.md");
+    // File content should not be modified
+    const content = readFileSync(join(inboxDir, "Old Title.md"), "utf-8");
+    expect(content).toBe(existingContent);
+  });
+
+  it("overwrite mode + sparkle_id match → overwrites the existing file even if filename differs", () => {
+    config.exportMode = "overwrite";
+    const item = makeItem({ id: "unique-sparkle-id-2", title: "New Title" });
+
+    // Pre-create a file with matching sparkle_id but different filename
+    const inboxDir = join(tempDir, "0_Inbox");
+    mkdirSync(inboxDir, { recursive: true });
+    const existingContent =
+      '---\nsparkle_id: "unique-sparkle-id-2"\n---\n\n# Old Name\n\nOld body\n';
+    writeFileSync(join(inboxDir, "Old Name.md"), existingContent, "utf-8");
+
+    const result = exportToObsidian(item, config);
+
+    expect(result.skipped).toBeUndefined();
+    expect(result.path).toBe("0_Inbox/Old Name.md");
+    // File should be overwritten with new content
+    const content = readFileSync(join(inboxDir, "Old Name.md"), "utf-8");
+    expect(content).toContain("# New Title");
+    expect(content).toContain('sparkle_id: "unique-sparkle-id-2"');
+    expect(content).not.toContain("Old body");
+  });
+
+  it("different sparkle_id but same title → creates collision-suffixed file", () => {
+    config.exportMode = "new";
+    const item = makeItem({ id: "different-sparkle-id", title: "Same Title" });
+
+    // Pre-create a file with same title but different sparkle_id
+    const inboxDir = join(tempDir, "0_Inbox");
+    mkdirSync(inboxDir, { recursive: true });
+    const existingContent =
+      '---\nsparkle_id: "other-sparkle-id"\n---\n\n# Same Title\n\nExisting body\n';
+    writeFileSync(join(inboxDir, "Same Title.md"), existingContent, "utf-8");
+
+    const result = exportToObsidian(item, config);
+
+    // Should NOT be skipped (different sparkle_id)
+    expect(result.skipped).toBeUndefined();
+    // Should have collision suffix
+    expect(result.path).not.toBe("0_Inbox/Same Title.md");
+    expect(result.path).toMatch(/^0_Inbox\/Same Title \(\d{8}-\d{6}\)\.md$/);
   });
 });

--- a/server/lib/export.ts
+++ b/server/lib/export.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { mkdirSync, writeFileSync, existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 /**
@@ -22,8 +22,8 @@ export function sanitizeFilename(title: string): string {
 }
 
 /**
- * Convert an ISO timestamp to local time without timezone suffix.
- * Input: "2026-02-25T06:00:00.000Z" → Output: "2026-02-25T14:00:00" (in local TZ)
+ * Convert an ISO timestamp to local time with timezone offset.
+ * Input: "2026-02-25T06:00:00.000Z" → Output: "2026-02-25T14:00:00+08:00" (in local TZ)
  */
 function toLocalDateTime(isoString: string): string {
   const d = new Date(isoString);
@@ -33,7 +33,12 @@ function toLocalDateTime(isoString: string): string {
   const h = String(d.getHours()).padStart(2, "0");
   const mi = String(d.getMinutes()).padStart(2, "0");
   const s = String(d.getSeconds()).padStart(2, "0");
-  return `${y}-${mo}-${da}T${h}:${mi}:${s}`;
+  const offsetMin = d.getTimezoneOffset();
+  const sign = offsetMin <= 0 ? "+" : "-";
+  const absOffset = Math.abs(offsetMin);
+  const offsetH = String(Math.floor(absOffset / 60)).padStart(2, "0");
+  const offsetM = String(absOffset % 60).padStart(2, "0");
+  return `${y}-${mo}-${da}T${h}:${mi}:${s}${sign}${offsetH}:${offsetM}`;
 }
 
 /** Escape special chars for YAML double-quoted string content. */
@@ -163,6 +168,33 @@ export interface ExportConfig {
 
 export interface ExportResult {
   path: string; // relative path within vault, e.g. "0_Inbox/Title.md"
+  skipped?: boolean;
+}
+
+/**
+ * Scan .md files in a directory for a matching sparkle_id in YAML frontmatter.
+ * Returns the filename if found, null otherwise.
+ */
+function findExistingBySparkleId(dir: string, sparkleId: string): string | null {
+  if (!existsSync(dir)) return null;
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith(".md")) continue;
+    try {
+      const content = readFileSync(join(dir, file), "utf-8");
+      // Quick check before parsing frontmatter
+      if (!content.includes(sparkleId)) continue;
+      // Check frontmatter for sparkle_id
+      const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+      if (!fmMatch?.[1]) continue;
+      const sparkleIdMatch = fmMatch[1].match(/^sparkle_id:\s*"?([^"\n]+)"?/m);
+      if (sparkleIdMatch?.[1] === sparkleId) {
+        return file;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return null;
 }
 
 /**
@@ -180,6 +212,20 @@ export function exportToObsidian(item: ExportableItem, config: ExportConfig): Ex
   // Ensure the target directory exists
   mkdirSync(targetDir, { recursive: true });
 
+  // Look for existing file with same sparkle_id
+  const existingFile = findExistingBySparkleId(targetDir, item.id);
+
+  if (existingFile) {
+    if (exportMode === "new") {
+      return { path: `${inboxFolder}/${existingFile}`, skipped: true };
+    }
+    // overwrite mode: write to the existing file regardless of name
+    const existingPath = join(targetDir, existingFile);
+    const content = generateMarkdown(item);
+    writeFileSync(existingPath, content, "utf-8");
+    return { path: `${inboxFolder}/${existingFile}` };
+  }
+
   const baseName = sanitizeFilename(item.title);
   let filename = `${baseName}.md`;
   const fullPath = join(targetDir, filename);
@@ -188,7 +234,7 @@ export function exportToObsidian(item: ExportableItem, config: ExportConfig): Ex
     // Check for collision when creating new files
     if (existsSync(fullPath)) {
       const now = new Date();
-      const ts = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, "0")}${String(now.getDate()).padStart(2, "0")}-${String(now.getHours()).padStart(2, "0")}${String(now.getMinutes()).padStart(2, "0")}`;
+      const ts = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, "0")}${String(now.getDate()).padStart(2, "0")}-${String(now.getHours()).padStart(2, "0")}${String(now.getMinutes()).padStart(2, "0")}${String(now.getSeconds()).padStart(2, "0")}`;
       filename = `${baseName} (${ts}).md`;
     }
   }

--- a/server/lib/line-commands/item-handlers.ts
+++ b/server/lib/line-commands/item-handlers.ts
@@ -94,6 +94,9 @@ const handleExport: CommandHandler = async ({ userId, command, db, sqlite }) => 
       inboxFolder: obsidian.obsidian_inbox_folder,
       exportMode: obsidian.obsidian_export_mode,
     });
+    if (result.skipped) {
+      return `⏭️ 已存在相同筆記，跳過匯出: ${result.path}`;
+    }
     updateItem(db, resolved.itemId, { status: "exported" });
     return `✅ 已匯出到 Obsidian: ${result.path}`;
   } catch (err) {

--- a/server/routes/items.ts
+++ b/server/routes/items.ts
@@ -129,10 +129,15 @@ itemsRouter.post("/batch", async (c) => {
       // 2. Loop export (file I/O, unavoidable)
       const errors: { id: string; error: string }[] = [];
       const exportedIds: string[] = [];
+      const skippedIds: string[] = [];
       for (const item of eligible) {
         try {
-          exportToObsidian(item as ExportableItem, exportConfig);
-          exportedIds.push(item.id);
+          const result = exportToObsidian(item as ExportableItem, exportConfig);
+          if (result.skipped) {
+            skippedIds.push(item.id);
+          } else {
+            exportedIds.push(item.id);
+          }
         } catch (e) {
           errors.push({ id: item.id, error: (e as Error).message });
         }
@@ -145,7 +150,7 @@ itemsRouter.post("/batch", async (c) => {
           .run();
       }
       affected = exportedIds.length;
-      skipped = ids.length - affected - errors.length;
+      skipped = skippedIds.length + (ids.length - eligible.length);
       return c.json({ affected, skipped, errors });
     } else if (action === "done") {
       // → done (todo only, any status)
@@ -215,8 +220,10 @@ itemsRouter.post("/:id/export", (c) => {
       inboxFolder: obsidian.obsidian_inbox_folder,
       exportMode: obsidian.obsidian_export_mode,
     });
-    updateItem(db, item.id, { status: "exported" });
-    return c.json({ path: result.path });
+    if (!result.skipped) {
+      updateItem(db, item.id, { status: "exported" });
+    }
+    return c.json({ path: result.path, skipped: result.skipped });
   } catch (e) {
     return c.json({ error: (e as Error).message }, 500);
   }


### PR DESCRIPTION
## Summary
- **DEF-023**: Add seconds to collision timestamp format (YYYYMMDD-HHMMSS) to reduce collision window from 60s to 1s
- **TD-020**: Append timezone offset to `toLocalDateTime` output (e.g. `+08:00`) for unambiguous timestamps in YAML frontmatter
- **FG-005**: Idempotent export guard via `sparkle_id` frontmatter lookup — prevents duplicate exports in `new` mode and ensures `overwrite` mode targets the correct file even if the title changed

## Test plan
- [x] Updated collision timestamp regex in tests from `\d{8}-\d{4}` to `\d{8}-\d{6}`
- [x] Added timezone offset assertion (`/[+-]\d{2}:\d{2}$/`) to frontmatter tests
- [x] Added 3 idempotent guard tests: new+match (skip), overwrite+match (overwrite existing), different sparkle_id same title (collision suffix)
- [x] All 928 unit tests passing
- [x] TypeScript type-check clean
- [x] Lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)