### PR TITLE
fix(backend): replace SELECT *, extract share tag parser, narrow export mode type

### DIFF
--- a/server/lib/shares.ts
+++ b/server/lib/shares.ts
@@ -54,7 +54,9 @@ export function createShareToken(
     .run(id, itemId, token, visibility, now);
 
   // SAFETY: better-sqlite3 .get() returns unknown; columns match ShareTokenRow by migration schema
-  return sqlite.prepare("SELECT * FROM share_tokens WHERE id = ?").get(id) as ShareTokenRow;
+  return sqlite
+    .prepare("SELECT id, item_id, token, visibility, created FROM share_tokens WHERE id = ?")
+    .get(id) as ShareTokenRow;
 }
 
 export function getShareByToken(sqlite: Database.Database, token: string): ShareWithItem | null {
@@ -123,7 +125,9 @@ export function revokeShare(sqlite: Database.Database, shareId: string): boolean
 export function getSharesByItemId(sqlite: Database.Database, itemId: string): ShareTokenRow[] {
   return (
     sqlite
-      .prepare("SELECT * FROM share_tokens WHERE item_id = ? ORDER BY created DESC")
+      .prepare(
+        "SELECT id, item_id, token, visibility, created FROM share_tokens WHERE item_id = ? ORDER BY created DESC",
+      )
       // SAFETY: better-sqlite3 .all() returns unknown[]; columns match ShareTokenRow by migration schema
       .all(itemId) as ShareTokenRow[]
   );

--- a/server/routes/public.ts
+++ b/server/routes/public.ts
@@ -1,8 +1,20 @@
 import { Hono } from "hono";
 import { sqlite } from "../db/index.js";
-import { getShareByToken, listPublicShares } from "../lib/shares.js";
+import { getShareByToken, listPublicShares, type ShareWithItem } from "../lib/shares.js";
 import { renderPublicPage, renderNotFoundPage } from "../lib/render-public-page.js";
 import { logger } from "../lib/logger.js";
+
+function parseShareTags(share: ShareWithItem): string[] {
+  try {
+    return JSON.parse(share.item_tags) as string[];
+  } catch {
+    logger.warn(
+      { token: share.token, raw: share.item_tags },
+      "Failed to parse tags in shared item",
+    );
+    return [];
+  }
+}
 
 const publicRouter = new Hono();
 
@@ -15,15 +27,7 @@ publicRouter.get("/api/public/:token", (c) => {
     return c.json({ error: "Share not found" }, 404);
   }
 
-  let tags: string[] = [];
-  try {
-    tags = JSON.parse(share.item_tags);
-  } catch {
-    logger.warn(
-      { token: share.token, raw: share.item_tags },
-      "Failed to parse tags in shared item",
-    );
-  }
+  const tags = parseShareTags(share);
 
   return c.json({
     token: share.token,
@@ -57,15 +61,7 @@ publicRouter.get("/s/:token", (c) => {
     return c.html(renderNotFoundPage(), 404);
   }
 
-  let tags: string[] = [];
-  try {
-    tags = JSON.parse(share.item_tags);
-  } catch {
-    logger.warn(
-      { token: share.token, raw: share.item_tags },
-      "Failed to parse tags in shared item",
-    );
-  }
+  const tags = parseShareTags(share);
 
   const html = renderPublicPage({
     title: share.item_title,

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -38,7 +38,7 @@ export function Settings({ onSettingsChanged }: SettingsProps) {
   const [enabled, setEnabled] = useState(false);
   const [vaultPath, setVaultPath] = useState("");
   const [inboxFolder, setInboxFolder] = useState("0_Inbox");
-  const [exportMode, setExportMode] = useState("overwrite");
+  const [exportMode, setExportMode] = useState<"new" | "overwrite">("overwrite");
 
   const { resolvedTheme, setTheme } = useTheme();
   const isOnline = useOnlineStatus();
@@ -200,7 +200,11 @@ export function Settings({ onSettingsChanged }: SettingsProps) {
             {/* Export mode */}
             <div>
               <label className="text-sm text-muted-foreground block mb-1">匯出模式</label>
-              <Select value={exportMode} onValueChange={setExportMode} disabled={!enabled}>
+              <Select
+                value={exportMode}
+                onValueChange={(v) => setExportMode(v as "new" | "overwrite")}
+                disabled={!enabled}
+              >
                 <SelectTrigger className="w-full">
                   <SelectValue />
                 </SelectTrigger>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -123,7 +123,7 @@ export interface SettingsResponse {
   obsidian_enabled: string;
   obsidian_vault_path: string;
   obsidian_inbox_folder: string;
-  obsidian_export_mode: string;
+  obsidian_export_mode: "new" | "overwrite";
 }
 
 // Parsed item with tags and aliases as arrays


### PR DESCRIPTION
## Summary
- **DEF-020**: Replace `SELECT *` with explicit column lists (`id, item_id, token, visibility, created`) in `server/lib/shares.ts` (2 occurrences: `createShareToken` and `getSharesByItemId`)
- **TD-017**: Extract `parseShareTags()` helper in `server/routes/public.ts` to deduplicate the `JSON.parse` + `logger.warn` error handling pattern (was duplicated in 2 routes)
- **TD-023**: Narrow `obsidian_export_mode` type from `string` to `"new" | "overwrite"` in `SettingsResponse` interface and `settings.tsx` useState/onValueChange

## Test plan
- [x] `npx vitest run server/routes/__tests__/shares.test.ts` — 38 tests pass
- [x] `npx vitest run src/components/__tests__/settings.test.tsx` — 11 tests pass
- [x] `npm run lint:fix && npm run format` — clean
- [x] `npx tsc --noEmit` (client + server) — clean
- [x] `npx vitest run` — all 928 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)