### PR TITLE
fix(backup): replace deprecated restic --repo2 with --from-repo

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -131,8 +131,10 @@ if [[ -n "${RESTIC_OFFSITE_REPOSITORY:-}" ]]; then
     else
         log "複製快照至異地儲存庫: $RESTIC_OFFSITE_REPOSITORY"
         if restic copy --tag sparkle \
-            --repo2 "$RESTIC_OFFSITE_REPOSITORY" \
-            --password-file2 "$OFFSITE_PW" \
+            --from-repo "$RESTIC_REPOSITORY" \
+            --from-password-file "$RESTIC_PASSWORD_FILE" \
+            --repo "$RESTIC_OFFSITE_REPOSITORY" \
+            --password-file "$OFFSITE_PW" \
             --quiet; then
             log "異地備份複製完成"
 


### PR DESCRIPTION
## Summary
- restic 已 deprecate `--repo2` / `--password-file2`，改用 `--from-repo` / `--from-password-file` + `--repo` / `--password-file`

## Test plan
- [x] 手動執行 `backup.sh`，本地 + 異地備份成功，無 deprecated warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)