### PR TITLE
fix(mcp): add strict() to all inputSchema to reject unknown parameters

### DIFF
--- a/mcp-server/src/__tests__/tools.test.ts
+++ b/mcp-server/src/__tests__/tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { z } from "zod";
 import { makeItem, makeMockServer } from "./helpers.js";
 
 // Mock client module
@@ -673,5 +674,25 @@ describe("error handling", () => {
     const result = await handler({ id: "a4662876-1234-5678-9abc-def012345678" });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toBe("Error (HTTP 404): Not Found");
+  });
+});
+
+describe("strict schema validation", () => {
+  it("z.object().strict() rejects unknown parameters", () => {
+    const schema = z
+      .object({
+        id: z.string(),
+        content: z.string().optional(),
+        old_content: z.string().optional(),
+      })
+      .strict();
+
+    // Correct parameters should pass
+    const valid = schema.safeParse({ id: "test", content: "hi", old_content: "old" });
+    expect(valid.success).toBe(true);
+
+    // Wrong parameter name (old_string instead of old_content) should be rejected
+    const invalid = schema.safeParse({ id: "test", content: "hi", old_string: "old" });
+    expect(invalid.success).toBe(false);
   });
 });

--- a/mcp-server/src/tools/categories.ts
+++ b/mcp-server/src/tools/categories.ts
@@ -48,7 +48,7 @@ export function registerCategoryTools(server: McpServer): void {
 Use this before assigning a category_id via sparkle_create_note or sparkle_update_note to find the correct UUID. Also useful for checking existing categories before creating a new one to avoid duplicates.
 
 Returns: Array of categories with name, color (hex), sort_order, and metadata.`,
-      inputSchema: {},
+      inputSchema: z.object({}).strict(),
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -82,7 +82,7 @@ Args:
   - color (string, optional): Hex color code (e.g. "#3b82f6"), must be #RRGGBB format. Null to leave unset.
 
 Returns: The created category with all fields.`,
-      inputSchema: {
+      inputSchema: z.object({
         name: z.string().min(1).max(50).describe("Category name"),
         color: z
           .string()
@@ -90,7 +90,7 @@ Returns: The created category with all fields.`,
           .nullable()
           .optional()
           .describe("Hex color code (#RRGGBB format, e.g. #3b82f6)"),
-      },
+      }).strict(),
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -126,7 +126,7 @@ Args:
   - sort_order (number, optional): New sort position (integer >= 0)
 
 Returns: The updated category with all fields.`,
-      inputSchema: {
+      inputSchema: z.object({
         id: z.string().uuid().describe("Category UUID"),
         name: z.string().min(1).max(50).optional().describe("New name"),
         color: z
@@ -136,7 +136,7 @@ Returns: The updated category with all fields.`,
           .optional()
           .describe("Hex color code (#RRGGBB format, null to clear)"),
         sort_order: z.number().int().min(0).max(999999).optional().describe("Sort position"),
-      },
+      }).strict(),
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -174,9 +174,9 @@ Args:
   - id (string, required): Category UUID
 
 Returns: Confirmation of deletion.`,
-      inputSchema: {
+      inputSchema: z.object({
         id: z.string().uuid().describe("Category UUID"),
-      },
+      }).strict(),
       annotations: {
         readOnlyHint: false,
         destructiveHint: true,
@@ -208,7 +208,7 @@ Args:
   - items (array, required): Array of { id: string (UUID), sort_order: number (integer >= 0) }. Min 1, max 500 items.
 
 Returns: Confirmation of reorder.`,
-      inputSchema: {
+      inputSchema: z.object({
         items: z
           .array(
             z.object({
@@ -219,7 +219,7 @@ Returns: Confirmation of reorder.`,
           .min(1)
           .max(500)
           .describe("Array of { id, sort_order } pairs"),
-      },
+      }).strict(),
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,

--- a/mcp-server/src/tools/guide.ts
+++ b/mcp-server/src/tools/guide.ts
@@ -10,11 +10,11 @@ export function registerGuideTools(server: McpServer): void {
     {
       title: "Sparkle Guide",
       description: `Query Sparkle documentation by topic. Available topics: ${validTopics.join(", ")}.`,
-      inputSchema: {
+      inputSchema: z.object({
         topic: z
           .enum([validTopics[0], ...validTopics.slice(1)])
           .describe("Documentation topic to retrieve"),
-      },
+      }).strict(),
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,

--- a/mcp-server/src/tools/meta.ts
+++ b/mcp-server/src/tools/meta.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 import { getStats, getTags } from "../client.js";
 import { formatStats, formatTags } from "../format.js";
 import { formatToolError } from "../utils.js";
@@ -13,7 +14,7 @@ export function registerMetaTools(server: McpServer): void {
 No args required.
 
 Returns: Zettelkasten note counts (fleeting/developing/permanent), GTD todo counts (active/done/overdue), and activity metrics (exports/completions/creations this week and month).`,
-      inputSchema: {},
+      inputSchema: z.object({}).strict(),
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -43,7 +44,7 @@ Returns: Zettelkasten note counts (fleeting/developing/permanent), GTD todo coun
 No args required.
 
 Returns: Array of tag names. Use these for filtering with sparkle_list_notes or when creating/updating notes to maintain consistent tagging.`,
-      inputSchema: {},
+      inputSchema: z.object({}).strict(),
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,

--- a/mcp-server/src/tools/read.ts
+++ b/mcp-server/src/tools/read.ts
@@ -16,9 +16,9 @@ Args:
 
 Returns: Full item with title, content, status, tags, aliases, linked items, and metadata.
 If prefix matches multiple items, returns error with candidate IDs.`,
-      inputSchema: {
+      inputSchema: z.object({
         id: z.string().min(4).describe("Item UUID or short ID prefix (min 4 chars)"),
-      },
+      }).strict(),
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -60,7 +60,7 @@ Args:
   - offset (number, optional): Pagination offset, default 0
 
 Returns: List of items with total count and pagination info.`,
-      inputSchema: {
+      inputSchema: z.object({
         status: z
           .enum([
             "fleeting",
@@ -84,7 +84,7 @@ Returns: List of items with total count and pagination info.`,
         order: z.enum(["asc", "desc"]).default("desc").describe("Sort order"),
         limit: z.number().int().min(1).max(100).default(50).describe("Max results"),
         offset: z.number().int().min(0).default(0).describe("Pagination offset"),
-      },
+      }).strict(),
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,

--- a/mcp-server/src/tools/search.ts
+++ b/mcp-server/src/tools/search.ts
@@ -21,10 +21,10 @@ Args:
   - limit (number, optional): Max results 1-50, default 20
 
 Returns: List of matching items with title, status, tags, and metadata.`,
-      inputSchema: {
+      inputSchema: z.object({
         query: z.string().min(1).describe("Search keywords"),
         limit: z.number().int().min(1).max(50).default(20).describe("Max results to return"),
-      },
+      }).strict(),
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -58,7 +58,7 @@ Args:
   - limit (number, optional): Max results per source (default 20, max 50)
 
 Returns: Results grouped by source — [Sparkle] for database items, [Vault] for vault files.`,
-      inputSchema: {
+      inputSchema: z.object({
         query: z.string().min(1).describe("Search keywords"),
         limit: z
           .number()
@@ -67,7 +67,7 @@ Returns: Results grouped by source — [Sparkle] for database items, [Vault] for
           .max(50)
           .default(20)
           .describe("Max results per source (default 20)"),
-      },
+      }).strict(),
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,

--- a/mcp-server/src/tools/vault.ts
+++ b/mcp-server/src/tools/vault.ts
@@ -47,9 +47,9 @@ Args:
 
 Returns: File path, frontmatter summary, and full body content.
 Requires Obsidian integration to be enabled in Sparkle settings.`,
-      inputSchema: {
+      inputSchema: z.object({
         sparkle_id: z.string().uuid().describe("Sparkle note UUID"),
-      },
+      }).strict(),
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -84,10 +84,10 @@ Args:
   - content (string): Full file content to write (including frontmatter)
 
 Returns: Confirmation with file path.`,
-      inputSchema: {
+      inputSchema: z.object({
         sparkle_id: z.string().uuid().describe("Sparkle note UUID"),
         content: z.string().min(1).describe("Full file content to write"),
-      },
+      }).strict(),
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -119,12 +119,12 @@ Args:
   - path (string): Relative path from vault root (e.g. "Projects/my-note.md")
 
 Returns: File path, frontmatter summary (if any), and full body content.`,
-      inputSchema: {
+      inputSchema: z.object({
         path: z
           .string()
           .min(1)
           .describe("Relative path from vault root (e.g. 'folder/note.md')"),
-      },
+      }).strict(),
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -159,14 +159,14 @@ Args:
   - content (string): Full file content to write
 
 Returns: Confirmation with file path.`,
-      inputSchema: {
+      inputSchema: z.object({
         path: z
           .string()
           .min(1)
           .regex(/\.md$/, "Path must end with .md")
           .describe("Relative path from vault root, must end with .md"),
         content: z.string().min(1).describe("Full file content to write"),
-      },
+      }).strict(),
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -203,7 +203,7 @@ Args:
 
 Returns: Matching files with line numbers, context, and frontmatter metadata.
 Requires Obsidian integration to be enabled in Sparkle settings.`,
-      inputSchema: {
+      inputSchema: z.object({
         query: z.string().min(1).describe("Search term (case-insensitive)"),
         path: z
           .string()
@@ -216,7 +216,7 @@ Requires Obsidian integration to be enabled in Sparkle settings.`,
           .max(100)
           .default(20)
           .describe("Max files to return (default 20)"),
-      },
+      }).strict(),
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -251,7 +251,7 @@ Args:
 
 Returns: File list with sparkle_id, tags, and modified date from frontmatter.
 Requires Obsidian integration to be enabled in Sparkle settings.`,
-      inputSchema: {
+      inputSchema: z.object({
         path: z
           .string()
           .optional()
@@ -267,7 +267,7 @@ Requires Obsidian integration to be enabled in Sparkle settings.`,
           .max(200)
           .default(50)
           .describe("Max files to return (default 50)"),
-      },
+      }).strict(),
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,

--- a/mcp-server/src/tools/workflow.ts
+++ b/mcp-server/src/tools/workflow.ts
@@ -22,10 +22,10 @@ Args:
   - target_status (string, required): "developing" or "permanent"
 
 Returns: The updated note.`,
-      inputSchema: {
+      inputSchema: z.object({
         id: z.string().uuid().describe("Note UUID"),
         target_status: z.enum(["developing", "permanent"]).describe("Target maturity status"),
-      },
+      }).strict(),
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -83,9 +83,9 @@ Args:
   - id (string, required): Note UUID
 
 Returns: The file path where the note was written in the Obsidian vault.`,
-      inputSchema: {
+      inputSchema: z.object({
         id: z.string().uuid().describe("Note UUID"),
-      },
+      }).strict(),
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,

--- a/mcp-server/src/tools/write.ts
+++ b/mcp-server/src/tools/write.ts
@@ -25,7 +25,7 @@ Args:
   - category_id (string, optional): Category UUID to assign (null to clear)
 
 Returns: The created item with all fields including generated ID and timestamps.`,
-      inputSchema: {
+      inputSchema: z.object({
         title: z.string().min(1).max(500).describe("Note title"),
         content: z.string().max(50000).optional().describe("Note content (markdown)"),
         tags: z.array(z.string().max(50)).max(20).optional().describe("Tags"),
@@ -37,7 +37,7 @@ Returns: The created item with all fields including generated ID and timestamps.
         aliases: z.array(z.string().max(200)).max(10).optional().describe("Alternative names"),
         linked_note_id: z.string().uuid().optional().describe("UUID of linked note (todo only)"),
         category_id: z.string().uuid().nullable().optional().describe("Category UUID to assign (null to clear)"),
-      },
+      }).strict(),
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -96,7 +96,7 @@ Returns: The updated item with all fields.
 Content editing modes:
   - Full replace: provide only content — replaces the entire content field.
   - Partial edit: provide both old_content and content — finds old_content in the note and replaces it with content. Always use sparkle_get_note first to get the exact text for old_content. Set content to empty string to delete the matched section.`,
-      inputSchema: {
+      inputSchema: z.object({
         id: z.string().uuid().describe("Item UUID"),
         title: z.string().min(1).max(500).optional().describe("New title"),
         content: z.string().max(50000).optional().describe("New content (replaces existing)"),
@@ -110,7 +110,7 @@ Content editing modes:
         source: z.string().max(2000).nullable().optional().describe("Reference URL (null to clear)"),
         linked_note_id: z.string().uuid().nullable().optional().describe("Linked note UUID (todo only, null to clear)"),
         category_id: z.string().uuid().nullable().optional().describe("Category UUID (null to clear)"),
-      },
+      }).strict(),
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,


### PR DESCRIPTION
## Summary

- All 22 MCP tool `inputSchema` changed from raw shape `{ ... }` to `z.object({ ... }).strict()`
- Unknown parameters now trigger `"Unrecognized key: ..."` validation error instead of being silently stripped
- Prevents data loss when LLMs pass wrong parameter names (e.g. `old_string` instead of `old_content` causing full content overwrite)
- Added test verifying strict schema rejection behavior

Fixes DEF-025.

## Test plan

- [x] `npx tsc --noEmit` — type check pass
- [x] `npx vitest run` — 117 tests pass (including new strict schema test)
- [x] `npm run build` — dist rebuilt
- [ ] Manual: call `sparkle_update_note` with `old_string` param → expect validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)