### PR TITLE
fix(mcp): vault write frontmatter guard + update_note side-effect docs

### DIFF
--- a/mcp-server/src/__tests__/tools.test.ts
+++ b/mcp-server/src/__tests__/tools.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { z } from "zod";
 import { makeItem, makeMockServer } from "./helpers.js";
 
 // Mock client module
@@ -204,7 +203,9 @@ describe("sparkle_list_notes", () => {
       limit: 1,
       offset: 0,
     });
-    expect(result.content[0].text).toContain("Offset: 0 | Limit: 1 | Has more: yes | Next offset: 1");
+    expect(result.content[0].text).toContain(
+      "Offset: 0 | Limit: 1 | Has more: yes | Next offset: 1",
+    );
   });
 });
 
@@ -459,7 +460,9 @@ describe("sparkle_list_tags", () => {
 
 // --- Vault tools ---
 
-const makeVaultFile = (overrides: Partial<import("../types.js").VaultFile> = {}): import("../types.js").VaultFile => ({
+const makeVaultFile = (
+  overrides: Partial<import("../types.js").VaultFile> = {},
+): import("../types.js").VaultFile => ({
   path: "0_Inbox/Test Note.md",
   content: '---\nsparkle_id: "abc-123"\ntags:\n  - test\n---\n\n# Test Note\n\nBody here.',
   frontmatter: { sparkle_id: "abc-123", tags: ["test"] },
@@ -487,7 +490,9 @@ describe("sparkle_read_obsidian", () => {
 
   it("returns error when file not found", async () => {
     const handler = getHandler();
-    readVaultFileBySparkleId.mockRejectedValue(new Error("No vault file found with sparkle_id: xyz"));
+    readVaultFileBySparkleId.mockRejectedValue(
+      new Error("No vault file found with sparkle_id: xyz"),
+    );
 
     const result = await handler({ sparkle_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" });
     expect(result.isError).toBe(true);
@@ -677,22 +682,39 @@ describe("error handling", () => {
   });
 });
 
+// --- Source file regression guards ---
+
+const { readdirSync, readFileSync } = require("fs");
+const { join } = require("path");
+const toolsDir = join(__dirname, "../tools");
+
+function readToolSource(filename: string): string {
+  return readFileSync(join(toolsDir, filename), "utf-8");
+}
+
 describe("strict schema validation", () => {
-  it("z.object().strict() rejects unknown parameters", () => {
-    const schema = z
-      .object({
-        id: z.string(),
-        content: z.string().optional(),
-        old_content: z.string().optional(),
-      })
-      .strict();
+  it("all tool inputSchemas use z.object().strict(), not raw shapes", () => {
+    const toolFiles = readdirSync(toolsDir).filter((f: string) => f.endsWith(".ts"));
 
-    // Correct parameters should pass
-    const valid = schema.safeParse({ id: "test", content: "hi", old_content: "old" });
-    expect(valid.success).toBe(true);
+    for (const file of toolFiles) {
+      const content = readFileSync(join(toolsDir, file), "utf-8");
+      const rawShapes = content.match(/inputSchema:\s*\{/g);
+      expect(
+        rawShapes,
+        `${file} has raw inputSchema — must use z.object({...}).strict()`,
+      ).toBeNull();
+    }
+  });
+});
 
-    // Wrong parameter name (old_string instead of old_content) should be rejected
-    const invalid = schema.safeParse({ id: "test", content: "hi", old_string: "old" });
-    expect(invalid.success).toBe(false);
+describe("tool description completeness", () => {
+  it("sparkle_update_note description warns about type conversion field clearing", () => {
+    const content = readToolSource("write.ts");
+    expect(content).toMatch(/[Tt]ype change.*scratch.*clear/);
+  });
+
+  it("sparkle_update_note description warns about exported note auto-reversion", () => {
+    const content = readToolSource("write.ts");
+    expect(content).toMatch(/exported.*permanent/i);
   });
 });

--- a/mcp-server/src/__tests__/vault.test.ts
+++ b/mcp-server/src/__tests__/vault.test.ts
@@ -23,6 +23,7 @@ import {
   getVaultPath,
   findBySparkleId,
   readVaultFileByPath,
+  writeVaultFileBySparkleId,
   writeVaultFileByPath,
   searchVault,
   listVault,
@@ -271,6 +272,53 @@ describe("readVaultFileByPath", () => {
     mockReadFile.mockRejectedValue(enoent);
 
     await expect(readVaultFileByPath("nonexistent.md")).rejects.toThrow("File not found");
+  });
+});
+
+// --- writeVaultFileBySparkleId ---
+
+describe("writeVaultFileBySparkleId", () => {
+  const SPARKLE_ID = "cbe1a447-dd5a-405f-8959-f1bd8f699046";
+
+  function setupFindable() {
+    mockGetSettings.mockResolvedValue({
+      obsidian_enabled: "true",
+      obsidian_vault_path: "/vault",
+    });
+    // Seed the index so findBySparkleId resolves without walking the filesystem
+    mockReadFile.mockResolvedValue(
+      `---\nsparkle_id: "${SPARKLE_ID}"\n---\n\n# Old Content`,
+    );
+    // readdir for buildIndex
+    mockReaddir.mockResolvedValue([
+      { name: "note.md", isFile: () => true, isDirectory: () => false },
+    ] as never);
+  }
+
+  it("rejects content without sparkle_id in frontmatter", async () => {
+    setupFindable();
+    // Prime the index
+    await findBySparkleId(SPARKLE_ID);
+
+    await expect(
+      writeVaultFileBySparkleId(SPARKLE_ID, "# No frontmatter at all"),
+    ).rejects.toThrow("missing sparkle_id");
+
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("accepts content with matching sparkle_id in frontmatter", async () => {
+    setupFindable();
+    await findBySparkleId(SPARKLE_ID);
+    mockWriteFile.mockResolvedValue(undefined);
+
+    const result = await writeVaultFileBySparkleId(
+      SPARKLE_ID,
+      `---\nsparkle_id: "${SPARKLE_ID}"\n---\n\n# Updated`,
+    );
+
+    expect(mockWriteFile).toHaveBeenCalled();
+    expect(result).toBe("note.md");
   });
 });
 

--- a/mcp-server/src/tools/write.ts
+++ b/mcp-server/src/tools/write.ts
@@ -25,19 +25,39 @@ Args:
   - category_id (string, optional): Category UUID to assign (null to clear)
 
 Returns: The created item with all fields including generated ID and timestamps.`,
-      inputSchema: z.object({
-        title: z.string().min(1).max(500).describe("Note title"),
-        content: z.string().max(50000).optional().describe("Note content (markdown)"),
-        tags: z.array(z.string().max(50)).max(20).optional().describe("Tags"),
-        status: z.enum(["fleeting", "developing", "permanent", "active", "draft"]).optional().describe("Initial status (default: fleeting)"),
-        type: z.enum(["note", "todo", "scratch"]).optional().describe("Item type (default: note)"),
-        priority: z.enum(["high", "medium", "low"]).optional().describe("Priority level (todo only)"),
-        due: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().describe("Due date YYYY-MM-DD (todo only)"),
-        source: z.string().max(2000).optional().describe("Reference URL"),
-        aliases: z.array(z.string().max(200)).max(10).optional().describe("Alternative names"),
-        linked_note_id: z.string().uuid().optional().describe("UUID of linked note (todo only)"),
-        category_id: z.string().uuid().nullable().optional().describe("Category UUID to assign (null to clear)"),
-      }).strict(),
+      inputSchema: z
+        .object({
+          title: z.string().min(1).max(500).describe("Note title"),
+          content: z.string().max(50000).optional().describe("Note content (markdown)"),
+          tags: z.array(z.string().max(50)).max(20).optional().describe("Tags"),
+          status: z
+            .enum(["fleeting", "developing", "permanent", "active", "draft"])
+            .optional()
+            .describe("Initial status (default: fleeting)"),
+          type: z
+            .enum(["note", "todo", "scratch"])
+            .optional()
+            .describe("Item type (default: note)"),
+          priority: z
+            .enum(["high", "medium", "low"])
+            .optional()
+            .describe("Priority level (todo only)"),
+          due: z
+            .string()
+            .regex(/^\d{4}-\d{2}-\d{2}$/)
+            .optional()
+            .describe("Due date YYYY-MM-DD (todo only)"),
+          source: z.string().max(2000).optional().describe("Reference URL"),
+          aliases: z.array(z.string().max(200)).max(10).optional().describe("Alternative names"),
+          linked_note_id: z.string().uuid().optional().describe("UUID of linked note (todo only)"),
+          category_id: z
+            .string()
+            .uuid()
+            .nullable()
+            .optional()
+            .describe("Category UUID to assign (null to clear)"),
+        })
+        .strict(),
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -45,7 +65,19 @@ Returns: The created item with all fields including generated ID and timestamps.
         openWorldHint: false,
       },
     },
-    async ({ title, content, tags, status, type, priority, due, source, aliases, linked_note_id, category_id }) => {
+    async ({
+      title,
+      content,
+      tags,
+      status,
+      type,
+      priority,
+      due,
+      source,
+      aliases,
+      linked_note_id,
+      category_id,
+    }) => {
       try {
         const item = await createItem({
           title,
@@ -95,22 +127,77 @@ Returns: The updated item with all fields.
 
 Content editing modes:
   - Full replace: provide only content — replaces the entire content field.
-  - Partial edit: provide both old_content and content — finds old_content in the note and replaces it with content. Always use sparkle_get_note first to get the exact text for old_content. Set content to empty string to delete the matched section.`,
-      inputSchema: z.object({
-        id: z.string().uuid().describe("Item UUID"),
-        title: z.string().min(1).max(500).optional().describe("New title"),
-        content: z.string().max(50000).optional().describe("New content (replaces existing)"),
-        old_content: z.string().min(1).max(50000).optional().describe("Find-and-replace: text to find in existing content (use with content)"),
-        tags: z.array(z.string().max(50)).max(20).optional().describe("New tags (replaces all)"),
-        status: z.enum(["fleeting", "developing", "permanent", "exported", "active", "done", "draft", "archived"]).optional().describe("New status"),
-        type: z.enum(["note", "todo", "scratch"]).optional().describe("Change item type (status auto-maps)"),
-        priority: z.enum(["high", "medium", "low"]).nullable().optional().describe("Priority (todo only, null to clear)"),
-        due: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullable().optional().describe("Due date YYYY-MM-DD (todo only, null to clear)"),
-        aliases: z.array(z.string().max(200)).max(10).optional().describe("New aliases (replaces all)"),
-        source: z.string().max(2000).nullable().optional().describe("Reference URL (null to clear)"),
-        linked_note_id: z.string().uuid().nullable().optional().describe("Linked note UUID (todo only, null to clear)"),
-        category_id: z.string().uuid().nullable().optional().describe("Category UUID (null to clear)"),
-      }).strict(),
+  - Partial edit: provide both old_content and content — finds old_content in the note and replaces it with content. Always use sparkle_get_note first to get the exact text for old_content. Set content to empty string to delete the matched section.
+
+Side effects:
+  - Type change to note: clears linked_note_id and due (not supported on notes).
+  - Type change to scratch: clears tags, priority, due, aliases, linked_note_id (scratch only keeps title + content). category_id is preserved.
+  - Editing an exported note's title or content automatically reverts status to "permanent".`,
+      inputSchema: z
+        .object({
+          id: z.string().uuid().describe("Item UUID"),
+          title: z.string().min(1).max(500).optional().describe("New title"),
+          content: z.string().max(50000).optional().describe("New content (replaces existing)"),
+          old_content: z
+            .string()
+            .min(1)
+            .max(50000)
+            .optional()
+            .describe("Find-and-replace: text to find in existing content (use with content)"),
+          tags: z.array(z.string().max(50)).max(20).optional().describe("New tags (replaces all)"),
+          status: z
+            .enum([
+              "fleeting",
+              "developing",
+              "permanent",
+              "exported",
+              "active",
+              "done",
+              "draft",
+              "archived",
+            ])
+            .optional()
+            .describe("New status"),
+          type: z
+            .enum(["note", "todo", "scratch"])
+            .optional()
+            .describe("Change item type (status auto-maps)"),
+          priority: z
+            .enum(["high", "medium", "low"])
+            .nullable()
+            .optional()
+            .describe("Priority (todo only, null to clear)"),
+          due: z
+            .string()
+            .regex(/^\d{4}-\d{2}-\d{2}$/)
+            .nullable()
+            .optional()
+            .describe("Due date YYYY-MM-DD (todo only, null to clear)"),
+          aliases: z
+            .array(z.string().max(200))
+            .max(10)
+            .optional()
+            .describe("New aliases (replaces all)"),
+          source: z
+            .string()
+            .max(2000)
+            .nullable()
+            .optional()
+            .describe("Reference URL (null to clear)"),
+          linked_note_id: z
+            .string()
+            .uuid()
+            .nullable()
+            .optional()
+            .describe("Linked note UUID (todo only, null to clear)"),
+          category_id: z
+            .string()
+            .uuid()
+            .nullable()
+            .optional()
+            .describe("Category UUID (null to clear)"),
+        })
+        .strict(),
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -118,12 +205,28 @@ Content editing modes:
         openWorldHint: false,
       },
     },
-    async ({ id, title, content, old_content, tags, status, type, priority, due, aliases, source, linked_note_id, category_id }) => {
+    async ({
+      id,
+      title,
+      content,
+      old_content,
+      tags,
+      status,
+      type,
+      priority,
+      due,
+      aliases,
+      source,
+      linked_note_id,
+      category_id,
+    }) => {
       try {
         // Find-and-replace mode: old_content + content
         if (old_content !== undefined && content === undefined) {
           return {
-            content: [{ type: "text", text: "Error: content is required when old_content is provided." }],
+            content: [
+              { type: "text", text: "Error: content is required when old_content is provided." },
+            ],
             isError: true,
           };
         }
@@ -135,13 +238,23 @@ Content editing modes:
           if (matchCount === 0) {
             const preview = current.content.slice(0, 200);
             return {
-              content: [{ type: "text", text: `NO_MATCH: The specified old_content was not found in the note.\nCurrent content (first 200 chars): ${preview}` }],
+              content: [
+                {
+                  type: "text",
+                  text: `NO_MATCH: The specified old_content was not found in the note.\nCurrent content (first 200 chars): ${preview}`,
+                },
+              ],
               isError: true,
             };
           }
           if (matchCount > 1) {
             return {
-              content: [{ type: "text", text: `AMBIGUOUS_MATCH: old_content was found ${matchCount} times. Provide more surrounding context to uniquely identify the section to replace.` }],
+              content: [
+                {
+                  type: "text",
+                  text: `AMBIGUOUS_MATCH: old_content was found ${matchCount} times. Provide more surrounding context to uniquely identify the section to replace.`,
+                },
+              ],
               isError: true,
             };
           }

--- a/mcp-server/src/vault.ts
+++ b/mcp-server/src/vault.ts
@@ -23,14 +23,10 @@ export async function getVaultPath(): Promise<string> {
   }
   const settings = await getSettings();
   if (settings.obsidian_enabled !== "true") {
-    throw new Error(
-      "Obsidian integration is not enabled. Configure it in Sparkle settings.",
-    );
+    throw new Error("Obsidian integration is not enabled. Configure it in Sparkle settings.");
   }
   if (!settings.obsidian_vault_path) {
-    throw new Error(
-      "Obsidian vault path is not configured. Set it in Sparkle settings.",
-    );
+    throw new Error("Obsidian vault path is not configured. Set it in Sparkle settings.");
   }
   cachedVaultPath = settings.obsidian_vault_path;
   cacheTimestamp = now;
@@ -233,10 +229,16 @@ export async function writeVaultFileBySparkleId(
   if (!result) {
     throw new Error(`No vault file found with sparkle_id: ${sparkleId}`);
   }
+  // Validate sparkle_id preserved in frontmatter before writing
+  const fm = parseFrontmatter(content);
+  if (!fm.sparkle_id) {
+    throw new Error(
+      `Content is missing sparkle_id in frontmatter. Include "sparkle_id: ${sparkleId}" in YAML frontmatter to preserve tracking.`,
+    );
+  }
   await writeFile(result.path, content, "utf-8");
   // Update index if sparkle_id changed
-  const fm = parseFrontmatter(content);
-  if (fm.sparkle_id && fm.sparkle_id !== sparkleId) {
+  if (fm.sparkle_id !== sparkleId) {
     sparkleIdIndex.delete(sparkleId);
     sparkleIdIndex.set(fm.sparkle_id, result.path);
   }
@@ -244,10 +246,7 @@ export async function writeVaultFileBySparkleId(
   return relative(vaultRoot, result.path);
 }
 
-export async function writeVaultFileByPath(
-  relativePath: string,
-  content: string,
-): Promise<string> {
+export async function writeVaultFileByPath(relativePath: string, content: string): Promise<string> {
   const vaultRoot = await getVaultPath();
   const absPath = resolveVaultPath(vaultRoot, relativePath);
   // Create parent directories if needed
@@ -271,9 +270,7 @@ export async function searchVault(
   options?: { path?: string; limit?: number },
 ): Promise<VaultSearchResult[]> {
   const vaultRoot = await getVaultPath();
-  const searchRoot = options?.path
-    ? resolveVaultPath(vaultRoot, options.path)
-    : vaultRoot;
+  const searchRoot = options?.path ? resolveVaultPath(vaultRoot, options.path) : vaultRoot;
   const limit = options?.limit ?? 20;
   const queryLower = query.toLowerCase();
 
@@ -317,13 +314,13 @@ export async function searchVault(
   return results;
 }
 
-export async function listVault(
-  options?: { path?: string; recursive?: boolean; limit?: number },
-): Promise<VaultListResult> {
+export async function listVault(options?: {
+  path?: string;
+  recursive?: boolean;
+  limit?: number;
+}): Promise<VaultListResult> {
   const vaultRoot = await getVaultPath();
-  const listRoot = options?.path
-    ? resolveVaultPath(vaultRoot, options.path)
-    : vaultRoot;
+  const listRoot = options?.path ? resolveVaultPath(vaultRoot, options.path) : vaultRoot;
   const recursive = options?.recursive ?? true;
   const limit = options?.limit ?? 50;
 


### PR DESCRIPTION
## Summary

- **DEF-026**: `writeVaultFileBySparkleId` now validates sparkle_id exists in frontmatter before writing — prevents orphaned files after server restart
- **FG-008**: `sparkle_update_note` description now documents type conversion field clearing + exported note auto-reversion side effects
- Replace inline Zod strict test with file-scanning regression guard + description completeness tests

## Test plan

- [x] `npx vitest run` — 121 tests pass (4 new: 2 vault write, 1 schema guard, 2 description completeness)
- [x] `npx tsc --noEmit` — type check pass
- [x] `npm run build` — dist rebuilt
- [ ] Manual: call `sparkle_write_obsidian` without frontmatter → expect validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)