### PR TITLE
fix(line-bot): add user allowlist to restrict LINE Bot access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ AUTH_TOKEN=your-secret-token-here
 # LINE Bot (optional — omit to disable LINE integration)
 # LINE_CHANNEL_SECRET=from-line-developer-console
 # LINE_CHANNEL_ACCESS_TOKEN=from-line-developer-console
+# LINE user allowlist — comma-separated user IDs (strongly recommended)
+# Only these users can interact with the bot. Get userId from webhook logs.
+# LINE_ALLOWED_USER_IDS=Uxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # LINE admin notifications — used by monitoring scripts (optional)
 # Get your userId from LINE Developer Console or webhook logs

--- a/server/index.ts
+++ b/server/index.ts
@@ -94,6 +94,9 @@ if (lineSecret || lineToken) {
       lineToken.length,
     );
   }
+  if (!process.env.LINE_ALLOWED_USER_IDS) {
+    logger.warn("LINE_ALLOWED_USER_IDS is not set — LINE bot accepts messages from any user");
+  }
 }
 
 const app = new Hono();

--- a/server/routes/__tests__/webhook.test.ts
+++ b/server/routes/__tests__/webhook.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, beforeAll, vi } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll, afterEach, vi } from "vitest";
 import crypto from "node:crypto";
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -1572,6 +1572,62 @@ describe("POST /api/webhook/line", () => {
       const fetchMock = vi.mocked(fetch);
       const callBody = JSON.parse(fetchMock.mock.calls[0][1]!.body as string);
       expect(callBody.messages[0].text).toContain("不存在");
+    });
+  });
+
+  // ============================================================
+  // User allowlist tests
+  // ============================================================
+
+  describe("LINE_ALLOWED_USER_IDS allowlist", () => {
+    afterEach(() => {
+      delete process.env.LINE_ALLOWED_USER_IDS;
+    });
+
+    it("blocks unauthorized user when allowlist is set", async () => {
+      process.env.LINE_CHANNEL_SECRET = TEST_LINE_SECRET;
+      process.env.LINE_CHANNEL_ACCESS_TOKEN = TEST_LINE_ACCESS_TOKEN;
+      process.env.LINE_ALLOWED_USER_IDS = "allowed-user-1,allowed-user-2";
+
+      const res = await sendLineMessage(app, "Hello", "unauthorized-user");
+      expect(res.status).toBe(200);
+
+      // Should NOT create any items
+      const allItems = testDb.select().from(items).all();
+      expect(allItems).toHaveLength(0);
+
+      // Should reply with rejection message
+      const fetchMock = vi.mocked(fetch);
+      expect(fetchMock).toHaveBeenCalled();
+      const callBody = JSON.parse(fetchMock.mock.calls[0][1]!.body as string);
+      expect(callBody.messages[0].text).toContain("未授權");
+    });
+
+    it("allows authorized user when allowlist is set", async () => {
+      process.env.LINE_CHANNEL_SECRET = TEST_LINE_SECRET;
+      process.env.LINE_CHANNEL_ACCESS_TOKEN = TEST_LINE_ACCESS_TOKEN;
+      process.env.LINE_ALLOWED_USER_IDS = "allowed-user-1,allowed-user-2";
+
+      const res = await sendLineMessage(app, "Buy milk", "allowed-user-1");
+      expect(res.status).toBe(200);
+
+      // Item should be created
+      const allItems = testDb.select().from(items).all();
+      expect(allItems).toHaveLength(1);
+      expect(allItems[0].title).toBe("Buy milk");
+    });
+
+    it("allows any user when allowlist is not set", async () => {
+      process.env.LINE_CHANNEL_SECRET = TEST_LINE_SECRET;
+      process.env.LINE_CHANNEL_ACCESS_TOKEN = TEST_LINE_ACCESS_TOKEN;
+      delete process.env.LINE_ALLOWED_USER_IDS;
+
+      const res = await sendLineMessage(app, "Buy milk", "any-random-user");
+      expect(res.status).toBe(200);
+
+      const allItems = testDb.select().from(items).all();
+      expect(allItems).toHaveLength(1);
+      expect(allItems[0].title).toBe("Buy milk");
     });
   });
 });

--- a/server/routes/webhook.ts
+++ b/server/routes/webhook.ts
@@ -21,6 +21,10 @@ const lineWebhookSchema = z.object({
 
 export const webhookRouter = new Hono();
 
+function getAllowedUserIds(): string[] {
+  return process.env.LINE_ALLOWED_USER_IDS?.split(",").filter(Boolean) ?? [];
+}
+
 function verifySignature(body: string, signature: string, secret: string): boolean {
   const hash = crypto.createHmac("SHA256", secret).update(body).digest("base64");
   return safeCompare(hash, signature);
@@ -50,6 +54,7 @@ webhookRouter.post("/line", async (c) => {
     return c.json({ error: "Invalid JSON body" }, 400);
   }
   const events = parsed.events;
+  const allowedUserIds = getAllowedUserIds();
 
   for (const event of events) {
     if (event.type !== "message" || event.message?.type !== "text") {
@@ -62,6 +67,15 @@ webhookRouter.post("/line", async (c) => {
     if (!event.message?.text) continue;
     const text: string = event.message.text;
     const userId: string = event.source?.userId ?? "unknown";
+
+    if (allowedUserIds.length > 0 && !allowedUserIds.includes(userId)) {
+      logger.warn({ userId }, "LINE message from unauthorized user");
+      if (event.replyToken) {
+        await replyLine(channelToken, event.replyToken, "⛔ 未授權的使用者");
+      }
+      continue;
+    }
+
     const cmd = parseCommand(text);
 
     if (!event.replyToken) continue;


### PR DESCRIPTION
## Summary

- Add `LINE_ALLOWED_USER_IDS` env var to restrict which LINE users can interact with the bot
- Unauthorized users receive a rejection reply (`⛔ 未授權的使用者`) and are logged
- Startup warning when LINE is configured but allowlist is not set
- Backward compatible: empty allowlist preserves existing open-access behavior

## Test plan

- [x] Unit tests: 3 new cases (block unauthorized / allow authorized / empty allowlist)
- [x] All 84 webhook tests pass
- [x] Lint + type check clean
- [ ] Deploy: set `LINE_ALLOWED_USER_IDS` in `.env` with admin userId
- [ ] Verify: send LINE message from allowed account → works
- [ ] Verify: check server logs for startup warning when unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)