### PR TITLE
feat(db): add viewed_at column and dashboard settings (migration 14)

### DIFF
--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -8,7 +8,7 @@ import { logger } from "../lib/logger.js";
 
 const DB_PATH = process.env.DATABASE_URL || "./data/todo.db";
 
-const TARGET_VERSION = 13;
+const TARGET_VERSION = 14;
 
 function getSchemaVersion(sqlite: Database.Database): number {
   // Check if schema_version table exists
@@ -271,6 +271,30 @@ function runMigrations(sqlite: Database.Database) {
 
     setSchemaVersion(sqlite, 13);
   }
+
+  // Step 13→14: Add viewed_at column + dashboard settings
+  if (version < 14) {
+    try {
+      sqlite.exec("ALTER TABLE items ADD COLUMN viewed_at TEXT DEFAULT NULL");
+    } catch (e: unknown) {
+      const msg = (e as Error).message || "";
+      if (!msg.includes("duplicate column")) throw e;
+    }
+
+    sqlite.exec("CREATE INDEX IF NOT EXISTS idx_items_viewed_at ON items(viewed_at)");
+    sqlite.exec("CREATE INDEX IF NOT EXISTS idx_items_status_modified ON items(status, modified)");
+
+    // Mark all existing items as viewed (start with clean inbox)
+    sqlite.exec("UPDATE items SET viewed_at = created WHERE viewed_at IS NULL");
+
+    // Dashboard settings
+    sqlite.exec(`
+      INSERT OR IGNORE INTO settings (key, value) VALUES ('recent_days', '7');
+      INSERT OR IGNORE INTO settings (key, value) VALUES ('stale_days', '14');
+    `);
+
+    setSchemaVersion(sqlite, 14);
+  }
 }
 
 function createDb() {
@@ -305,6 +329,7 @@ function createDb() {
         aliases TEXT NOT NULL DEFAULT '[]',
         linked_note_id TEXT DEFAULT NULL,
         category_id TEXT DEFAULT NULL,
+        viewed_at TEXT DEFAULT NULL,
         created TEXT NOT NULL,
         modified TEXT NOT NULL,
         FOREIGN KEY (linked_note_id) REFERENCES items(id) ON DELETE SET NULL,
@@ -314,6 +339,8 @@ function createDb() {
       CREATE INDEX idx_items_status ON items(status);
       CREATE INDEX idx_items_type ON items(type);
       CREATE INDEX idx_items_created ON items(created DESC);
+      CREATE INDEX idx_items_viewed_at ON items(viewed_at);
+      CREATE INDEX idx_items_status_modified ON items(status, modified);
 
       CREATE TABLE settings (
         key TEXT PRIMARY KEY,
@@ -323,7 +350,9 @@ function createDb() {
         ('obsidian_enabled', 'false'),
         ('obsidian_vault_path', ''),
         ('obsidian_inbox_folder', '0_Inbox'),
-        ('obsidian_export_mode', 'overwrite');
+        ('obsidian_export_mode', 'overwrite'),
+        ('recent_days', '7'),
+        ('stale_days', '14');
 
       CREATE TABLE share_tokens (
         id TEXT PRIMARY KEY,

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -31,6 +31,7 @@ export const items = sqliteTable(
     aliases: text("aliases").notNull().default("[]"),
     linked_note_id: text("linked_note_id"),
     category_id: text("category_id"),
+    viewed_at: text("viewed_at"),
     created: text("created").notNull(),
     modified: text("modified").notNull(),
   },
@@ -39,6 +40,8 @@ export const items = sqliteTable(
     index("idx_items_type").on(table.type),
     index("idx_items_created").on(table.created),
     index("idx_items_category_id").on(table.category_id),
+    index("idx_items_viewed_at").on(table.viewed_at),
+    index("idx_items_status_modified").on(table.status, table.modified),
   ],
 );
 

--- a/server/lib/__tests__/settings.test.ts
+++ b/server/lib/__tests__/settings.test.ts
@@ -39,6 +39,8 @@ describe("Settings", () => {
         obsidian_vault_path: "",
         obsidian_inbox_folder: "0_Inbox",
         obsidian_export_mode: "overwrite",
+        recent_days: "7",
+        stale_days: "14",
       });
     });
 

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -46,6 +46,22 @@ export function getObsidianSettings(sqlite: Database.Database): ObsidianSettings
   };
 }
 
+export interface DashboardSettings {
+  recentDays: number;
+  staleDays: number;
+}
+
+/**
+ * Get dashboard-specific settings with typed conversions.
+ */
+export function getDashboardSettings(sqlite: Database.Database): DashboardSettings {
+  const all = getSettings(sqlite);
+  return {
+    recentDays: parseInt(all.recent_days ?? "7", 10) || 7,
+    staleDays: parseInt(all.stale_days ?? "14", 10) || 14,
+  };
+}
+
 /**
  * Update one or more settings. Uses upsert (INSERT OR REPLACE).
  */

--- a/server/routes/__tests__/api.test.ts
+++ b/server/routes/__tests__/api.test.ts
@@ -1716,6 +1716,8 @@ describe("GET /api/settings", () => {
       obsidian_vault_path: "",
       obsidian_inbox_folder: "0_Inbox",
       obsidian_export_mode: "overwrite",
+      recent_days: "7",
+      stale_days: "14",
     });
   });
 });

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -11,6 +11,8 @@ const ALLOWED_KEYS = [
   "obsidian_vault_path",
   "obsidian_inbox_folder",
   "obsidian_export_mode",
+  "recent_days",
+  "stale_days",
 ] as const;
 
 const updateSettingsSchema = z
@@ -43,6 +45,18 @@ const updateSettingsSchema = z
       return true;
     },
     { message: 'obsidian_export_mode must be "overwrite" or "new"' },
+  )
+  .refine(
+    (obj) => {
+      for (const key of ["recent_days", "stale_days"] as const) {
+        if (key in obj) {
+          const n = parseInt(obj[key] ?? "", 10);
+          if (isNaN(n) || n < 1 || n > 365) return false;
+        }
+      }
+      return true;
+    },
+    { message: "recent_days and stale_days must be integers between 1 and 365" },
   );
 
 // GET /api/settings — return all settings

--- a/server/test-utils.ts
+++ b/server/test-utils.ts
@@ -23,6 +23,7 @@ export function createTestDb() {
       aliases TEXT NOT NULL DEFAULT '[]',
       linked_note_id TEXT DEFAULT NULL,
       category_id TEXT DEFAULT NULL,
+      viewed_at TEXT DEFAULT NULL,
       created TEXT NOT NULL,
       modified TEXT NOT NULL,
       FOREIGN KEY (linked_note_id) REFERENCES items(id) ON DELETE SET NULL,
@@ -40,7 +41,9 @@ export function createTestDb() {
       ('obsidian_enabled', 'false'),
       ('obsidian_vault_path', ''),
       ('obsidian_inbox_folder', '0_Inbox'),
-      ('obsidian_export_mode', 'overwrite');
+      ('obsidian_export_mode', 'overwrite'),
+      ('recent_days', '7'),
+      ('stale_days', '14');
 
     CREATE TABLE share_tokens (
       id TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- Add `viewed_at` TEXT column to `items` table (migration 13→14) to track when items are first opened in the app
- Mark all existing items as viewed (`viewed_at = created`) to start with a clean "unreviewed" inbox
- Add `recent_days` (default 7) and `stale_days` (default 14) to settings table for configurable dashboard thresholds
- Add `getDashboardSettings()` helper with typed conversions
- Add settings validation: `recent_days` and `stale_days` must be integers between 1 and 365
- Add `idx_items_viewed_at` and `idx_items_status_modified` composite indexes for query performance

## Context
Part of Dashboard redesign (#PR1 of 5). This migration enables the "unreviewed inbox" feature where items created via MCP/LINE Bot start with `viewed_at = NULL` and get marked as viewed when opened in the app.

## Test plan
- [x] All 931 unit tests pass
- [x] Type check passes (server)
- [ ] Deploy and verify `PRAGMA table_info(items)` includes `viewed_at`
- [ ] Verify `SELECT * FROM settings` includes `recent_days` and `stale_days`
- [ ] Health check passes after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)