### PR TITLE
feat(api): add dashboard endpoints and viewed_at tracking

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -24,6 +24,7 @@ import { webhookRouter } from "./routes/webhook.js";
 import { settingsRouter } from "./routes/settings.js";
 import { sharesRouter } from "./routes/shares.js";
 import { categoriesRouter } from "./routes/categories.js";
+import { dashboardRouter } from "./routes/dashboard.js";
 import { publicRouter } from "./routes/public.js";
 import { db, sqlite, DB_PATH } from "./db/index.js";
 import { items } from "./db/schema.js";
@@ -171,6 +172,7 @@ app.route("/api/stats", statsRouter);
 app.route("/api/webhook", webhookRouter);
 app.route("/api/settings", settingsRouter);
 app.route("/api/categories", categoriesRouter);
+app.route("/api/dashboard", dashboardRouter);
 app.route("/api", sharesRouter);
 
 // Health check endpoint (unauthenticated — skipped in auth middleware)

--- a/server/lib/items.ts
+++ b/server/lib/items.ts
@@ -30,6 +30,7 @@ export function createItem(db: DB, input: Partial<CreateItemInput> & { title: st
     aliases: type === "scratch" ? "[]" : JSON.stringify(input.aliases ?? []),
     linked_note_id: type === "todo" ? (input.linked_note_id ?? null) : null,
     category_id: input.category_id ?? null,
+    viewed_at: !input.origin || input.origin === "app" ? now : null,
     created: now,
     modified: now,
   };
@@ -183,6 +184,7 @@ export function updateItem(db: DB, id: string, input: UpdateItemInput) {
   if (input.aliases !== undefined) updates.aliases = JSON.stringify(input.aliases);
   if (input.linked_note_id !== undefined) updates.linked_note_id = input.linked_note_id;
   if (input.category_id !== undefined) updates.category_id = input.category_id;
+  if (input.viewed_at !== undefined) updates.viewed_at = input.viewed_at;
 
   // Type conversion auto-mapping (Section 9)
   if (input.type !== undefined && input.type !== existing.type) {

--- a/server/lib/stats.ts
+++ b/server/lib/stats.ts
@@ -88,6 +88,26 @@ export function getStats(sqlite: Database.Database): Stats {
   return row;
 }
 
+export interface DashboardItem {
+  id: string;
+  type: string;
+  title: string;
+  status: string;
+  priority: string | null;
+  due: string | null;
+  tags: string;
+  origin: string;
+  category_id: string | null;
+  category_name: string | null;
+  created: string;
+  modified: string;
+  viewed_at: string | null;
+}
+
+export interface AttentionItem extends DashboardItem {
+  attention_reason: "overdue" | "high_priority";
+}
+
 export interface StaleItem {
   id: string;
   title: string;
@@ -96,19 +116,124 @@ export interface StaleItem {
   days_stale: number;
 }
 
-export function getStaleNotes(sqlite: Database.Database): StaleItem[] {
-  return sqlite
+export function getStaleNotes(
+  sqlite: Database.Database,
+  days = 7,
+  limit = 10,
+): { items: StaleItem[]; total: number } {
+  const items = sqlite
     .prepare(
       `SELECT i.id, i.title, c.name AS category_name, i.modified,
         CAST(julianday('now') - julianday(i.modified) AS INTEGER) AS days_stale
        FROM items i
        LEFT JOIN categories c ON i.category_id = c.id
        WHERE i.status = 'developing'
-         AND i.modified < datetime('now', '-7 days')
+         AND i.modified < datetime('now', '-' || ? || ' days')
        ORDER BY i.modified ASC
-       LIMIT 10`,
+       LIMIT ?`,
     )
-    .all() as StaleItem[];
+    .all(days, limit) as StaleItem[];
+
+  const countRow = sqlite
+    .prepare(
+      `SELECT COUNT(*) AS count
+       FROM items i
+       WHERE i.status = 'developing'
+         AND i.modified < datetime('now', '-' || ? || ' days')`,
+    )
+    .get(days) as { count: number };
+
+  return { items, total: countRow.count };
+}
+
+export function getUnreviewedItems(
+  sqlite: Database.Database,
+  limit = 5,
+  offset = 0,
+): { items: DashboardItem[]; total: number } {
+  const items = sqlite
+    .prepare(
+      `SELECT i.*, c.name AS category_name
+       FROM items i
+       LEFT JOIN categories c ON i.category_id = c.id
+       WHERE i.viewed_at IS NULL
+         AND i.status NOT IN ('archived', 'done')
+       ORDER BY i.created DESC
+       LIMIT ? OFFSET ?`,
+    )
+    .all(limit, offset) as DashboardItem[];
+
+  const countRow = sqlite
+    .prepare(
+      `SELECT COUNT(*) AS count
+       FROM items i
+       WHERE i.viewed_at IS NULL
+         AND i.status NOT IN ('archived', 'done')`,
+    )
+    .get() as { count: number };
+
+  return { items, total: countRow.count };
+}
+
+export function getRecentItems(
+  sqlite: Database.Database,
+  days: number,
+  limit = 5,
+  offset = 0,
+): { items: DashboardItem[]; total: number } {
+  const items = sqlite
+    .prepare(
+      `SELECT i.*, c.name AS category_name
+       FROM items i
+       LEFT JOIN categories c ON i.category_id = c.id
+       WHERE i.created >= datetime('now', '-' || ? || ' days')
+         AND i.status != 'archived'
+       ORDER BY i.created DESC
+       LIMIT ? OFFSET ?`,
+    )
+    .all(days, limit, offset) as DashboardItem[];
+
+  const countRow = sqlite
+    .prepare(
+      `SELECT COUNT(*) AS count
+       FROM items i
+       WHERE i.created >= datetime('now', '-' || ? || ' days')
+         AND i.status != 'archived'`,
+    )
+    .get(days) as { count: number };
+
+  return { items, total: countRow.count };
+}
+
+export function getAttentionItems(
+  sqlite: Database.Database,
+  limit = 5,
+): { items: AttentionItem[]; total: number } {
+  const today = getTodayDate();
+
+  const items = sqlite
+    .prepare(
+      `SELECT i.*, c.name AS category_name,
+        CASE WHEN i.type = 'todo' AND i.due < :today THEN 'overdue' ELSE 'high_priority' END AS attention_reason
+       FROM items i
+       LEFT JOIN categories c ON i.category_id = c.id
+       WHERE i.status NOT IN ('done', 'archived') AND i.type != 'scratch'
+         AND ((i.type = 'todo' AND i.due < :today) OR i.priority = 'high')
+       ORDER BY attention_reason ASC, i.due ASC, i.created DESC
+       LIMIT :limit`,
+    )
+    .all({ today, limit }) as AttentionItem[];
+
+  const countRow = sqlite
+    .prepare(
+      `SELECT COUNT(*) AS count
+       FROM items i
+       WHERE i.status NOT IN ('done', 'archived') AND i.type != 'scratch'
+         AND ((i.type = 'todo' AND i.due < :today) OR i.priority = 'high')`,
+    )
+    .get({ today }) as { count: number };
+
+  return { items, total: countRow.count };
 }
 
 export interface CategoryDistribution {

--- a/server/routes/dashboard.ts
+++ b/server/routes/dashboard.ts
@@ -1,0 +1,45 @@
+import { Hono } from "hono";
+import { sqlite } from "../db/index.js";
+import { getDashboardSettings } from "../lib/settings.js";
+import {
+  getUnreviewedItems,
+  getRecentItems,
+  getAttentionItems,
+  getStaleNotes,
+} from "../lib/stats.js";
+
+const dashboardRouter = new Hono();
+
+// GET /api/dashboard/unreviewed
+dashboardRouter.get("/unreviewed", (c) => {
+  const limit = Math.min(Math.max(parseInt(c.req.query("limit") ?? "5", 10) || 5, 1), 100);
+  const offset = Math.max(parseInt(c.req.query("offset") ?? "0", 10) || 0, 0);
+  const result = getUnreviewedItems(sqlite, limit, offset);
+  return c.json(result);
+});
+
+// GET /api/dashboard/recent
+dashboardRouter.get("/recent", (c) => {
+  const { recentDays } = getDashboardSettings(sqlite);
+  const limit = Math.min(Math.max(parseInt(c.req.query("limit") ?? "5", 10) || 5, 1), 100);
+  const offset = Math.max(parseInt(c.req.query("offset") ?? "0", 10) || 0, 0);
+  const result = getRecentItems(sqlite, recentDays, limit, offset);
+  return c.json(result);
+});
+
+// GET /api/dashboard/attention
+dashboardRouter.get("/attention", (c) => {
+  const limit = Math.min(Math.max(parseInt(c.req.query("limit") ?? "5", 10) || 5, 1), 100);
+  const result = getAttentionItems(sqlite, limit);
+  return c.json(result);
+});
+
+// GET /api/dashboard/stale
+dashboardRouter.get("/stale", (c) => {
+  const { staleDays } = getDashboardSettings(sqlite);
+  const limit = Math.min(Math.max(parseInt(c.req.query("limit") ?? "10", 10) || 10, 1), 100);
+  const result = getStaleNotes(sqlite, staleDays, limit);
+  return c.json(result);
+});
+
+export { dashboardRouter };

--- a/server/routes/stats.ts
+++ b/server/routes/stats.ts
@@ -10,8 +10,8 @@ statsRouter.get("/", (c) => {
 });
 
 statsRouter.get("/stale", (c) => {
-  const items = getStaleNotes(sqlite);
-  return c.json({ items });
+  const result = getStaleNotes(sqlite);
+  return c.json(result);
 });
 
 statsRouter.get("/category-distribution", (c) => {

--- a/server/schemas/items.ts
+++ b/server/schemas/items.ts
@@ -53,6 +53,7 @@ export const updateItemSchema = z.object({
   aliases: z.array(z.string().max(200)).max(10).optional(),
   linked_note_id: z.string().uuid().nullable().optional(),
   category_id: z.string().uuid().nullable().optional(),
+  viewed_at: z.string().nullable().optional(),
 });
 
 export const listItemsSchema = z.object({


### PR DESCRIPTION
## Summary
- Add 4 new dashboard API endpoints (`/api/dashboard/unreviewed`, `/recent`, `/attention`, `/stale`)
- `createItem` auto-sets `viewed_at` based on origin — app-created items marked as viewed, MCP/LINE items start as unreviewed
- `updateItem` supports `viewed_at` field for marking items as viewed when opened in detail panel
- `getStaleNotes` now accepts configurable `days` and `limit` params (backward compatible, old API unchanged)

## Context
PR 2 of 5 in Dashboard redesign. Depends on #169 (migration 14, already merged).

## Test plan
- [x] All 931 unit tests pass
- [x] Type check passes (client + server)
- [ ] `curl /api/dashboard/unreviewed` returns `{ items: [], total: 0 }` (all existing items marked viewed)
- [ ] Create item via MCP → appears in `/api/dashboard/unreviewed`
- [ ] Create item via app → does NOT appear in `/api/dashboard/unreviewed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)