### PR TITLE
feat(mcp): add dashboard query tools and set origin on create

### DIFF
--- a/mcp-server/src/client.ts
+++ b/mcp-server/src/client.ts
@@ -116,7 +116,7 @@ export async function createItem(input: {
   linked_note_id?: string | null;
   category_id?: string | null;
 }): Promise<SparkleItem> {
-  return sparkleApi<SparkleItem>("/items", "POST", { type: "note", ...input });
+  return sparkleApi<SparkleItem>("/items", "POST", { type: "note", origin: "mcp", ...input });
 }
 
 export async function updateItem(
@@ -166,6 +166,57 @@ export async function reorderCategoriesApi(
   items: { id: string; sort_order: number }[],
 ): Promise<{ ok: boolean }> {
   return sparkleApi<{ ok: boolean }>("/categories/reorder", "PATCH", { items });
+}
+
+// --- Dashboard operations ---
+
+export async function getUnreviewed(
+  limit = 20,
+  offset = 0,
+): Promise<{ items: SparkleItem[]; total: number }> {
+  const params = new URLSearchParams();
+  if (limit !== 20) params.set("limit", String(limit));
+  if (offset) params.set("offset", String(offset));
+  const qs = params.toString();
+  return sparkleApi(`/dashboard/unreviewed${qs ? `?${qs}` : ""}`);
+}
+
+export async function getRecent(
+  limit = 20,
+  offset = 0,
+): Promise<{ items: SparkleItem[]; total: number }> {
+  const params = new URLSearchParams();
+  if (limit !== 20) params.set("limit", String(limit));
+  if (offset) params.set("offset", String(offset));
+  const qs = params.toString();
+  return sparkleApi(`/dashboard/recent${qs ? `?${qs}` : ""}`);
+}
+
+export async function getAttention(
+  limit = 10,
+): Promise<{ items: SparkleItem[]; total: number }> {
+  const params = new URLSearchParams();
+  if (limit !== 10) params.set("limit", String(limit));
+  const qs = params.toString();
+  return sparkleApi(`/dashboard/attention${qs ? `?${qs}` : ""}`);
+}
+
+export async function getDashboardStale(
+  limit = 10,
+): Promise<{
+  items: {
+    id: string;
+    title: string;
+    category_name: string | null;
+    modified: string;
+    days_stale: number;
+  }[];
+  total: number;
+}> {
+  const params = new URLSearchParams();
+  if (limit !== 10) params.set("limit", String(limit));
+  const qs = params.toString();
+  return sparkleApi(`/dashboard/stale${qs ? `?${qs}` : ""}`);
 }
 
 // --- Settings ---

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -8,6 +8,7 @@ import { registerWorkflowTools } from "./tools/workflow.js";
 import { registerMetaTools } from "./tools/meta.js";
 import { registerGuideTools } from "./tools/guide.js";
 import { registerVaultTools } from "./tools/vault.js";
+import { registerDashboardTools } from "./tools/dashboard.js";
 import { SPARKLE_INSTRUCTIONS } from "./docs/instructions.js";
 import { registerDocResources } from "./docs/resources.js";
 
@@ -28,6 +29,7 @@ export function createSparkleServer(): McpServer {
   registerMetaTools(server);
   registerGuideTools(server);
   registerVaultTools(server);
+  registerDashboardTools(server);
   registerDocResources(server);
 
   return server;

--- a/mcp-server/src/tools/dashboard.ts
+++ b/mcp-server/src/tools/dashboard.ts
@@ -1,0 +1,161 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getUnreviewed, getRecent, getAttention, getDashboardStale } from "../client.js";
+import { formatItemList } from "../format.js";
+import { formatToolError } from "../utils.js";
+
+export function registerDashboardTools(server: McpServer): void {
+  server.registerTool(
+    "sparkle_list_unreviewed",
+    {
+      title: "List Unreviewed Items",
+      description:
+        "列出尚未在 app 中開啟過的項目（透過 MCP 或 LINE 建立的）。用於查看哪些項目需要在 app 中確認或整理。",
+      inputSchema: z
+        .object({
+          limit: z
+            .number()
+            .int()
+            .min(1)
+            .max(100)
+            .default(20)
+            .describe("回傳數量上限"),
+          offset: z.number().int().min(0).default(0).describe("分頁偏移量"),
+        })
+        .strict(),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ limit, offset }) => {
+      try {
+        const data = await getUnreviewed(limit, offset);
+        const text = formatItemList(data.items, data.total, { offset, limit });
+        return { content: [{ type: "text", text }] };
+      } catch (error) {
+        return formatToolError(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "sparkle_list_recent",
+    {
+      title: "List Recently Created Items",
+      description:
+        "列出最近 N 天內建立的項目（天數由 Sparkle settings 的 recent_days 控制，預設 7 天）。",
+      inputSchema: z
+        .object({
+          limit: z
+            .number()
+            .int()
+            .min(1)
+            .max(100)
+            .default(20)
+            .describe("回傳數量上限"),
+          offset: z.number().int().min(0).default(0).describe("分頁偏移量"),
+        })
+        .strict(),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ limit, offset }) => {
+      try {
+        const data = await getRecent(limit, offset);
+        const text = formatItemList(data.items, data.total, { offset, limit });
+        return { content: [{ type: "text", text }] };
+      } catch (error) {
+        return formatToolError(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "sparkle_list_attention",
+    {
+      title: "List Items Needing Attention",
+      description:
+        "列出需要關注的項目：逾期待辦和高優先度項目。逾期項目排在最前面。",
+      inputSchema: z
+        .object({
+          limit: z
+            .number()
+            .int()
+            .min(1)
+            .max(100)
+            .default(10)
+            .describe("回傳數量上限"),
+        })
+        .strict(),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ limit }) => {
+      try {
+        const data = await getAttention(limit);
+        const text = formatItemList(data.items, data.total);
+        return { content: [{ type: "text", text }] };
+      } catch (error) {
+        return formatToolError(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "sparkle_list_stale",
+    {
+      title: "List Stale Developing Notes",
+      description:
+        "列出長時間未更新的發展中筆記（天數由 Sparkle settings 的 stale_days 控制，預設 14 天）。",
+      inputSchema: z
+        .object({
+          limit: z
+            .number()
+            .int()
+            .min(1)
+            .max(100)
+            .default(10)
+            .describe("回傳數量上限"),
+        })
+        .strict(),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ limit }) => {
+      try {
+        const data = await getDashboardStale(limit);
+        if (data.items.length === 0) {
+          return { content: [{ type: "text", text: "No stale developing notes found." }] };
+        }
+        const lines: string[] = [
+          `Found ${data.total} stale developing notes (showing ${data.items.length}):\n`,
+        ];
+        for (const item of data.items) {
+          const catStr = item.category_name ? ` 📁${item.category_name}` : "";
+          lines.push(
+            `- **${item.title}** — ${item.days_stale} days stale${catStr}`,
+          );
+          lines.push(`  ID: ${item.id} | Modified: ${item.modified}`);
+        }
+        return { content: [{ type: "text", text: lines.join("\n") }] };
+      } catch (error) {
+        return formatToolError(error);
+      }
+    },
+  );
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -17,6 +17,7 @@ export interface SparkleItem {
   share_visibility: "public" | "unlisted" | null;
   category_id: string | null;
   category_name: string | null;
+  viewed_at: string | null;
   created: string;
   modified: string;
 }


### PR DESCRIPTION
## Summary
- Add 4 new MCP tools: `sparkle_list_unreviewed`, `sparkle_list_recent`, `sparkle_list_attention`, `sparkle_list_stale`
- Set `origin: "mcp"` as default on `createItem` to enable viewed_at tracking
- Add `viewed_at` field to `SparkleItem` type
- Build updated MCP dist

## Context
PR 4 of 5 in Dashboard redesign. Depends on #170 (dashboard API endpoints).

## Test plan
- [x] All 931 unit tests pass
- [x] TypeScript type check passes
- [x] MCP server build succeeds
- [ ] `sparkle_list_unreviewed` returns items created via MCP
- [ ] `sparkle_create_note` sets `origin: "mcp"` and `viewed_at: null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)