### PR TITLE
docs: update DB migration version to 0→14 in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Notes: `fleeting` → `developing` → `permanent` → `exported` → `archived`
 
 Type conversion auto-maps status server-side. `category_id` preserved; `due`/`linked_note_id` cleared on todo→note; tags/priority/aliases cleared on →scratch.
 
-DB migration version 0→13, idempotent. Migration safety enforced by PostToolUse hook.
+DB migration version 0→14, idempotent. Migration safety enforced by PostToolUse hook.
 
 ## Conventions
 


### PR DESCRIPTION
## Summary
- Update migration version reference from 0→13 to 0→14 in CLAUDE.md
- Reflects migration 14 (viewed_at column + dashboard settings) added in #169

## Test plan
- [ ] Verify CLAUDE.md shows correct migration version

🤖 Generated with [Claude Code](https://claude.com/claude-code)