### PR TITLE
chore: add superpowers directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ coverage/
 docs/plans/
 public/rootCA.pem
 .claude/
+.superpowers/
+docs/superpowers/
 test-results/
 playwright-report/
 e2e/.auth/


### PR DESCRIPTION
## Summary
- Add `.superpowers/` (brainstorm plugin runtime files) to `.gitignore`
- Add `docs/superpowers/` (local specs/plans) to `.gitignore`

## Test plan
- [x] Verify directories no longer appear in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)