### PR TITLE
chore: migrate quality tracking system to GitHub Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/defect.yml
+++ b/.github/ISSUE_TEMPLATE/defect.yml
@@ -1,0 +1,106 @@
+name: "缺陷回報 (Defect)"
+description: "記錄非預期的錯誤 — 寫入時就是錯的"
+labels: ["type:defect"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > 定義與分類標準見 [quality/README.md](quality/README.md#分類體系)。
+        > 缺陷搜查手冊見 [quality/defect-taxonomy.md](quality/defect-taxonomy.md)。
+  - type: input
+    id: title
+    attributes:
+      label: "TL;DR"
+      description: "一句話摘要：問題是什麼、影響什麼"
+      placeholder: "catch 區塊吞沒 HTTP 錯誤，使用者看不到失敗通知"
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "優先級"
+      description: "何時修？定義見 README"
+      options:
+        - "Critical — 立即處理（同日）"
+        - "High — 下個 Sprint（1-2 週）"
+        - "Medium — 規劃中（1 個月）"
+        - "Low — 有空時處理"
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: "嚴重度"
+      description: "技術影響多大？"
+      options:
+        - "S1-Critical — 系統不可用或資料遺失"
+        - "S2-Major — 功能異常，無 workaround"
+        - "S3-Minor — 功能異常，有 workaround"
+        - "S4-Trivial — 外觀/文字問題"
+    validations:
+      required: true
+  - type: dropdown
+    id: cost
+    attributes:
+      label: "預估成本"
+      options:
+        - "S — < 2 小時"
+        - "M — 2 小時 ~ 1 天"
+        - "L — 1 ~ 3 天"
+        - "XL — > 3 天"
+  - type: dropdown
+    id: root-cause
+    attributes:
+      label: "根因類別"
+      options:
+        - "Design Defect — 架構/設計錯誤"
+        - "Implementation Error — 實作與設計不符"
+        - "Configuration Omission — 配置遺漏"
+        - "Framework Limitation — 框架限制未規避"
+        - "Missing Test Coverage — 缺少測試覆蓋"
+  - type: dropdown
+    id: escape-stage
+    attributes:
+      label: "逃逸階段"
+      description: "在哪個階段漏掉的？"
+      options:
+        - "Code Review"
+        - "Unit Test"
+        - "Integration Test"
+        - "E2E Test"
+        - "Production"
+  - type: input
+    id: defect-category
+    attributes:
+      label: "缺陷子類別"
+      description: "對應 defect-taxonomy.md 的類別代碼"
+      placeholder: "D-SILENT / D-VALID / D-AUTH / D-TYPE / D-PERF / D-EDGE"
+  - type: textarea
+    id: current-state
+    attributes:
+      label: "現狀描述"
+      description: "詳細描述問題，含程式碼片段"
+    validations:
+      required: true
+  - type: textarea
+    id: affected-files
+    attributes:
+      label: "受影響檔案"
+      description: "列出相關檔案和具體問題"
+      placeholder: |
+        | 檔案 | 問題 |
+        | ---- | ---- |
+        | `src/api.ts` (L42) | catch 區塊只有 console.log |
+  - type: textarea
+    id: solution
+    attributes:
+      label: "解決方案"
+      description: "修復計畫（可分 Phase）"
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: "驗收標準"
+      description: "怎麼確認修好了？"
+      placeholder: |
+        - [ ] 錯誤正確傳遞給 UI
+        - [ ] 測試通過

--- a/.github/ISSUE_TEMPLATE/feature-gap.yml
+++ b/.github/ISSUE_TEMPLATE/feature-gap.yml
@@ -1,0 +1,61 @@
+name: "功能缺口 (Feature Gap)"
+description: "記錄功能不完整 — 缺少預期互動"
+labels: ["type:feature-gap"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > 定義與分類標準見 [quality/README.md](quality/README.md#分類體系)。
+  - type: input
+    id: title
+    attributes:
+      label: "TL;DR"
+      placeholder: "搜尋結果沒有分頁，超過 100 筆時無法瀏覽"
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "優先級"
+      options:
+        - "Critical — 立即處理（同日）"
+        - "High — 下個 Sprint（1-2 週）"
+        - "Medium — 規劃中（1 個月）"
+        - "Low — 有空時處理"
+    validations:
+      required: true
+  - type: dropdown
+    id: cost
+    attributes:
+      label: "預估成本"
+      options:
+        - "S — < 2 小時"
+        - "M — 2 小時 ~ 1 天"
+        - "L — 1 ~ 3 天"
+        - "XL — > 3 天"
+  - type: input
+    id: user-impact
+    attributes:
+      label: "使用者影響"
+      description: "缺少此功能對使用者造成什麼問題？"
+      placeholder: "使用者無法找到歷史資料，需手動逐頁查看"
+    validations:
+      required: true
+  - type: textarea
+    id: current-state
+    attributes:
+      label: "現狀描述"
+    validations:
+      required: true
+  - type: textarea
+    id: affected-files
+    attributes:
+      label: "受影響檔案"
+  - type: textarea
+    id: solution
+    attributes:
+      label: "解決方案"
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: "驗收標準"

--- a/.github/ISSUE_TEMPLATE/tech-debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech-debt.yml
@@ -1,0 +1,66 @@
+name: "技術債 (Tech Debt)"
+description: "記錄有意識的妥協 — 先上線再改"
+labels: ["type:tech-debt"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > 定義與分類標準見 [quality/README.md](quality/README.md#分類體系)。
+  - type: input
+    id: title
+    attributes:
+      label: "TL;DR"
+      placeholder: "為了趕上線，跳過了輸入驗證的完整性檢查"
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "優先級"
+      options:
+        - "Critical — 立即處理（同日）"
+        - "High — 下個 Sprint（1-2 週）"
+        - "Medium — 規劃中（1 個月）"
+        - "Low — 有空時處理"
+    validations:
+      required: true
+  - type: dropdown
+    id: cost
+    attributes:
+      label: "預估成本"
+      options:
+        - "S — < 2 小時"
+        - "M — 2 小時 ~ 1 天"
+        - "L — 1 ~ 3 天"
+        - "XL — > 3 天"
+  - type: input
+    id: compromise-reason
+    attributes:
+      label: "妥協原因"
+      description: "為什麼做了這個妥協？"
+      placeholder: "deadline 壓力、等上游 API 穩定後再處理"
+    validations:
+      required: true
+  - type: input
+    id: planned-resolution
+    attributes:
+      label: "預計解決時機"
+      placeholder: "下個 Sprint / Phase 2 完成後 / 無時程"
+  - type: textarea
+    id: current-state
+    attributes:
+      label: "現狀描述"
+    validations:
+      required: true
+  - type: textarea
+    id: affected-files
+    attributes:
+      label: "受影響檔案"
+  - type: textarea
+    id: solution
+    attributes:
+      label: "解決方案"
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: "驗收標準"

--- a/.github/ISSUE_TEMPLATE/test-infra.yml
+++ b/.github/ISSUE_TEMPLATE/test-infra.yml
@@ -1,0 +1,66 @@
+name: "測試基礎設施 (Test Infrastructure)"
+description: "記錄測試覆蓋缺口與測試工具建設"
+labels: ["type:test-infra"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > 定義與分類標準見 [quality/README.md](quality/README.md#分類體系)。
+  - type: input
+    id: title
+    attributes:
+      label: "TL;DR"
+      placeholder: "API 端點缺少整合測試，只有手動驗證"
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: "優先級"
+      options:
+        - "Critical — 立即處理（同日）"
+        - "High — 下個 Sprint（1-2 週）"
+        - "Medium — 規劃中（1 個月）"
+        - "Low — 有空時處理"
+    validations:
+      required: true
+  - type: dropdown
+    id: cost
+    attributes:
+      label: "預估成本"
+      options:
+        - "S — < 2 小時"
+        - "M — 2 小時 ~ 1 天"
+        - "L — 1 ~ 3 天"
+        - "XL — > 3 天"
+  - type: input
+    id: coverage-gap
+    attributes:
+      label: "覆蓋缺口"
+      description: "缺少什麼測試覆蓋？"
+      placeholder: "POST /api/items 缺少邊界條件測試（空字串、超長輸入）"
+    validations:
+      required: true
+  - type: input
+    id: planned-resolution
+    attributes:
+      label: "預計解決時機"
+      placeholder: "下個 Sprint / Phase 2 完成後 / 無時程"
+  - type: textarea
+    id: current-state
+    attributes:
+      label: "現狀描述"
+    validations:
+      required: true
+  - type: textarea
+    id: affected-files
+    attributes:
+      label: "受影響檔案"
+  - type: textarea
+    id: solution
+    attributes:
+      label: "解決方案"
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: "驗收標準"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## 變更說明
+
+<!-- 修了什麼、為什麼 -->
+
+## 缺陷掃查
+
+**缺陷類別：** <!-- D-SILENT / D-VALID / D-STATE / D-OFFLINE / D-QUERY / D-MIGRATE / D-AUTH / D-EDGE / D-TYPE / D-PERF / D-DEPLOY / D-RACE / N/A -->
+**掃查範圍：** <!-- e.g. src/**/*.ts -->
+
+- [ ] 已用搜查手冊的 grep 模式掃查同類問題（非 bug fix 可跳過）
+- 掃查結果：
+
+## 關聯 Issue
+
+Fixes #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Detailed module conventions (API retry, PWA, Logging, Sentry, CSP, Offline UI, S
 
 ## Quality Management
 
-品質追蹤系統（Defect / Tech Debt / Feature Gap）。**操作前必須載入 `/quality` skill**。
+品質追蹤系統（Defect / Tech Debt / Feature Gap / Test Infrastructure）。**操作前必須載入 `/quality` skill**。
 
 ## Skills Reference
 
@@ -61,4 +61,4 @@ Detailed module conventions (API retry, PWA, Logging, Sentry, CSP, Offline UI, S
 
 ## Maintenance
 
-Update docs in same commit: **CLAUDE.md** (core conventions), **`docs/plans/quality/README.md`** (quality items). Skills (`.claude/skills/`) are local-only (gitignored).
+Update docs in same commit: **CLAUDE.md** (core conventions). Skills (`.claude/skills/`) are local-only (gitignored).

--- a/quality/README.md
+++ b/quality/README.md
@@ -1,0 +1,191 @@
+# 品質管理追蹤
+
+你的專案的品質管理體系。追蹤缺陷、技術債、功能缺口、測試覆蓋與工具建設，並維護品質防線。
+
+透過 GitHub Issues / GitLab Issues 管理品質項目，搭配 [defect-taxonomy.md](./defect-taxonomy.md) 搜查手冊進行系統性缺陷掃查。
+
+---
+
+## 快速查詢
+
+> 品質項目以 Issue 追蹤，透過 label 過濾取得即時結果。
+> 以下指令以 `gh` (GitHub) 為例，GitLab 替換為 `glab`。
+
+| 查詢               | 指令                                                              |
+| ------------------ | ----------------------------------------------------------------- |
+| 活躍項目           | `gh issue list --label "type:defect" --state open`                |
+| Critical/High 活躍 | `gh issue list --label "priority:critical" --state open`          |
+| In Progress 項目   | `gh issue list --label "status:in-progress" --state open`         |
+| Blocked 項目       | `gh issue list --label "status:blocked-by-decision" --state open` |
+| 搜查進度           | 見 [defect-taxonomy.md 分類總覽](./defect-taxonomy.md#分類總覽)   |
+| 統計報告           | `gh issue list --state all \| wc -l`（總數）                      |
+
+---
+
+## 分類體系
+
+| 分類                    | 定義                                                | 處理策略                | Label                       |
+| ----------------------- | --------------------------------------------------- | ----------------------- | --------------------------- |
+| **Defect**              | 非預期的錯誤，寫入時就是錯的                        | 立即修復 + 回溯流程漏洞 | `type:defect`               |
+| **Tech Debt**           | 有意識的妥協，先上線再改                            | 排優先級，安排容量      | `type:tech-debt`            |
+| **Feature Gap**         | 功能不完整，缺少預期互動                            | 放進 backlog            | `type:feature-gap`          |
+| **Test Infrastructure** | 測試覆蓋缺口與測試工具建設                          | 排優先級，系統性補齊    | `type:test-infra`           |
+| **Quality Gate**        | 防止 Defect / Tech Debt / Feature Gap 進入 codebase | 持續投資的基礎設施      | （例如 CI、搜查手冊、hook） |
+
+### 如何判斷分類？
+
+```
+這個問題是有意識的妥協嗎？
+├── 是 → 妥協的是測試覆蓋或測試工具嗎？
+│   ├── 是 → Test Infrastructure（「知道該寫測試，先上線再補」）
+│   └── 否 → Tech Debt（「我知道不夠好，先上線」）
+└── 否 → 程式碼行為與設計意圖一致嗎？
+    ├── 否 → Defect（逃逸缺陷 / 設計缺陷）
+    └── 是 → 功能設計完整嗎？
+        ├── 否 → 缺少的是測試覆蓋嗎？
+        │   ├── 是 → Test Infrastructure（未覆蓋的測試路徑或缺少的測試工具）
+        │   └── 否 → Feature Gap（缺少的互動或資訊）
+        └── 是 → 不需要追蹤
+```
+
+---
+
+## 定義參考
+
+### 狀態
+
+| 狀態                    | Issue 對應                          | 定義                                  |
+| ----------------------- | ----------------------------------- | ------------------------------------- |
+| **Pending**             | Open（無 status label）             | 已記錄，等待處理                      |
+| **In Progress**         | Open + `status:in-progress`         | 正在修復中                            |
+| **Blocked-by-Decision** | Open + `status:blocked-by-decision` | 解決方案需要人類決策，AI 不應自行推進 |
+| **Done**                | Closed                              | 修復完成，已通過驗收                  |
+
+### 優先級（業務緊急度 — 何時修）
+
+| 優先級       | 定義                       | 處理時機              |
+| ------------ | -------------------------- | --------------------- |
+| **Critical** | 影響生產穩定性或安全性     | 立即處理（同日）      |
+| **High**     | 阻礙開發效率或造成頻繁 bug | 下個 Sprint（1-2 週） |
+| **Medium**   | 增加維護成本但不影響功能   | 規劃中處理（1 個月）  |
+| **Low**      | 改善開發體驗，非必要       | 有空時處理（無 SLA）  |
+
+### 嚴重度（技術影響 — 多嚴重，Defect 專用）
+
+| 嚴重度          | 定義                        | 範例                       |
+| --------------- | --------------------------- | -------------------------- |
+| **S1-Critical** | 系統不可用或資料遺失        | 寫入操作靜默遺失資料       |
+| **S2-Major**    | 功能異常，無合理 workaround | API 回傳錯誤的 status code |
+| **S3-Minor**    | 功能異常，有 workaround     | 手動刷新頁面可繞過         |
+| **S4-Trivial**  | 外觀/文字問題               | 錯誤訊息措辭不佳           |
+
+### 成本（實作工時）
+
+| 代號   | 範圍          | 說明                 |
+| ------ | ------------- | -------------------- |
+| **S**  | < 2 小時      | 簡單修復，單一改動   |
+| **M**  | 2 小時 ~ 1 天 | 中等複雜度，多個檔案 |
+| **L**  | 1 ~ 3 天      | 複雜修復，需要設計   |
+| **XL** | > 3 天        | 大型重構，建議分階段 |
+
+### 根因類別（Defect 專用）
+
+| 根因                       | 定義                         |
+| -------------------------- | ---------------------------- |
+| **Design Defect**          | 架構/設計層面的錯誤決策      |
+| **Implementation Error**   | 實作與設計意圖不符           |
+| **Configuration Omission** | 配置遺漏（框架、建置工具等） |
+| **Framework Limitation**   | 框架已知限制未規避           |
+| **Missing Test Coverage**  | 缺少測試導致未發現           |
+
+### 逃逸階段（Defect 專用）
+
+| 階段                 | 說明                     |
+| -------------------- | ------------------------ |
+| **Code Review**      | 初次實作時 review 未捕獲 |
+| **Unit Test**        | 單元測試未覆蓋此路徑     |
+| **Integration Test** | 整合測試未覆蓋此場景     |
+| **E2E Test**         | E2E 測試未覆蓋此場景     |
+| **Production**       | 生產環境使用者發現       |
+
+#### 升級與降級信號
+
+優先級不是固定的 — 隨情境變化調整。以下為常見信號，非硬性規則：
+
+**升級（例如 Medium → High）：**
+
+- 同類問題重複出現（第二次遇到 = 模式，不再是偶發）
+- 外部依賴變化（上游 API 即將 deprecate、安全漏洞公告）
+- 影響範圍擴大（原本只影響一個功能，發現波及多處）
+- 阻擋其他項目進展
+
+**降級（例如 High → Medium）：**
+
+- 找到有效的 workaround 且已記錄
+- 影響範圍確認比預期小（例如只在特定邊界條件觸發）
+- 外部壓力消失（deadline 延後、相關功能暫停開發）
+
+> **操作：** 調整優先級時，更新 Issue 的 `priority:` label 並在 comment 簡述變更原因。
+
+---
+
+## Label 參考
+
+| Prefix        | 用途               | 必填？                                             | 值                                                                            |
+| ------------- | ------------------ | -------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `type:`       | 項目類型           | **必填**（GitHub 模板自動套用；GitLab 需手動加上） | `defect` / `tech-debt` / `feature-gap` / `test-infra`                         |
+| `priority:`   | 優先級             | **必填**                                           | `critical` / `high` / `medium` / `low`                                        |
+| `status:`     | 細分狀態           | 選填                                               | `in-progress` / `blocked-by-decision`                                         |
+| `severity:`   | 嚴重度（Defect）   | 選填，建議填                                       | `s1-critical` / `s2-major` / `s3-minor` / `s4-trivial`                        |
+| `cost:`       | 成本               | 選填                                               | `s` / `m` / `l` / `xl`                                                        |
+| `escape:`     | 逃逸階段（Defect） | 選填，建議填                                       | `code-review` / `unit-test` / `integration-test` / `e2e-test` / `production`  |
+| `root-cause:` | 根因（Defect）     | 選填                                               | `design` / `implementation` / `configuration` / `framework` / `test-coverage` |
+
+> 各專案可擴充 `defect-category:d-xxx` label 對應自己的 taxonomy。
+
+---
+
+## 搜查手冊
+
+定義所有已知缺陷類別和可重複執行的搜查模式：**[defect-taxonomy.md](./defect-taxonomy.md)**
+
+---
+
+## 待追蹤發現
+
+搜查中發現但尚未建立正式項目的問題。
+
+> **AI 行動指引：** 此段落僅供參考。**不要主動升級為正式項目** — 由人類決定何時建立。
+> 若人類要求處理某項，再依「建立新項目」流程操作。
+
+- **`type DB` alias 散佈 4 個 server 檔案**：`items.ts`, `item-enrichment.ts`, `categories.ts`, `line-commands/types.ts` 各自定義相同的 `type DB = BetterSQLite3Database<typeof schema>`。可抽到 `server/db/index.ts` 統一 export。（發現於 2026-03-16）
+- **`test-utils.ts` 缺少 migration 14 的兩個 index**：`idx_items_viewed_at` 和 `idx_items_status_modified` 已加入 production schema，但 `server/test-utils.ts` 未同步。（發現於 2026-03-21）
+
+---
+
+## 建立新項目
+
+1. 用[分類決策樹](#如何判斷分類)判斷類型（Defect / Tech Debt / Feature Gap / Test Infrastructure）
+2. 用對應的 Issue 模板建立 Issue：
+   - GitHub：`gh issue create --template defect.yml`（或 `tech-debt.yml` / `feature-gap.yml` / `test-infra.yml`）
+   - GitLab：`glab issue create --template Defect`（或 `Tech-Debt` / `Feature-Gap` / `Test-Infrastructure`）
+3. 填寫模板中的所有欄位，加上 `priority:` label
+   > **注意：** 模板的下拉選單僅記錄在 Issue body 中，不會自動建立對應的 label。`type:` label 由 GitHub 模板自動套用，其他 label（`priority:`、`severity:` 等）需手動加上。
+4. 若 Defect，填寫「缺陷子類別」（對應 [defect-taxonomy.md](./defect-taxonomy.md) 的 D-XXX 代碼）
+5. 開始處理時，加上 `status:in-progress` label
+
+---
+
+## 完成步驟
+
+> **IMPORTANT:** 修復完成後，依序執行以下步驟。缺任何一步 = 未完成。
+
+1. 關閉 Issue，填寫完成 comment：
+   ```
+   ## 完成紀錄
+   **Commit/PR：** abc1234 或 PR 連結
+   **修改摘要：** 簡述實際修改
+   **測試結果：** X passed, 0 failed
+   ```
+2. 若有相依 Issue（Complements/Blocks）→ 檢查對方 Issue 是否需更新
+3. 若為 Defect 且在系統性搜查中發現 → 確認搜查結果已記錄於 [defect-taxonomy.md](./defect-taxonomy.md)

--- a/quality/defect-taxonomy.md
+++ b/quality/defect-taxonomy.md
@@ -1,0 +1,607 @@
+# 缺陷分類學 — 系統性搜查手冊
+
+> **用途：** 定義已知和潛在的缺陷類別，提供可重複執行的搜查模式，讓開發者能快速找出同類問題。
+> 每個類別附帶搜查指令、已知實例、和判定標準。
+
+**建立日期：** 2026-03-04
+**最後更新：** 2026-03-22
+
+> 舊系統項目參考：https://github.com/hottim900/sparkle-quality
+
+### 搜查結果記錄格式
+
+每個類別搜查完畢後，用以下三層結構記錄結果：
+
+1. **發現（建 Issue）** — 確認的缺陷，已建立追蹤 Issue。格式：`DEF-NNN（Issue #N）— 描述`
+2. **Low-risk observations（不建 Issue）** — 可疑但影響太低，不值得正式追蹤。記錄檔案位置和原因，供未來參考。
+3. **審查但判定合理（非缺陷）** — 經審查排除的項目。記錄判定理由，避免下次重複審查。
+
+---
+
+## 分類總覽
+
+| 代號      | 缺陷類別                | 層級              | 已知實例                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 搜查狀態      |
+| --------- | ----------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| D-SILENT  | 靜默失敗與可觀測性缺口  | 全層              | DEF-001, DEF-011, DEF-012, DEF-018, DEF-019, DEF-022, DEF-025, DEF-026, TD-026 | ✅ 2026-03-20 |
+| D-VALID   | 輸入驗證缺口            | API               | DEF-003, DEF-004, DEF-005, DEF-013, DEF-021, DEF-025                                                                                                                                                                                                          | ✅ 2026-03-20 |
+| D-STATE   | 前端狀態管理不一致      | Frontend          | DEF-002, DEF-015, DEF-016                                                                                                                                                                                                                                                                                                                                                                          | ✅ 2026-03-20 |
+| D-OFFLINE | 離線同步與 PWA 問題     | Frontend / SW     | (DEF-001)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | ✅ 2026-03-20 |
+| D-QUERY   | 查詢語意錯誤            | Server            | DEF-010                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | ✅ 2026-03-20 |
+| D-MIGRATE | DB Migration 安全性     | Server            | —                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | ✅ 2026-03-20 |
+| D-AUTH    | 認證、授權與安全防線    | API / 全層        | —                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | ✅ 2026-03-20 |
+| D-EDGE    | 邊界條件與資源限制      | 全層              | DEF-006, DEF-007                                                                                                                                                                                                                                                                                                                                                                                                                                                                | ✅ 2026-03-20 |
+| D-TYPE    | TypeScript 型別安全漏洞 | Frontend / Server | DEF-008, TD-001, TD-004, TD-005, TD-006                                                                                                                                                                                                                                                                  | ✅ 2026-03-20 |
+| D-PERF    | 效能問題                | 全層              | DEF-009, DEF-014, TD-002, TD-003, FG-001                                                                                                                                                                                                                                                                                            | ✅ 2026-03-20 |
+| D-DEPLOY  | Build/Deploy 一致性     | DevOps            | TD-027                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | ✅ 2026-03-20 |
+| D-RACE    | 競態條件與並發問題      | Frontend / Server | DEF-024                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | ✅ 2026-03-20 |
+
+---
+
+## D-SILENT: 靜默失敗與可觀測性缺口
+
+### 定義
+
+兩個子面向：
+
+1. **錯誤吞沒** — catch 塊中只記錄 log 或完全忽略錯誤，上層不知道操作失敗。包含 API 錯誤未正確傳遞給 UI、Service Worker 中的錯誤吞沒等。
+2. **可觀測性缺口** — 應該被記錄但沒有記錄的操作。包含缺少 audit trail 的破壞性操作（批次刪除、匯出）、前端用 `console.*` 而非結構化 logger、Sentry 整合缺口。
+
+### 搜查方式
+
+```bash
+# === 錯誤吞沒（原有） ===
+
+# 精準搜查：bare catch（空 catch 或只有註解的 catch）— 最高信噪比
+grep -n "catch.*{" server/ src/ --include="*.ts" --include="*.tsx" -A 2 | grep -B 1 "^\s*}"
+
+# 次精準：catch 後沒有 throw/toast/log 的地方
+grep -n "catch" server/ src/ --include="*.ts" --include="*.tsx" -A 5 | grep -v "throw\|toast\|log\|warn\|error\|reject"
+
+# 廣域搜查（噪音高，~70 筆）：所有 catch — 只在首次全面盤點時用
+grep -rn "catch" server/ src/ --include="*.ts" --include="*.tsx"
+
+# HTTP response 未檢查 status（fetch 後沒有 ok/status 檢查）
+grep -n "await fetch" server/ src/ --include="*.ts" --include="*.tsx" -A 3 | grep -v "\.ok\|\.status\|response\.ok"
+
+# === 可觀測性缺口（新增） ===
+
+# 前端 console.* 應改用結構化 logger 或移除
+grep -rn "console\." src/ --include="*.ts" --include="*.tsx" | grep -v node_modules | grep -v "\.test\."
+
+# 破壞性操作（delete、batch）缺少 server-side logger
+grep -rn "delete\|batch" server/routes/ --include="*.ts" -A 5 | grep -v "logger\."
+
+# Sentry captureException 覆蓋範圍
+grep -rn "captureException\|captureMessage" server/ src/ --include="*.ts" --include="*.tsx"
+```
+
+> **搜查策略：** 錯誤吞沒從精準到廣域。可觀測性先查 console.\* 和缺 logger 的破壞性路由。
+
+**搜查狀態：** ✅ 已搜查（2026-03-20）
+
+### 搜查結果
+
+**範圍：** `server/` + `src/` 全部 `.ts/.tsx`（排除測試檔），共檢查 ~70 個 catch 區塊。
+
+**發現：**
+
+- DEF-001 — `src/sw.ts` replayQueue 未檢查 HTTP response status，4xx/5xx 時靜默刪除離線佇列項目（Medium / S2-Major）
+- DEF-011 — `server/routes/search.ts` catch 塊無 logger.error，搜尋失敗被吞沒（High / S2-Major）
+- DEF-012 — `server/routes/webhook.ts` LINE 搜尋 bare catch，無日誌記錄（High / S2-Major）
+- DEF-026 — `mcp-server/src/vault.ts` writeVaultFileBySparkleId 寫入不驗證 frontmatter，sparkle_id 追蹤靜默斷裂（High / S2-Major）— 已修復 PR #167
+- `server/db/index.ts:268,362` — 多餘的 bare catch 包裹 `IF NOT EXISTS` 語句，可能吞掉非預期 SQLite 錯誤（Low，未建 DEF）
+- TD-026 — `mcp-server/src/http.ts` 15 處 console.\* 代替結構化 logger，繞過 Sentry 和結構化日誌（Medium）（2026-03-20 增量發現）
+
+**審查但判定合理（非缺陷）：**
+
+- Server 端 JSON.parse catch → 均有 `logger.warn` + HTTP 4xx 回應
+- Frontend catch → 均有 `toast.error` 通知使用者
+- Health check catch → 設定 degraded 狀態（設計如此）
+- SW offline queue catch → 正確的離線佇列排隊模式
+
+---
+
+## D-VALID: 輸入驗證缺口
+
+### 定義
+
+API endpoint 的 Zod schema 未覆蓋所有輸入欄位，或驗證規則不完整（缺少長度限制、格式檢查等）。
+
+### 搜查方式
+
+```bash
+# 列出所有 route handler
+grep -rn "app\.\(get\|post\|put\|patch\|delete\)" server/routes/ --include="*.ts"
+
+# 列出所有 Zod schema
+grep -rn "z\.object" server/ --include="*.ts"
+
+# 對比：每個寫入端點是否有對應的 Zod 驗證
+```
+
+**搜查狀態：** ✅ 已搜查（2026-03-20）
+
+### 搜查結果
+
+**範圍：** 18 個 API endpoint、7 個 Zod schema。
+
+**發現：**
+
+- DEF-003 — Import endpoint 5 處驗證缺口（id 非 UUID、type 缺 scratch、content 無 max、tags/aliases 無 JSON 驗證、items 無上限）
+- DEF-004 — 搜尋 q 無 max、tag 無 min/max
+- DEF-005 — LINE !tag 繞過 Zod max(20) 限制
+- DEF-013 — Short ID prefix lookup 無 max 長度驗證、LIKE 查詢缺 ORDER BY（High / S2-Major）
+
+**審查但判定合理：** 路徑參數 :id 未顯式驗證但由 DB lookup 保護、FTS5 轉義正確。
+
+---
+
+## D-STATE: 前端狀態管理不一致
+
+### 定義
+
+React Query cache 未正確 invalidate、樂觀更新與伺服器狀態不一致、多個元件的狀態同步問題。
+
+### 搜查方式
+
+```bash
+# 列出所有 useMutation 的 onSuccess/onSettled
+grep -A 5 "useMutation" src/ --include="*.ts" --include="*.tsx" -r
+
+# 檢查 invalidateQueries 的覆蓋範圍
+grep -rn "invalidateQueries\|invalidate" src/ --include="*.ts" --include="*.tsx"
+
+# 找出直接操作 state 而非透過 React Query 的地方
+grep -rn "setState\|setItems\|setNotes" src/ --include="*.ts" --include="*.tsx"
+```
+
+**搜查狀態：** ✅ 已搜查（2026-03-20）
+
+### 搜查結果
+
+**範圍：** TanStack Router 遷移後全面重掃，含 route 元件、ErrorBoundary、invalidation 模式、error/empty 狀態區分。
+
+**發現：**
+
+- DEF-002 — LinkedItemsSection 3 處 invalidation 不完整
+- DEF-015 — 大多數 list route 缺少 ErrorBoundary，元件 throw 時白屏（Medium / S3-Minor）
+- DEF-016 — item-list 錯誤狀態與空列表共用同一 UI，toast 消失後不可區分（Low / S4-Trivial）
+
+**Low-risk observations：** ShareDialog 使用本地 state 管理（非缺陷，設計合理）。refetchOnWindowFocus 部分元件停用（item-detail dirty check、fleeting-triage），不一致但各有合理原因。
+
+**審查但判定合理：** QuickCapture/ItemDetail/FleetingTriage invalidation 策略一致、CategoryManagement 樂觀更新有完整 rollback。
+
+---
+
+## D-OFFLINE: 離線同步與 PWA 問題
+
+### 定義
+
+IndexedDB 離線佇列的同步失敗處理、Service Worker 快取策略不當、離線 → 上線恢復時的資料衝突。
+
+### 搜查方式
+
+```bash
+# 離線佇列相關邏輯
+grep -rn "offlineQueue\|indexedDB\|IDB" src/ --include="*.ts" --include="*.tsx"
+
+# Service Worker 快取策略
+grep -rn "NetworkFirst\|CacheFirst\|StaleWhileRevalidate" src/ --include="*.ts"
+
+# 網路狀態偵測
+grep -rn "navigator.onLine\|online\|offline" src/ --include="*.ts" --include="*.tsx"
+```
+
+**搜查狀態：** ✅ 已搜查（2026-03-20）
+
+### 搜查結果
+
+**發現：** 無新缺陷（DEF-001 已知）。
+
+**Low-risk observations：** IndexedDB 佇列無大小限制檢查（實務低風險，配額 50-100MB）。
+
+**審查但判定合理：** SW 快取策略（NetworkFirst + 10s timeout）、POST 離線佇列設計、online listener 設計均合理。
+
+---
+
+## D-QUERY: 查詢語意錯誤
+
+### 定義
+
+SQL 查詢能正確執行但語意不對：排序不確定、FTS5 搜尋行為異常、分頁遺漏、JOIN 條件不完整。
+
+### 搜查方式
+
+```bash
+# Drizzle ORM 查詢
+grep -rn "db\.\(select\|insert\|update\|delete\)" server/ --include="*.ts"
+
+# 原生 SQL 查詢
+grep -rn "db\.prepare\|\.run(\|\.get(\|\.all(" server/ --include="*.ts"
+
+# LIMIT 無 ORDER BY
+grep -B 5 "\.limit(" server/ --include="*.ts"
+
+# FTS5 搜尋查詢
+grep -rn "fts\|MATCH" server/ --include="*.ts"
+```
+
+**搜查狀態：** ✅ 已搜查（2026-03-20）
+
+### 搜查結果
+
+**發現：**
+
+- DEF-010 — `listItems()` tag filter 路徑使用 `sql.raw(sortField)` 繞過參數化查詢，違反防禦縱深（High / S2-Major）
+- DEF-020 — `shares.ts` 兩處使用 `SELECT *`，回傳多餘欄位。已修復為明確欄位列表。（Low / S4-Trivial）✅ Done
+
+**審查但判定合理：** FTS5 外部內容表正確、GROUP BY + LEFT JOIN 安全、統計 CASE WHEN 邏輯正確、short ID prefix LIKE 查詢使用 Drizzle `like()` 安全函式。
+
+---
+
+## D-MIGRATE: DB Migration 安全性
+
+### 定義
+
+SQLite migration 中的不安全操作：`SELECT *` 在 INSERT 中（欄位順序依賴）、缺少 foreign_keys OFF 的 DROP TABLE、transaction 內的 schema version 設定。
+
+### 搜查方式
+
+```bash
+# Migration 相關程式碼（已有 PostToolUse hook 保護）
+grep -n "SELECT \*" server/db/index.ts
+grep -n "DROP TABLE" server/db/index.ts
+grep -n "setSchemaVersion" server/db/index.ts
+```
+
+> **注意：** 已有 `.claude/hooks/migration-safety.sh` PostToolUse hook 做自動檢查。此分類主要用於回顧性搜查。
+
+**搜查狀態：** ✅ 已搜查（2026-03-20）
+
+### 搜查結果
+
+**發現：** 無缺陷。Migration v0-13 均使用明確列列表（無 SELECT \*）、FK 管理正確、setSchemaVersion 在 transaction 外、idempotent 保護完整。
+
+---
+
+## D-AUTH: 認證、授權與安全防線
+
+### 定義
+
+三個子面向：
+
+1. **認證與授權** — Bearer token 驗證遺漏、API 端點未正確保護、公開路由暴露過多資訊。
+2. **Secret 儲存與傳輸** — auth token 在 localStorage/MessageChannel 的安全性、.env 中的 secret 管理、logout 時 token 清除。
+3. **內容注入防線** — CSP header 完整性、markdown 渲染 XSS 防護、dangerouslySetInnerHTML 使用。
+
+### 搜查方式
+
+```bash
+# === 認證與授權（原有） ===
+
+# 所有 API 路由
+grep -rn "app\.\(get\|post\|put\|patch\|delete\)" server/routes/ --include="*.ts"
+
+# 認證中介層
+grep -rn "authMiddleware\|bearerAuth\|Authorization" server/ --include="*.ts"
+
+# 公開路由（不需認證）
+grep -rn "/api/public\|/api/webhook\|/api/health" server/ --include="*.ts"
+
+# === Secret 儲存與傳輸（新增） ===
+
+# localStorage / sessionStorage 中的 token
+grep -rn "localStorage\|sessionStorage" src/ --include="*.ts" --include="*.tsx"
+
+# Service Worker token 傳遞
+grep -rn "postMessage\|MessageChannel" src/ --include="*.ts" --include="*.tsx" -A 3
+
+# === 內容注入防線（新增） ===
+
+# CSP header 定義
+grep -rn "Content-Security-Policy" server/ --include="*.ts"
+
+# dangerouslySetInnerHTML（應為 0）
+grep -rn "dangerouslySetInnerHTML\|innerHTML" src/ --include="*.tsx"
+
+# eval / Function constructor（應為 0）
+grep -rn "eval(\|new Function(" src/ server/ --include="*.ts" --include="*.tsx"
+```
+
+**搜查狀態：** ✅ 已搜查（2026-03-20）
+
+### 搜查結果
+
+**範圍：** 認證、secret 儲存、CSP/XSS 全面搜查。
+
+**發現：** 無缺陷。
+
+**認證與授權：** Bearer token timing-safe 比較正確、全域 authMiddleware 覆蓋所有 /api/\* 路由、公開路由正確過濾 visibility、LINE webhook HMAC-SHA256 驗證正確。
+
+**Secret 儲存：** localStorage auth_token 是 SPA 標準做法（CF Access 已在前端保護）。SW token 透過 MessageChannel 安全傳遞（非 localStorage 暴露）。.env 正確 gitignored。
+
+**內容注入：** CSP `script-src 'self'` 阻擋 inline script。`style-src 'unsafe-inline'` 為 Tailwind 所需。無 dangerouslySetInnerHTML、無 eval。react-markdown 安全渲染（不執行 HTML）。
+
+---
+
+## D-EDGE: 邊界條件與資源限制
+
+### 定義
+
+未處理的極端輸入：超長標題、空內容、超大 tags 陣列、分頁 offset 負數、同時操作同一筆記錄。
+
+### 搜查方式
+
+```bash
+# Zod schema 的 max/min 限制
+grep -rn "z\.string()\.\(max\|min\)" server/ --include="*.ts"
+
+# 分頁參數驗證
+grep -rn "offset\|limit\|page" server/routes/ --include="*.ts"
+
+# 陣列長度限制
+grep -rn "z\.array" server/ --include="*.ts"
+```
+
+**搜查狀態：** ✅ 已搜查（2026-03-20）
+
+### 搜查結果
+
+**發現：**
+
+- DEF-006 — color 無格式驗證、reorder items 無 max、sort_order 無 max
+- DEF-007 — batch ids 陣列無 max 上限
+- DEF-023 — export collision timestamp 只到分鐘精度，同分鐘內重複 export 會覆蓋。已修復為秒精度。（Low / S4-Trivial）✅ Done
+
+**Low-risk observations：** offset 允許任意大整數（SQLite 自動處理）、並發寫入（WAL 模式序列化）。
+
+**審查但判定合理：** origin/source max 已設、tags/aliases 上限已設、空 content 按設計允許。
+
+---
+
+## D-TYPE: TypeScript 型別安全漏洞
+
+### 定義
+
+`as any` 強制轉型、不安全的類型斷言、API 回傳值與前端型別定義不一致。
+
+### 搜查方式
+
+```bash
+# any 使用
+grep -rn "as any\|: any" src/ server/ --include="*.ts" --include="*.tsx" | grep -v node_modules | grep -v "*.test.*"
+
+# 型別斷言
+grep -rn "as [A-Z]" src/ server/ --include="*.ts" --include="*.tsx" | grep -v "as const"
+
+# API 回傳型別
+grep -rn "interface.*Response\|type.*Response" src/ --include="*.ts"
+```
+
+**搜查狀態：** ✅ 已搜查（2026-03-20）
+
+### 搜查結果
+
+**範圍：** TanStack Router 遷移後全面重掃，含 navigation `as any`、search param 型別、Query invalidation 模式、dependency 漏洞。
+
+**發現：**
+
+- DEF-008 — parseItem JSON.parse 無 try-catch，前端崩潰風險
+- TD-001 — 多處 `as` 斷言掩蓋型別驗證（items.ts, shares.ts, webhook.ts）
+- TD-004 — Router search params 多處 `as any` / `as NavigateOptions` 繞過型別安全（Medium / S3-Minor）
+- TD-005 — React Query 每次 mutation 都 invalidate `items.all`，導致 cascade refetch（Medium / S3-Minor）
+- TD-006 — Hono 4.7.4 prototype pollution 漏洞，需升級至 >= 4.12.7（Medium / S3-Minor）
+
+**Low-risk observations：** 前後端型別定義有潛在偏差但 JSON 序列化自動處理。`routeTree.gen.ts` 自動產生的 `as any` 不需處理。gcTime 未顯式設定（使用預設 5 分鐘，可接受）。
+
+**審查但判定合理：** Item tags/aliases 為 string（配合 parseItem 轉換）、ShareTokenRow 分離設計清晰。Server 端 error handling、auth middleware、rate limiting、input validation 全部通過。
+
+---
+
+## D-PERF: 效能問題
+
+### 定義
+
+不必要的 re-render、缺少 memo/useMemo、N+1 查詢、大量資料未分頁、bundle size 過大。
+
+### 搜查方式
+
+```bash
+# React 元件是否使用 memo
+grep -rn "React\.memo\|memo(" src/ --include="*.tsx"
+
+# useMemo/useCallback 使用
+grep -rn "useMemo\|useCallback" src/ --include="*.tsx"
+
+# 資料庫查詢是否有 LIMIT
+grep -rn "\.all(" server/ --include="*.ts" | grep -v "LIMIT\|limit"
+```
+
+**搜查狀態：** ✅ 已搜查（2026-03-20）
+
+### 搜查結果
+
+**範圍：** Router 遷移後重掃，含 accessibility、bundle size、re-render 模式。
+
+**發現：**
+
+- DEF-009 — /api/export 無 LIMIT，大量資料 OOM 風險
+- DEF-014 — listShares / listPublicShares 查詢無 LIMIT（High / S2-Major）
+- TD-002 — React Query staleTime=0 過度重查
+- TD-003 — ~~Batch 操作 N+1 查詢，1000 IDs 最壞 5000+ 查詢~~ ✅ Done（PR #102，改為 bulk SQL）
+- FG-001 — 多數 icon-only buttons 缺少 aria-label，螢幕閱讀器無法辨識（Medium）
+
+**Low-risk observations：** export 無欄位篩選（帶寬可優化）、ItemList 分組 O(n) 已用 useMemo。inline query options 在 linked-items-section（React Query 內部處理 memoization，實際影響低）。
+
+**審查但判定合理：** DB 索引完整覆蓋、前端陣列大小合理。item-list.tsx useMemo 覆蓋良好。bundle size 合理（42 precache entries，code splitting via TanStack Router）。
+
+---
+
+## D-DEPLOY: Build/Deploy 一致性
+
+### 定義
+
+Source code 與 deployed artifact 的不一致。包含：
+
+- **Build artifact 過期** — `dist/` 目錄未重新 build，缺少新增的模組（如 MCP server categories tools）
+- **Config drift** — .env / .env.example 不同步、systemd service 設定與 code 不匹配、Cloudflare tunnel config 過期
+- **版本標籤** — package.json version 未更新、deploy 後未驗證
+
+### 搜查方式
+
+```bash
+# === Build artifact 一致性 ===
+
+# MCP server: source vs dist 模組對比
+diff <(ls mcp-server/src/tools/*.ts 2>/dev/null | xargs -I{} basename {} .ts | sort) \
+     <(ls mcp-server/dist/tools/*.js 2>/dev/null | xargs -I{} basename {} .js | sort)
+
+# MCP server: dist/index.js imports vs src/index.ts imports
+grep "import.*from" mcp-server/dist/index.js | sort
+grep "import.*from" mcp-server/src/index.ts | sort
+
+# Frontend: dist/ 是否存在且非空
+ls -la dist/index.html 2>/dev/null
+
+# === Config drift ===
+
+# .env.example vs 實際使用的 env vars 對比
+grep -rn "process\.env\." server/ --include="*.ts" | grep -oP "process\.env\.\w+" | sort -u
+cat .env.example 2>/dev/null | grep -v "^#" | grep "=" | cut -d= -f1 | sort
+
+# systemd service 檔案引用的路徑是否存在
+grep -r "ExecStart\|WorkingDirectory\|Environment" /etc/systemd/system/sparkle* 2>/dev/null
+
+# === 版本一致性 ===
+
+# package.json version vs git tag
+grep '"version"' package.json
+git tag --sort=-v:refname | head -5
+```
+
+> **搜查策略：** diff source vs artifact 是最高效的搜查。config drift 需要 cross-reference .env.example 和 process.env 使用處。
+
+**搜查狀態：** ✅ 已搜查（2026-03-20）
+
+### 搜查結果
+
+**範圍：** MCP server source vs dist、.env.example vs process.env 使用處、systemd service 路徑、package.json version vs git tag。
+
+**發現：**
+
+- TD-027 — MCP server version 硬編碼 `"1.0.0"`（`mcp-server/src/server.ts:15`），主程式已 `1.1.1`。`mcp-server/package.json` 也停在 `1.0.0`。（Low / S4-Trivial）
+
+**Low-risk observations：**
+
+- `SPARKLE_API_URL` 和 `RATE_LIMIT_MAX` 在程式碼中使用但未記載於 `.env.example`。兩者皆有合理 fallback（localhost:3000、200 req/min），低風險。
+- MCP dist 與 source 同步（8 tool modules 皆正確編譯），deploy workflow 正確處理 build。
+
+**審查但判定合理：**
+
+- SystemD service paths 全部存在且正確（sparkle.service、sparkle-mcp-http.service）。
+- Frontend `dist/index.html` 存在且完整（PWA manifest、SW、icons）。
+- `dist/` 正確 gitignored，deploy workflow 在 restart 前 rebuild。
+
+---
+
+## D-RACE: 競態條件與並發問題
+
+### 定義
+
+前端或後端的並發操作導致非預期行為。包含：
+
+- **Double-submit** — mutation 按鈕未在 pending 時 disable，使用者快速雙擊送出兩次
+- **Stale closure** — useCallback/useEffect 的 dependency 不完整，callback 捕獲過期的 state
+- **Abort race** — AbortController timeout 與 response 到達的競爭、unmount 後的 state update
+- **Server-side 並發** — 同一筆記的並行寫入（SQLite WAL 序列化，低風險但仍需確認 optimistic update 一致性）
+
+### 搜查方式
+
+```bash
+# === Double-submit ===
+
+# mutation 按鈕是否有 disabled={isPending} 保護
+grep -rn "mutateAsync\|mutate(" src/ --include="*.tsx" -B 10 | grep -v "disabled"
+
+# useMutation 的 isPending 是否被使用
+grep -rn "useMutation" src/ --include="*.ts" --include="*.tsx" -A 3
+
+# === Stale closure ===
+
+# useCallback 的 dependency array 是否完整（需人工審查）
+grep -rn "useCallback" src/ --include="*.ts" --include="*.tsx" -A 1
+
+# useEffect cleanup 是否有 return（非同步 effect 需要 cleanup）
+grep -rn "useEffect.*async\|useEffect.*fetch\|useEffect.*await" src/ --include="*.ts" --include="*.tsx"
+
+# === Abort race ===
+
+# AbortController 使用與 cleanup
+grep -rn "AbortController\|abort()" src/ --include="*.ts" --include="*.tsx"
+
+# unmount 後的 setState（cancelled flag pattern）
+grep -rn "cancelled\|isMounted\|aborted" src/ --include="*.ts" --include="*.tsx"
+
+# === 前端 debounce cleanup ===
+
+# setTimeout 是否有對應的 clearTimeout
+grep -rn "setTimeout" src/ --include="*.ts" --include="*.tsx" | grep -v "\.test\."
+```
+
+> **搜查策略：** Double-submit 最容易 grep，stale closure 需要人工審查 dependency array。abort race 檢查 AbortController 與 cleanup 配對。
+
+**搜查狀態：** ✅ 已搜查（2026-03-20）
+
+### 搜查結果
+
+**範圍：** 全部 `src/` `.tsx/.ts` 的 useMutation、useCallback、useEffect、setTimeout、AbortController，以及 `server/` 的 transaction 使用。
+
+**發現：**
+
+- DEF-024 — CategoryManagement 4 個 mutation（create、update、reorder、delete）按鈕均缺 `isPending` 保護，使用者快速雙擊可觸發重複操作。（Medium / S3-Minor）
+
+**Low-risk observations：**
+
+- `CategorySelect.handleCreateSubmit`（`category-select.tsx:59`）無 isPending 保護，但觸發點為 Enter key，重複風險低。
+- `TagInput` blur setTimeout 200ms 無 cleanup（`tag-input.tsx:105`），unmount 後可能 setState，但 React 容忍此行為且僅影響 UI state。
+- Batch export 無 transaction 包裹 read-then-write（`items.ts:94-149`），但 export 為冪等操作且罕見使用，風險低。
+
+**審查但判定合理：**
+
+- **Double-submit 保護完善的元件：** QuickCapture（`isPending` guard + disabled）、ShareDialog（`creating/revokingId` state + disabled）、FleetingTriage（single-item workflow 限制並發）。
+- **Stale closure 防護：** useItemForm（ref-based debounce + cleanup）、SearchBar（debounceRef + cleanup）、LinkedItemsSection（noteSearchTimeoutRef + cleanup）、Settings（`cancelled` flag pattern）。
+- **Abort race：** `api.ts` AbortController + clearTimeout 配對正確。
+- **Server-side 並發：** Category create/reorder 皆用 `db.transaction()` 保護。Optimistic update（category reorder）有完整 rollback。
+
+---
+
+## 搜查執行紀錄
+
+| 日期       | 搜查範圍                                       | 結果                                                                                                           |
+| ---------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| 2026-03-04 | D-SILENT（全層 catch 區塊）                    | 1 defect (DEF-001), 1 low-risk observation                                                                     |
+| 2026-03-06 | D-VALID（API 輸入驗證）                        | 3 defects (DEF-003, DEF-004, DEF-005)                                                                          |
+| 2026-03-06 | D-STATE（React Query invalidation）            | 1 defect (DEF-002)                                                                                             |
+| 2026-03-06 | D-OFFLINE（離線同步）                          | 0 new defects                                                                                                  |
+| 2026-03-06 | D-QUERY（查詢語意）                            | 0 defects                                                                                                      |
+| 2026-03-06 | D-MIGRATE（Migration 安全性）                  | 0 defects                                                                                                      |
+| 2026-03-06 | D-AUTH（認證授權）                             | 0 defects                                                                                                      |
+| 2026-03-06 | D-EDGE（邊界條件）                             | 2 defects (DEF-006, DEF-007)                                                                                   |
+| 2026-03-06 | D-TYPE（型別安全）                             | 1 defect (DEF-008), 1 tech debt (TD-001)                                                                       |
+| 2026-03-06 | D-PERF（效能）                                 | 1 defect (DEF-009), 1 tech debt (TD-002)                                                                       |
+| 2026-03-08 | 全 10 類別增量搜查                             | 5 new defects (DEF-010~014), 1 tech debt (TD-003)                                                              |
+| 2026-03-13 | Router 遷移後全面架構搜查                      | 2 defects (DEF-015, DEF-016), 3 tech debt (TD-004~006), 1 feature gap (FG-001)                                 |
+| 2026-03-13 | AI 開發效率與成功率專題搜查                    | 4 tech debt (TD-007~010), 2 feature gaps (FG-002, FG-003)                                                      |
+| 2026-03-17 | 重構後全 10 類別增量搜查                       | 0 new defects — 重構品質良好，error handling/validation/invalidation 均正確維持                                |
+| 2026-03-17 | 新增 D-DEPLOY + D-RACE，擴充 D-SILENT + D-AUTH | 分類 10→12，D-SILENT 加入可觀測性，D-AUTH 加入 secret/CSP                                                      |
+| 2026-03-20 | 全 12 類別完整搜查（含 D-DEPLOY/D-RACE 首次）  | 1 defect (DEF-024), 2 tech debt (TD-026, TD-027); MCP HTTP transport + vault tools 增量掃描通過; FG-004 已完成 |
+
+---
+
+## 下次搜查建議
+
+全 12 類別搜查完成（2026-03-20）。
+
+1. **新 PR 合併後** — 針對變更檔案涉及的類別做增量搜查
+2. **季度全面搜查** — 重跑所有類別，比對上次結果（下次：2026-06）
+3. **MCP HTTP server 持續關注** — 新功能快速迭代中，D-SILENT（console.\*）、D-VALID（schema 邊界）、D-AUTH（token 管理）需隨新 PR 增量掃描

--- a/quality/quality-system-design-notes.md
+++ b/quality/quality-system-design-notes.md
@@ -1,0 +1,104 @@
+# 品質管理追蹤體系設計筆記
+
+> 可移植到其他專案的品質管理追蹤方法論。
+> 基於 ODC、DORA、GitHub Label Taxonomy 等業界實踐，
+> 針對「單人/小團隊 + AI 開發」場景優化。
+
+---
+
+## 1. 設計原則
+
+### 1.1 核心目標
+
+為 **AI 輔助開發** 設計的品質追蹤系統，最高優先級是：
+
+1. **AI 可自主操作** — 每個工作流步驟都有明確指引，不依賴隱性知識
+2. **單一來源** — 每筆資料只存在一處，避免多處同步導致不一致
+3. **可擴展** — 從 8 項到 800 項，結構不需改變
+
+### 1.2 設計取捨
+
+| 決策 | 選擇 | 放棄 | 理由 |
+|------|------|------|------|
+| Dashboard 策略 | README 只列 Critical/High | 列出所有項目 | 項目增長到 100+ 時 README 不膨脹 |
+| 發現機制 | `glob` + `grep`（零維護） | INDEX.md 索引檔 | 減少冗餘，AI 本身就能搜尋 |
+| 模板分類 | 三種獨立模板 | 一個模板 + 條件欄位 | 避免 AI 填錯不適用的欄位 |
+| 檔名慣例 | ID 前綴（`DEF-001-xxx.md`） | 日期前綴 | 搜尋結果即時可辨識，不需開檔 |
+| 優先級 vs 嚴重度 | 分離為兩個欄位 | 合併為一個 | 「何時修」和「多嚴重」是不同維度 |
+
+---
+
+## 2. 分類體系
+
+### 2.1 四分類 + 決策樹
+
+```
+這個問題是有意識的妥協嗎？
+├── 是 → Tech Debt（「我知道不夠好，先上線」）
+└── 否 → 程式碼行為與設計意圖一致嗎？
+    ├── 否 → Defect（逃逸缺陷 / 設計缺陷）
+    └── 是 → 功能設計完整嗎？
+        ├── 否 → Feature Gap（缺少的互動或資訊）
+        └── 是 → 不需要追蹤
+```
+
+第四類 **Quality Gate** 獨立於決策樹 — 不是「要修的東西」，而是「防止前三類進入 codebase 的基礎設施」（例如架構測試、CI 品質關卡、搜查手冊）。
+
+---
+
+## 3. AI 效率優化設計
+
+這是本體系與一般品質追蹤最大的差異。每個設計決策都考慮 AI 的工作方式。
+
+### 3.1 發現性（AI 怎麼知道這個系統存在）
+
+在專案的 `CLAUDE.md`（或等效的 AI 指令檔）加入入口：
+
+```markdown
+## 品質管理
+
+活躍的缺陷、技術債、功能缺口追蹤在 `docs/plans/quality/README.md`。
+
+**發現項目：** `glob docs/plans/quality/defects/DEF-*.md` + `grep '狀態.*Pending'`
+**修復後必須更新：** 依照項目檔底部「完成步驟」checklist 逐項執行。
+**建立新項目：** 依照 README.md「建立新項目」段落操作。
+```
+
+### 3.2 完成步驟 Checklist（AI 防遺漏）
+
+每個項目檔底部有明確的完成步驟。AI 最常犯的錯就是改完原始碼但忘記更新追蹤文件。
+
+### 3.3 待追蹤發現的行動指引
+
+明確告訴 AI「不要主動升級為正式項目」，避免 AI 過度主動地建立大量低優先級項目。
+
+### 3.4 雙向連結
+
+- **Taxonomy → Item：** 搜查手冊每個已知實例有可點擊連結到 DEF 項目
+- **Item → Taxonomy：** 每個 Defect 的「缺陷子類別」有可點擊連結到搜查手冊段落
+
+### 3.5 AI 效率 Checklist（移植到新專案時確認）
+
+| # | 項目 | 驗證方式 |
+|---|------|---------|
+| 1 | CLAUDE.md 有品質系統入口 | `grep '品質管理' CLAUDE.md` |
+| 2 | 每個項目有「完成步驟」checklist | `grep -rl '完成步驟' docs/plans/quality/` |
+| 3 | Checklist 包含「更新統計概覽」 | `grep -rl '統計概覽' docs/plans/quality/defects/` |
+| 4 | README 只列 Critical/High | 目視確認 Medium/Low 不在表格中 |
+| 5 | 搜查手冊有反向連結到 DEF 項目 | `grep -c '\[DEF-' defect-taxonomy.md` |
+| 6 | DEF 項目有正向連結到搜查手冊 | `grep '\[D-' docs/plans/quality/defects/DEF-*.md` |
+| 7 | README 有「建立新項目」流程 | `grep '建立新項目' README.md` |
+| 8 | 「待追蹤發現」有行動指引 | `grep 'AI 行動指引' README.md` |
+
+---
+
+## 4. 方法論來源
+
+| 來源 | 採用的概念 |
+|------|-----------|
+| [Orthogonal Defect Classification (ODC)](https://en.wikipedia.org/wiki/Orthogonal_Defect_Classification) | Root Cause 分類、Trigger（逃逸階段）、可重複的搜查模式 |
+| [DORA Metrics](https://dora.dev/guides/dora-metrics/) | Change Failure Rate 的概念 → 逃逸階段追蹤 |
+| [GitHub Label Taxonomy](https://robinpowered.com/blog/best-practice-system-for-organizing-and-tagging-github-issues) | 前綴式分類（type: / priority: / status:） |
+| [Shift-Left Testing](https://www.sonarsource.com/resources/library/shift-left/) | 搜查手冊 → 自動化防線的演進路徑 |
+| [Escaped Defect Analysis](https://softwareengineeringauthority.com/index.php/tools/13-software-engineering-disciplines/14-escaped-defect-analysis) | 逃逸階段欄位設計 |
+| [Martin Fowler Tech Debt Quadrant](https://en.wikipedia.org/wiki/Technical_debt) | Deliberate vs Inadvertent → 決策樹的「有意識的妥協」分支 |


### PR DESCRIPTION
## Summary

- 品質追蹤系統從 companion repo markdown 遷移到 GitHub Issue-native 模式
- 4 個 Issue templates（defect, tech-debt, feature-gap, test-infra）+ PR template
- 搜查手冊（12 類別 + 3 輪搜查基線）搬至 `quality/`
- 28 個 labels 已由 `setup-github.sh` 建立（PR 外操作）
- 舊系統 61 個項目全部已完成（59 Done + 2 Won't Fix），從零開始

## 變更說明

從零開始，不遷移舊項目（避免 ID 斷裂）。保留搜查手冊作為歷史基線。

## 缺陷掃查

**缺陷類別：** N/A（非程式碼變更）
**掃查範圍：** N/A

- [x] 已用搜查手冊的 grep 模式掃查同類問題（非 bug fix 可跳過）
- 掃查結果：不適用

## 關聯 Issue

N/A — 系統性遷移

## Test plan

- [ ] `gh label list | grep -cE "^(type:|priority:|status:)"` → 28 labels 已建立
- [ ] `gh issue create --template defect.yml` → 測試 Issue 建立成功
- [ ] 關閉測試 Issue → 驗證 3 步完成流程
- [ ] `/quality` skill 載入正常
- [ ] `quality/defect-taxonomy.md` 無殘留 markdown 連結

🤖 Generated with [Claude Code](https://claude.com/claude-code)