### PR TITLE
fix(server): harden security headers, IP extraction, and error messages

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -108,6 +108,13 @@ app.use("*", async (c, next) => {
   await next();
   c.res.headers.set("X-Sparkle", "1");
 });
+// Security hardening headers (defense-in-depth alongside Cloudflare)
+app.use("*", async (c, next) => {
+  await next();
+  c.res.headers.set("X-Content-Type-Options", "nosniff");
+  c.res.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  c.res.headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+});
 app.use("*", compress());
 app.use("*", async (c, next) => {
   await next();

--- a/server/middleware/__tests__/rate-limit.test.ts
+++ b/server/middleware/__tests__/rate-limit.test.ts
@@ -8,7 +8,10 @@ import type { Context } from "hono";
 
 function getClientIp(c: Context): string {
   return (
-    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ?? c.req.header("x-real-ip") ?? "unknown"
+    c.req.header("cf-connecting-ip") ??
+    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ??
+    c.req.header("x-real-ip") ??
+    "unknown"
   );
 }
 
@@ -98,6 +101,27 @@ describe("Rate limiting", () => {
         headers: { "x-forwarded-for": "1.2.3.4, 10.0.0.2" },
       });
       expect(res.status).toBe(429);
+    });
+
+    it("prefers cf-connecting-ip over x-forwarded-for", async () => {
+      // Exhaust limit for the CF IP
+      for (let i = 0; i < 5; i++) {
+        await app.request("/api/test", {
+          headers: { "cf-connecting-ip": "203.0.113.1", "x-forwarded-for": "10.0.0.99" },
+        });
+      }
+
+      // CF IP is blocked even though x-forwarded-for differs
+      const blocked = await app.request("/api/test", {
+        headers: { "cf-connecting-ip": "203.0.113.1", "x-forwarded-for": "10.0.0.100" },
+      });
+      expect(blocked.status).toBe(429);
+
+      // Different CF IP is still allowed
+      const allowed = await app.request("/api/test", {
+        headers: { "cf-connecting-ip": "203.0.113.2", "x-forwarded-for": "10.0.0.99" },
+      });
+      expect(allowed.status).toBe(200);
     });
 
     it("falls back to x-real-ip when x-forwarded-for is absent", async () => {

--- a/server/middleware/rate-limit.ts
+++ b/server/middleware/rate-limit.ts
@@ -3,7 +3,10 @@ import type { Context } from "hono";
 
 function getClientIp(c: Context): string {
   return (
-    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ?? c.req.header("x-real-ip") ?? "unknown"
+    c.req.header("cf-connecting-ip") ??
+    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ??
+    c.req.header("x-real-ip") ??
+    "unknown"
   );
 }
 

--- a/server/routes/__tests__/api.test.ts
+++ b/server/routes/__tests__/api.test.ts
@@ -73,6 +73,13 @@ function createApp() {
       c.res.headers.set("Vary", "Accept-Encoding");
     }
   });
+  // Security hardening headers (mirrors server/index.ts)
+  app.use("*", async (c, next) => {
+    await next();
+    c.res.headers.set("X-Content-Type-Options", "nosniff");
+    c.res.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+    c.res.headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+  });
   app.use(
     "/api/*",
     bodyLimit({
@@ -1824,7 +1831,7 @@ describe("PUT /api/settings", () => {
     });
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toMatch(/not writable/);
+    expect(body.error).toBe("Vault path is not accessible or not writable");
   });
 
   it("enables obsidian with valid writable vault path", async () => {
@@ -1975,5 +1982,25 @@ describe("Vary header", () => {
     });
     expect(res.status).toBe(200);
     expect(res.headers.get("Vary")).toBe("Accept-Encoding");
+  });
+});
+
+// ============================================================
+// Security Headers Tests
+// ============================================================
+describe("Security hardening headers", () => {
+  it("sets X-Content-Type-Options: nosniff", async () => {
+    const res = await app.request("/api/items", { headers: authHeaders() });
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+
+  it("sets Referrer-Policy", async () => {
+    const res = await app.request("/api/items", { headers: authHeaders() });
+    expect(res.headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+  });
+
+  it("sets Permissions-Policy", async () => {
+    const res = await app.request("/api/items", { headers: authHeaders() });
+    expect(res.headers.get("Permissions-Policy")).toBe("camera=(), microphone=(), geolocation=()");
   });
 });

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -89,7 +89,7 @@ settingsRouter.put("/", async (c) => {
       try {
         accessSync(vaultPath, constants.W_OK);
       } catch {
-        return c.json({ error: `Vault path is not writable: ${vaultPath}` }, 400);
+        return c.json({ error: "Vault path is not accessible or not writable" }, 400);
       }
     }
 


### PR DESCRIPTION
## Summary

- Prioritize `CF-Connecting-IP` over `X-Forwarded-For` in rate limiter to prevent IP spoofing bypass (#178)
- Add security hardening headers middleware: `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy` (#179)
- Remove filesystem path leakage from Settings API error responses (#180)
- Add corresponding unit tests for all three changes

HSTS excluded from this PR — setting it on `localhost` HTTP would cause browsers to refuse connections for 1 year, breaking local development. CF Tunnel already handles TLS at the edge.

## Test plan

- [x] Rate limit tests pass (13 tests) — including new CF-Connecting-IP priority test
- [x] API tests pass (97 tests) — including new security header assertions and updated settings error assertion
- [x] ESLint + TypeScript type check clean
- [ ] E2E tests pass after build
- [ ] `curl -I` confirms 3 security headers present in production

Closes #178, closes #179, closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)