### PR TITLE
refactor(server): extract import schema to single source of truth

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -33,9 +33,8 @@ import { dirname } from "node:path";
 import { eq, sql } from "drizzle-orm";
 import { getAllTags } from "./lib/items.js";
 import { getObsidianSettings } from "./lib/settings.js";
-import { z, ZodError } from "zod";
-import { statusEnum } from "./schemas/items.js";
-import { isValidTypeStatus } from "./lib/item-type-system.js";
+import { ZodError } from "zod";
+import { importSchema } from "./schemas/items.js";
 import { clearExpiredSessions } from "./lib/line-session.js";
 
 // --- Startup validation ---
@@ -221,46 +220,7 @@ app.get("/api/export", (c) => {
   });
 });
 
-// Import items (upsert) — only accepts new field names/status values
-const jsonStringArray = z.preprocess(
-  (val) => {
-    if (typeof val === "string") {
-      try {
-        return JSON.parse(val);
-      } catch {
-        return val;
-      }
-    }
-    return val;
-  },
-  z.array(z.string().min(1).max(200)).max(20),
-);
-
-const importItemSchema = z
-  .object({
-    id: z.string().uuid(),
-    type: z.enum(["note", "todo", "scratch"]).default("note"),
-    title: z.string().min(1).max(500),
-    content: z.string().max(50000).default(""),
-    status: statusEnum.default("fleeting"),
-    priority: z.enum(["low", "medium", "high"]).nullable().default(null),
-    due: z.string().nullable().default(null),
-    tags: jsonStringArray.default([]),
-    origin: z.string().default(""),
-    source: z.string().nullable().default(null),
-    aliases: jsonStringArray.default([]),
-    linked_note_id: z.string().nullable().default(null),
-    created: z.string().min(1),
-    modified: z.string().min(1),
-  })
-  .refine((data) => isValidTypeStatus(data.type, data.status), {
-    message: "Invalid status for the given type",
-    path: ["status"],
-  });
-
-const importSchema = z.object({
-  items: z.array(importItemSchema).max(10000),
-});
+// Import items (upsert) — schema defined in schemas/items.ts
 
 // Detect old format fields and reject with helpful message
 const OLD_FIELD_NAMES = ["due_date", "created_at", "updated_at"] as const;

--- a/server/routes/__tests__/api.test.ts
+++ b/server/routes/__tests__/api.test.ts
@@ -40,50 +40,10 @@ import { logger } from "../../lib/logger.js";
 import { getObsidianSettings } from "../../lib/settings.js";
 import { items } from "../../db/schema.js";
 import { eq } from "drizzle-orm";
-import { z, ZodError } from "zod";
-import { statusEnum } from "../../schemas/items.js";
-import { isValidTypeStatus } from "../../lib/item-type-system.js";
+import { ZodError } from "zod";
+import { importSchema } from "../../schemas/items.js";
 
 const TEST_TOKEN = "test-secret-token-12345";
-
-const jsonStringArray = z.preprocess(
-  (val) => {
-    if (typeof val === "string") {
-      try {
-        return JSON.parse(val);
-      } catch {
-        return val;
-      }
-    }
-    return val;
-  },
-  z.array(z.string().min(1).max(200)).max(20),
-);
-
-const importItemSchema = z
-  .object({
-    id: z.string().min(1),
-    type: z.enum(["note", "todo", "scratch"]).default("note"),
-    title: z.string().min(1).max(500),
-    content: z.string().default(""),
-    status: statusEnum.default("fleeting"),
-    priority: z.enum(["low", "medium", "high"]).nullable().default(null),
-    due: z.string().nullable().default(null),
-    tags: jsonStringArray.default([]),
-    origin: z.string().default(""),
-    source: z.string().nullable().default(null),
-    aliases: jsonStringArray.default([]),
-    created: z.string().min(1),
-    modified: z.string().min(1),
-  })
-  .refine((data) => isValidTypeStatus(data.type, data.status), {
-    message: "Invalid status for the given type",
-    path: ["status"],
-  });
-
-const importSchema = z.object({
-  items: z.array(importItemSchema),
-});
 
 function createApp() {
   const app = new Hono();

--- a/server/schemas/items.ts
+++ b/server/schemas/items.ts
@@ -80,5 +80,46 @@ export const searchSchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(20),
 });
 
+// Import schema — accepts JSON string arrays from export files
+export const jsonStringArray = z.preprocess(
+  (val) => {
+    if (typeof val === "string") {
+      try {
+        return JSON.parse(val);
+      } catch {
+        return val;
+      }
+    }
+    return val;
+  },
+  z.array(z.string().min(1).max(200)).max(20),
+);
+
+export const importItemSchema = z
+  .object({
+    id: z.string().uuid(),
+    type: z.enum(["note", "todo", "scratch"]).default("note"),
+    title: z.string().min(1).max(500),
+    content: z.string().max(50000).default(""),
+    status: statusEnum.default("fleeting"),
+    priority: z.enum(["low", "medium", "high"]).nullable().default(null),
+    due: z.string().nullable().default(null),
+    tags: jsonStringArray.default([]),
+    origin: z.string().default(""),
+    source: z.string().nullable().default(null),
+    aliases: jsonStringArray.default([]),
+    linked_note_id: z.string().nullable().default(null),
+    created: z.string().min(1),
+    modified: z.string().min(1),
+  })
+  .refine((data) => isValidTypeStatus(data.type, data.status), {
+    message: "Invalid status for the given type",
+    path: ["status"],
+  });
+
+export const importSchema = z.object({
+  items: z.array(importItemSchema).max(10000),
+});
+
 export type CreateItemInput = z.infer<typeof createItemSchema>;
 export type UpdateItemInput = z.infer<typeof updateItemSchema>;


### PR DESCRIPTION
## Summary

- Move `jsonStringArray`, `importItemSchema`, and `importSchema` from `server/index.ts` to `server/schemas/items.ts` as exports
- `server/index.ts` and `api.test.ts` both import from the single source of truth
- Eliminates schema duplication that caused test drift (discovered fixing #182/#183 in PR #186)
- Net -39 lines (85 deleted, 46 added)

## Test plan

- [x] 102 API tests pass
- [x] ESLint + TypeScript type check clean
- [ ] E2E tests pass after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)