### PR TITLE
feat(db): add is_private column (migration v15)

### DIFF
--- a/server/db/__tests__/migration-v15.test.ts
+++ b/server/db/__tests__/migration-v15.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { initializeDatabase } from "../index";
+
+function createV14Database() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec(`
+    CREATE TABLE schema_version (version INTEGER NOT NULL);
+    INSERT INTO schema_version (version) VALUES (14);
+
+    CREATE TABLE items (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL DEFAULT 'note',
+      title TEXT NOT NULL,
+      content TEXT DEFAULT '',
+      status TEXT NOT NULL DEFAULT 'fleeting',
+      priority TEXT,
+      due TEXT,
+      tags TEXT NOT NULL DEFAULT '[]',
+      origin TEXT DEFAULT '',
+      source TEXT DEFAULT NULL,
+      aliases TEXT NOT NULL DEFAULT '[]',
+      linked_note_id TEXT DEFAULT NULL,
+      category_id TEXT DEFAULT NULL,
+      viewed_at TEXT DEFAULT NULL,
+      created TEXT NOT NULL,
+      modified TEXT NOT NULL,
+      FOREIGN KEY (linked_note_id) REFERENCES items(id) ON DELETE SET NULL,
+      FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE SET NULL
+    );
+    CREATE INDEX idx_items_status ON items(status);
+    CREATE INDEX idx_items_type ON items(type);
+    CREATE INDEX idx_items_created ON items(created DESC);
+    CREATE INDEX idx_items_viewed_at ON items(viewed_at);
+    CREATE INDEX idx_items_status_modified ON items(status, modified);
+
+    CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    CREATE TABLE share_tokens (
+      id TEXT PRIMARY KEY, item_id TEXT NOT NULL,
+      token TEXT NOT NULL UNIQUE, visibility TEXT NOT NULL DEFAULT 'unlisted',
+      created TEXT NOT NULL,
+      FOREIGN KEY (item_id) REFERENCES items(id) ON DELETE CASCADE
+    );
+    CREATE TABLE categories (
+      id TEXT PRIMARY KEY, name TEXT NOT NULL UNIQUE,
+      sort_order INTEGER NOT NULL DEFAULT 0, color TEXT DEFAULT NULL,
+      created TEXT NOT NULL, modified TEXT NOT NULL
+    );
+  `);
+  return sqlite;
+}
+
+describe("Migration v15: is_private column", () => {
+  it("adds is_private column with default 0", () => {
+    const sqlite = new Database(":memory:");
+    initializeDatabase(sqlite);
+    const cols = sqlite.pragma("table_info(items)") as { name: string; dflt_value: string }[];
+    const col = cols.find((c) => c.name === "is_private");
+    expect(col).toBeDefined();
+    expect(col!.dflt_value).toBe("0");
+  });
+
+  it("creates composite indexes", () => {
+    const sqlite = new Database(":memory:");
+    initializeDatabase(sqlite);
+    const indexes = sqlite.pragma("index_list(items)") as { name: string }[];
+    const names = indexes.map((i) => i.name);
+    expect(names).toContain("idx_items_private_status");
+    expect(names).toContain("idx_items_private_status_modified");
+  });
+
+  it("preserves original indexes as safety net", () => {
+    const sqlite = new Database(":memory:");
+    initializeDatabase(sqlite);
+    const indexes = sqlite.pragma("index_list(items)") as { name: string }[];
+    const names = indexes.map((i) => i.name);
+    expect(names).toContain("idx_items_status");
+  });
+
+  it("is idempotent (running twice does not error)", () => {
+    const sqlite = new Database(":memory:");
+    initializeDatabase(sqlite);
+    expect(() => initializeDatabase(sqlite)).not.toThrow();
+  });
+
+  it("upgrade from v14: adds is_private column to existing rows", () => {
+    const sqlite = createV14Database();
+    sqlite.exec(
+      `INSERT INTO items (id, title, created, modified) VALUES ('item-1', 'Test', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')`,
+    );
+    initializeDatabase(sqlite);
+
+    const row = sqlite.prepare("SELECT is_private FROM items WHERE id = 'item-1'").get() as {
+      is_private: number;
+    };
+    expect(row.is_private).toBe(0);
+
+    const ver = sqlite.prepare("SELECT version FROM schema_version").get() as { version: number };
+    expect(ver.version).toBe(15);
+  });
+
+  it("upgrade from v14: is idempotent", () => {
+    const sqlite = createV14Database();
+    initializeDatabase(sqlite);
+    expect(() => initializeDatabase(sqlite)).not.toThrow();
+  });
+});

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -8,7 +8,7 @@ import { logger } from "../lib/logger.js";
 
 const DB_PATH = process.env.DATABASE_URL || "./data/todo.db";
 
-const TARGET_VERSION = 14;
+const TARGET_VERSION = 15;
 
 function getSchemaVersion(sqlite: Database.Database): number {
   // Check if schema_version table exists
@@ -295,18 +295,26 @@ function runMigrations(sqlite: Database.Database) {
 
     setSchemaVersion(sqlite, 14);
   }
+
+  // Step 14→15: Add is_private column + composite indexes
+  if (version < 15) {
+    try {
+      sqlite.exec("ALTER TABLE items ADD COLUMN is_private INTEGER DEFAULT 0");
+    } catch (e: unknown) {
+      const msg = (e as Error).message || "";
+      if (!msg.includes("duplicate column")) throw e;
+    }
+
+    sqlite.exec("CREATE INDEX IF NOT EXISTS idx_items_private_status ON items(is_private, status)");
+    sqlite.exec(
+      "CREATE INDEX IF NOT EXISTS idx_items_private_status_modified ON items(is_private, status, modified)",
+    );
+
+    setSchemaVersion(sqlite, 15);
+  }
 }
 
-function createDb() {
-  mkdirSync(dirname(DB_PATH), { recursive: true });
-  const sqlite = new Database(DB_PATH);
-  sqlite.pragma("journal_mode = WAL");
-  sqlite.pragma("foreign_keys = ON");
-  sqlite.pragma("synchronous = NORMAL");
-  sqlite.pragma("journal_size_limit = 67108864");
-
-  const db = drizzle(sqlite, { schema });
-
+export function initializeDatabase(sqlite: Database.Database) {
   // Check if the items table exists
   const tableExists = sqlite
     .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='items'")
@@ -330,6 +338,7 @@ function createDb() {
         linked_note_id TEXT DEFAULT NULL,
         category_id TEXT DEFAULT NULL,
         viewed_at TEXT DEFAULT NULL,
+        is_private INTEGER DEFAULT 0,
         created TEXT NOT NULL,
         modified TEXT NOT NULL,
         FOREIGN KEY (linked_note_id) REFERENCES items(id) ON DELETE SET NULL,
@@ -341,6 +350,8 @@ function createDb() {
       CREATE INDEX idx_items_created ON items(created DESC);
       CREATE INDEX idx_items_viewed_at ON items(viewed_at);
       CREATE INDEX idx_items_status_modified ON items(status, modified);
+      CREATE INDEX idx_items_private_status ON items(is_private, status);
+      CREATE INDEX idx_items_private_status_modified ON items(is_private, status, modified);
 
       CREATE TABLE settings (
         key TEXT PRIMARY KEY,
@@ -394,6 +405,19 @@ function createDb() {
   }
 
   setupFTS(sqlite);
+}
+
+function createDb() {
+  mkdirSync(dirname(DB_PATH), { recursive: true });
+  const sqlite = new Database(DB_PATH);
+  sqlite.pragma("journal_mode = WAL");
+  sqlite.pragma("foreign_keys = ON");
+  sqlite.pragma("synchronous = NORMAL");
+  sqlite.pragma("journal_size_limit = 67108864");
+
+  const db = drizzle(sqlite, { schema });
+
+  initializeDatabase(sqlite);
 
   // Checkpoint and truncate WAL to reclaim space from previous sessions
   try {

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -32,6 +32,7 @@ export const items = sqliteTable(
     linked_note_id: text("linked_note_id"),
     category_id: text("category_id"),
     viewed_at: text("viewed_at"),
+    is_private: integer("is_private").default(0),
     created: text("created").notNull(),
     modified: text("modified").notNull(),
   },
@@ -42,6 +43,8 @@ export const items = sqliteTable(
     index("idx_items_category_id").on(table.category_id),
     index("idx_items_viewed_at").on(table.viewed_at),
     index("idx_items_status_modified").on(table.status, table.modified),
+    index("idx_items_private_status").on(table.is_private, table.status),
+    index("idx_items_private_status_modified").on(table.is_private, table.status, table.modified),
   ],
 );
 

--- a/server/test-utils.ts
+++ b/server/test-utils.ts
@@ -24,6 +24,7 @@ export function createTestDb() {
       linked_note_id TEXT DEFAULT NULL,
       category_id TEXT DEFAULT NULL,
       viewed_at TEXT DEFAULT NULL,
+      is_private INTEGER DEFAULT 0,
       created TEXT NOT NULL,
       modified TEXT NOT NULL,
       FOREIGN KEY (linked_note_id) REFERENCES items(id) ON DELETE SET NULL,


### PR DESCRIPTION
## Summary
- Add `is_private INTEGER DEFAULT 0` column to items table
- Add composite indexes: `idx_items_private_status`, `idx_items_private_status_modified`
- Migration v14 → v15 with idempotent ALTER TABLE
- Update Drizzle schema and test-utils to match

## Context
First PR for private notes feature (#192). DB migration deployed separately before feature code.

## Test plan
- [x] Fresh-install path: column exists, indexes created, original indexes preserved
- [x] Upgrade path (v14→v15): column added to existing rows with default 0
- [x] Idempotent: running migration twice does not error
- [x] Full test suite passes (947 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)