### PR TITLE
feat(frontend): add idle timer and improve private notes lock mechanism

### DIFF
--- a/quality/defect-taxonomy.md
+++ b/quality/defect-taxonomy.md
@@ -20,20 +20,20 @@
 
 ## 分類總覽
 
-| 代號      | 缺陷類別                | 層級              | 已知實例                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | 搜查狀態      |
-| --------- | ----------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| 代號      | 缺陷類別                | 層級              | 已知實例                                                                       | 搜查狀態      |
+| --------- | ----------------------- | ----------------- | ------------------------------------------------------------------------------ | ------------- |
 | D-SILENT  | 靜默失敗與可觀測性缺口  | 全層              | DEF-001, DEF-011, DEF-012, DEF-018, DEF-019, DEF-022, DEF-025, DEF-026, TD-026 | ✅ 2026-03-20 |
-| D-VALID   | 輸入驗證缺口            | API               | DEF-003, DEF-004, DEF-005, DEF-013, DEF-021, DEF-025                                                                                                                                                                                                          | ✅ 2026-03-20 |
-| D-STATE   | 前端狀態管理不一致      | Frontend          | DEF-002, DEF-015, DEF-016                                                                                                                                                                                                                                                                                                                                                                          | ✅ 2026-03-20 |
-| D-OFFLINE | 離線同步與 PWA 問題     | Frontend / SW     | (DEF-001)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | ✅ 2026-03-20 |
-| D-QUERY   | 查詢語意錯誤            | Server            | DEF-010                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | ✅ 2026-03-20 |
-| D-MIGRATE | DB Migration 安全性     | Server            | —                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | ✅ 2026-03-20 |
-| D-AUTH    | 認證、授權與安全防線    | API / 全層        | —                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | ✅ 2026-03-20 |
-| D-EDGE    | 邊界條件與資源限制      | 全層              | DEF-006, DEF-007                                                                                                                                                                                                                                                                                                                                                                                                                                                                | ✅ 2026-03-20 |
-| D-TYPE    | TypeScript 型別安全漏洞 | Frontend / Server | DEF-008, TD-001, TD-004, TD-005, TD-006                                                                                                                                                                                                                                                                  | ✅ 2026-03-20 |
-| D-PERF    | 效能問題                | 全層              | DEF-009, DEF-014, TD-002, TD-003, FG-001                                                                                                                                                                                                                                                                                            | ✅ 2026-03-20 |
-| D-DEPLOY  | Build/Deploy 一致性     | DevOps            | TD-027                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | ✅ 2026-03-20 |
-| D-RACE    | 競態條件與並發問題      | Frontend / Server | DEF-024                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | ✅ 2026-03-20 |
+| D-VALID   | 輸入驗證缺口            | API               | DEF-003, DEF-004, DEF-005, DEF-013, DEF-021, DEF-025                           | ✅ 2026-03-20 |
+| D-STATE   | 前端狀態管理不一致      | Frontend          | DEF-002, DEF-015, DEF-016                                                      | ✅ 2026-03-20 |
+| D-OFFLINE | 離線同步與 PWA 問題     | Frontend / SW     | (DEF-001)                                                                      | ✅ 2026-03-20 |
+| D-QUERY   | 查詢語意錯誤            | Server            | DEF-010                                                                        | ✅ 2026-03-20 |
+| D-MIGRATE | DB Migration 安全性     | Server            | —                                                                              | ✅ 2026-03-20 |
+| D-AUTH    | 認證、授權與安全防線    | API / 全層        | —                                                                              | ✅ 2026-03-20 |
+| D-EDGE    | 邊界條件與資源限制      | 全層              | DEF-006, DEF-007                                                               | ✅ 2026-03-20 |
+| D-TYPE    | TypeScript 型別安全漏洞 | Frontend / Server | DEF-008, TD-001, TD-004, TD-005, TD-006                                        | ✅ 2026-03-20 |
+| D-PERF    | 效能問題                | 全層              | DEF-009, DEF-014, TD-002, TD-003, FG-001                                       | ✅ 2026-03-20 |
+| D-DEPLOY  | Build/Deploy 一致性     | DevOps            | TD-027                                                                         | ✅ 2026-03-20 |
+| D-RACE    | 競態條件與並發問題      | Frontend / Server | DEF-024                                                                        | ✅ 2026-03-20 |
 
 ---
 
@@ -132,7 +132,13 @@ grep -rn "z\.object" server/ --include="*.ts"
 - DEF-005 — LINE !tag 繞過 Zod max(20) 限制
 - DEF-013 — Short ID prefix lookup 無 max 長度驗證、LIKE 查詢缺 ORDER BY（High / S2-Major）
 
-**審查但判定合理：** 路徑參數 :id 未顯式驗證但由 DB lookup 保護、FTS5 轉義正確。
+**增量搜查（2026-03-22 資料層/輸入層安全評估）：**
+
+- Issue #182（Defect, High / S2-Major）— Import API 未驗證 type-status 組合（`importItemSchema` 缺 `.refine()`），可寫入 `{type: "todo", status: "fleeting"}` 等無效狀態
+- Issue #183（Defect, Low / S4-Trivial）— Tags/aliases 陣列元素允許空字串，缺 `.min(1)`
+- Issue #184（Tech Debt, Low）— Import 未驗證 FK 參照完整性（linked_note_id / category_id），可能觸發 FK constraint error 500
+
+**審查但判定合理：** 路徑參數 :id 未顯式驗證但由 DB lookup 保護、FTS5 轉義正確。UUID format 由 Zod `.uuid()` 嚴格檢查。Short ID prefix lookup 已有 `LIKE_SAFE_RE` 防止 LIKE wildcards 注入。MCP vault `readVaultFileByPath` 不限副檔名但有 `resolveVaultPath()` 路徑邊界檢查。Zod v3 預設 strip unknown keys（無 `.passthrough()`），prototype pollution 不適用。日期格式 regex 不做語意驗證（`"9999-99-99"` 可通過），SQLite TEXT 儲存不受影響。
 
 ---
 
@@ -314,13 +320,23 @@ grep -rn "eval(\|new Function(" src/ server/ --include="*.ts" --include="*.tsx"
 
 **範圍：** 認證、secret 儲存、CSP/XSS 全面搜查。
 
-**發現：** 無缺陷。
+**發現：**
 
-**認證與授權：** Bearer token timing-safe 比較正確、全域 authMiddleware 覆蓋所有 /api/\* 路由、公開路由正確過濾 visibility、LINE webhook HMAC-SHA256 驗證正確。
+- Issue #180（Defect, Low）— `server/routes/settings.ts:92` 錯誤回應洩漏伺服器檔案系統路徑（`Vault path is not writable: ${vaultPath}`）
 
-**Secret 儲存：** localStorage auth_token 是 SPA 標準做法（CF Access 已在前端保護）。SW token 透過 MessageChannel 安全傳遞（非 localStorage 暴露）。.env 正確 gitignored。
+**增量搜查（2026-03-22 全專案安全性評估）：**
 
-**內容注入：** CSP `script-src 'self'` 阻擋 inline script。`style-src 'unsafe-inline'` 為 Tailwind 所需。無 dangerouslySetInnerHTML、無 eval。react-markdown 安全渲染（不執行 HTML）。
+- Issue #178（Tech Debt, High）— Rate limiter IP 提取依賴 `X-Forwarded-For`（`server/middleware/rate-limit.ts:4-8`），可被偽造繞過。屬 D-EDGE 交叉，但根因在安全防線設計。
+- Issue #179（Tech Debt, Medium）— 缺少 HSTS / `X-Content-Type-Options: nosniff` / `Referrer-Policy` / `Permissions-Policy` 安全標頭
+- Issue #181（Tech Debt, Low）— `/s/*` 公開分享頁 CSP 使用 `unsafe-inline` script
+
+**認證與授權：** Bearer token timing-safe 比較正確、全域 authMiddleware 覆蓋所有 /api/\* 路由、公開路由正確過濾 visibility、LINE webhook HMAC-SHA256 驗證正確。Auth token 啟動時驗證 entropy ≥ 3.0、長度 ≥ 32。暴露面僅 4 個無 auth 入口（health、public、webhook、share page），全部有速率限制。
+
+**Secret 儲存：** localStorage auth_token 是 SPA 標準做法（CF Access 已在前端保護）。SW token 透過 MessageChannel 安全傳遞（非 localStorage 暴露）。.env 正確 gitignored，從未 commit 到 git。Share token 使用 `randomBytes(9)`（72-bit entropy），不可暴力猜測。
+
+**內容注入：** CSP `script-src 'self'` 阻擋 inline script（`/s/*` 例外，見 Issue #181）。`style-src 'unsafe-inline'` 為 Tailwind 所需。無 dangerouslySetInnerHTML、無 eval。react-markdown 安全渲染（不執行 HTML）。SSR 公開頁使用 `escapeHtml()` 處理所有使用者輸入。
+
+**輸入驗證（D-VALID 交叉確認）：** Zod 全覆蓋所有 API 路由、FTS5 `escapeFts5Query()` 防搜尋注入、body size limit 1MB。Drizzle ORM + prepared statements 零原生 SQL 拼接。`sanitizeFilename()` 防路徑遍歷。零 `exec()`/`spawn()` 呼叫。
 
 ---
 

--- a/src/hooks/__tests__/use-private-lock.test.ts
+++ b/src/hooks/__tests__/use-private-lock.test.ts
@@ -1,0 +1,416 @@
+import { renderHook, act, cleanup } from "@testing-library/react";
+import { usePrivateLock } from "../use-private-lock";
+
+// --- Setup ---
+
+let originalVisibilityState: string;
+
+beforeEach(() => {
+  originalVisibilityState = document.visibilityState;
+  vi.useFakeTimers();
+  vi.spyOn(globalThis, "fetch").mockImplementation(() =>
+    Promise.resolve(new Response(JSON.stringify({ success: true }))),
+  );
+  localStorage.setItem("auth_token", "test-auth-token");
+});
+
+afterEach(() => {
+  // Unmount hooks BEFORE restoring mocks, so cleanup effects
+  // (fireLock on unmount) still use the mocked fetch.
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  Object.defineProperty(document, "visibilityState", {
+    value: originalVisibilityState,
+    writable: true,
+    configurable: true,
+  });
+  localStorage.clear();
+});
+
+function setVisibilityState(state: "visible" | "hidden") {
+  Object.defineProperty(document, "visibilityState", {
+    value: state,
+    writable: true,
+    configurable: true,
+  });
+}
+
+function fireVisibilityChange(state: "visible" | "hidden") {
+  setVisibilityState(state);
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+// --- Tests ---
+
+describe("usePrivateLock", () => {
+  // === Group 1: Initialization ===
+
+  describe("initialization", () => {
+    it("returns overlayVisible=false by default", () => {
+      const { result } = renderHook(() => usePrivateLock({ sessionToken: "tok", onLock: vi.fn() }));
+      expect(result.current.overlayVisible).toBe(false);
+    });
+
+    it("does not attach listeners when sessionToken is null", () => {
+      const addSpy = vi.spyOn(document, "addEventListener");
+      const winAddSpy = vi.spyOn(window, "addEventListener");
+
+      renderHook(() => usePrivateLock({ sessionToken: null, onLock: vi.fn() }));
+
+      expect(addSpy).not.toHaveBeenCalledWith("visibilitychange", expect.any(Function));
+      expect(winAddSpy).not.toHaveBeenCalledWith("blur", expect.any(Function));
+      expect(addSpy).not.toHaveBeenCalledWith(
+        "pointerdown",
+        expect.any(Function),
+        expect.anything(),
+      );
+
+      addSpy.mockRestore();
+      winAddSpy.mockRestore();
+    });
+  });
+
+  // === Group 2: Visibility trigger ===
+
+  describe("visibilitychange trigger", () => {
+    it("shows overlay and calls onLock when page becomes hidden", () => {
+      const onLock = vi.fn();
+      const { result } = renderHook(() => usePrivateLock({ sessionToken: "tok", onLock }));
+
+      act(() => fireVisibilityChange("hidden"));
+
+      expect(result.current.overlayVisible).toBe(true);
+      expect(onLock).toHaveBeenCalledOnce();
+    });
+
+    it("fires lock API with keepalive", () => {
+      renderHook(() => usePrivateLock({ sessionToken: "tok", onLock: vi.fn() }));
+
+      act(() => fireVisibilityChange("hidden"));
+
+      expect(fetch).toHaveBeenCalledWith("/api/private/lock", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-auth-token",
+          "X-Private-Token": "tok",
+        },
+        keepalive: true,
+      });
+    });
+
+    it("does not trigger on visibilityState=visible", () => {
+      const onLock = vi.fn();
+      renderHook(() => usePrivateLock({ sessionToken: "tok", onLock }));
+
+      act(() => fireVisibilityChange("visible"));
+
+      expect(onLock).not.toHaveBeenCalled();
+    });
+
+    it("prevents double-lock on rapid visibility changes", () => {
+      const onLock = vi.fn();
+      renderHook(() => usePrivateLock({ sessionToken: "tok", onLock }));
+
+      act(() => {
+        fireVisibilityChange("hidden");
+        fireVisibilityChange("hidden");
+      });
+
+      expect(onLock).toHaveBeenCalledOnce();
+      expect(fetch).toHaveBeenCalledOnce();
+    });
+  });
+
+  // === Group 3: Blur/focus trigger ===
+
+  describe("blur/focus trigger", () => {
+    it("shows overlay after blur grace period", () => {
+      const { result } = renderHook(() =>
+        usePrivateLock({
+          sessionToken: "tok",
+          onLock: vi.fn(),
+          blurGraceMs: 200,
+        }),
+      );
+
+      act(() => window.dispatchEvent(new Event("blur")));
+      expect(result.current.overlayVisible).toBe(false);
+
+      act(() => vi.advanceTimersByTime(200));
+      expect(result.current.overlayVisible).toBe(true);
+    });
+
+    it("cancels overlay if focus returns within grace period", () => {
+      const { result } = renderHook(() =>
+        usePrivateLock({
+          sessionToken: "tok",
+          onLock: vi.fn(),
+          blurGraceMs: 200,
+        }),
+      );
+
+      act(() => window.dispatchEvent(new Event("blur")));
+      act(() => vi.advanceTimersByTime(100));
+      act(() => window.dispatchEvent(new Event("focus")));
+      act(() => vi.advanceTimersByTime(200));
+
+      expect(result.current.overlayVisible).toBe(false);
+    });
+
+    it("hides overlay on focus when blur-only overlay was shown", () => {
+      const onLock = vi.fn();
+      const { result } = renderHook(() =>
+        usePrivateLock({
+          sessionToken: "tok",
+          onLock,
+          blurGraceMs: 200,
+        }),
+      );
+
+      act(() => window.dispatchEvent(new Event("blur")));
+      act(() => vi.advanceTimersByTime(200));
+      expect(result.current.overlayVisible).toBe(true);
+
+      act(() => window.dispatchEvent(new Event("focus")));
+      expect(result.current.overlayVisible).toBe(false);
+      expect(onLock).not.toHaveBeenCalled();
+    });
+
+    it("does NOT call onLock on blur", () => {
+      const onLock = vi.fn();
+      renderHook(() =>
+        usePrivateLock({
+          sessionToken: "tok",
+          onLock,
+          blurGraceMs: 200,
+        }),
+      );
+
+      act(() => window.dispatchEvent(new Event("blur")));
+      act(() => vi.advanceTimersByTime(200));
+
+      expect(onLock).not.toHaveBeenCalled();
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("skips blur handler when already locked by visibilitychange", () => {
+      const { result } = renderHook(() =>
+        usePrivateLock({
+          sessionToken: "tok",
+          onLock: vi.fn(),
+          blurGraceMs: 200,
+        }),
+      );
+
+      // Lock via visibilitychange first
+      act(() => fireVisibilityChange("hidden"));
+      expect(result.current.overlayVisible).toBe(true);
+
+      // blur should be no-op (lockedRef is true)
+      act(() => window.dispatchEvent(new Event("blur")));
+      act(() => vi.advanceTimersByTime(200));
+
+      // onLock and fetch should have been called exactly once (from visibility)
+      expect(fetch).toHaveBeenCalledOnce();
+    });
+  });
+
+  // === Group 4: Idle timer ===
+
+  describe("idle timer", () => {
+    const IDLE_MS = 5 * 60 * 1000; // 5 min default
+
+    it("locks after idle timeout expires", () => {
+      const onLock = vi.fn();
+      const { result } = renderHook(() => usePrivateLock({ sessionToken: "tok", onLock }));
+
+      act(() => vi.advanceTimersByTime(IDLE_MS));
+
+      expect(result.current.overlayVisible).toBe(true);
+      expect(onLock).toHaveBeenCalledOnce();
+      expect(fetch).toHaveBeenCalledOnce();
+    });
+
+    it("resets idle timer on user activity", () => {
+      const onLock = vi.fn();
+      renderHook(() => usePrivateLock({ sessionToken: "tok", onLock }));
+
+      // Advance 4 min, then activity
+      act(() => vi.advanceTimersByTime(4 * 60 * 1000));
+      act(() => document.dispatchEvent(new Event("pointerdown")));
+
+      // Advance another 4 min — should NOT have locked (timer reset)
+      act(() => vi.advanceTimersByTime(4 * 60 * 1000));
+      expect(onLock).not.toHaveBeenCalled();
+
+      // Advance 1 more min (total 5 after last activity) — should lock
+      act(() => vi.advanceTimersByTime(1 * 60 * 1000));
+      expect(onLock).toHaveBeenCalledOnce();
+    });
+
+    it("throttles timer resets (ignores activity within 30s)", () => {
+      const onLock = vi.fn();
+      renderHook(() => usePrivateLock({ sessionToken: "tok", onLock }));
+
+      // t=10s: keydown — should be throttled (< 30s since mount)
+      act(() => vi.advanceTimersByTime(10_000));
+      act(() => document.dispatchEvent(new Event("keydown")));
+
+      // t=31s: keydown — should reset timer (>= 30s since last reset at t=0)
+      act(() => vi.advanceTimersByTime(21_000));
+      act(() => document.dispatchEvent(new Event("keydown")));
+
+      // Timer resets at t=31s → lock at t=31s + 5min = t=331s
+      // Advance to t=31s + 4min59s = t=330s — should NOT be locked
+      act(() => vi.advanceTimersByTime(4 * 60 * 1000 + 59_000));
+      expect(onLock).not.toHaveBeenCalled();
+
+      // Advance 1 more second to t=331s — should lock
+      act(() => vi.advanceTimersByTime(1_000));
+      expect(onLock).toHaveBeenCalledOnce();
+    });
+
+    it("accepts custom idle timeout", () => {
+      const onLock = vi.fn();
+      renderHook(() =>
+        usePrivateLock({
+          sessionToken: "tok",
+          onLock,
+          idleTimeoutMs: 60_000,
+        }),
+      );
+
+      act(() => vi.advanceTimersByTime(59_999));
+      expect(onLock).not.toHaveBeenCalled();
+
+      act(() => vi.advanceTimersByTime(1));
+      expect(onLock).toHaveBeenCalledOnce();
+    });
+  });
+
+  // === Group 5: Unmount ===
+
+  describe("unmount", () => {
+    it("fires lock API on unmount when token is set", () => {
+      const { unmount } = renderHook(() =>
+        usePrivateLock({ sessionToken: "tok", onLock: vi.fn() }),
+      );
+
+      unmount();
+
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/private/lock",
+        expect.objectContaining({ keepalive: true }),
+      );
+    });
+
+    it("does NOT fire lock API on unmount when token is null", () => {
+      const { unmount } = renderHook(() => usePrivateLock({ sessionToken: null, onLock: vi.fn() }));
+
+      unmount();
+
+      expect(fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  // === Group 6: Cleanup ===
+
+  describe("cleanup", () => {
+    it("removes all event listeners on unmount", () => {
+      const docRemoveSpy = vi.spyOn(document, "removeEventListener");
+      const winRemoveSpy = vi.spyOn(window, "removeEventListener");
+
+      const { unmount } = renderHook(() =>
+        usePrivateLock({ sessionToken: "tok", onLock: vi.fn() }),
+      );
+
+      unmount();
+
+      expect(docRemoveSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
+      expect(docRemoveSpy).toHaveBeenCalledWith("pointerdown", expect.any(Function));
+      expect(docRemoveSpy).toHaveBeenCalledWith("keydown", expect.any(Function));
+      expect(docRemoveSpy).toHaveBeenCalledWith("scroll", expect.any(Function));
+      expect(winRemoveSpy).toHaveBeenCalledWith("blur", expect.any(Function));
+      expect(winRemoveSpy).toHaveBeenCalledWith("focus", expect.any(Function));
+
+      docRemoveSpy.mockRestore();
+      winRemoveSpy.mockRestore();
+    });
+
+    it("clears idle timer on unmount", () => {
+      const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+
+      const { unmount } = renderHook(() =>
+        usePrivateLock({ sessionToken: "tok", onLock: vi.fn() }),
+      );
+
+      unmount();
+
+      expect(clearSpy).toHaveBeenCalled();
+      clearSpy.mockRestore();
+    });
+
+    it("re-registers listeners when sessionToken changes from null to string", () => {
+      const docAddSpy = vi.spyOn(document, "addEventListener");
+
+      const { rerender } = renderHook(
+        ({ token }) => usePrivateLock({ sessionToken: token, onLock: vi.fn() }),
+        { initialProps: { token: null as string | null } },
+      );
+
+      docAddSpy.mockClear();
+      rerender({ token: "new-tok" });
+
+      expect(docAddSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
+      expect(docAddSpy).toHaveBeenCalledWith(
+        "pointerdown",
+        expect.any(Function),
+        expect.objectContaining({ passive: true }),
+      );
+
+      docAddSpy.mockRestore();
+    });
+  });
+
+  // === Group 7: clearOverlay ===
+
+  describe("clearOverlay", () => {
+    it("resets overlayVisible to false", () => {
+      const { result } = renderHook(() => usePrivateLock({ sessionToken: "tok", onLock: vi.fn() }));
+
+      // Trigger lock to show overlay
+      act(() => fireVisibilityChange("hidden"));
+      expect(result.current.overlayVisible).toBe(true);
+
+      act(() => result.current.clearOverlay());
+      expect(result.current.overlayVisible).toBe(false);
+    });
+
+    it("allows re-locking after clearOverlay + new token", () => {
+      const onLock = vi.fn();
+      const { result, rerender } = renderHook(
+        ({ token }) => usePrivateLock({ sessionToken: token, onLock }),
+        { initialProps: { token: "tok1" as string | null } },
+      );
+
+      // Lock
+      act(() => fireVisibilityChange("hidden"));
+      expect(onLock).toHaveBeenCalledOnce();
+
+      // Simulate re-unlock: parent clears token, then sets new one
+      rerender({ token: null });
+      act(() => result.current.clearOverlay());
+      rerender({ token: "tok2" });
+
+      // Re-set to visible for next test
+      act(() => {
+        setVisibilityState("visible");
+      });
+
+      // Should be able to lock again
+      act(() => fireVisibilityChange("hidden"));
+      expect(onLock).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/hooks/use-private-lock.ts
+++ b/src/hooks/use-private-lock.ts
@@ -1,0 +1,174 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { flushSync } from "react-dom";
+import { getToken } from "@/lib/api";
+
+const DEFAULT_IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+const DEFAULT_BLUR_GRACE_MS = 200;
+const IDLE_THROTTLE_MS = 30_000; // Only reset idle timer if 30s+ since last reset
+
+interface UsePrivateLockOptions {
+  sessionToken: string | null;
+  onLock: () => void;
+  idleTimeoutMs?: number;
+  blurGraceMs?: number;
+}
+
+interface UsePrivateLockReturn {
+  overlayVisible: boolean;
+  clearOverlay: () => void;
+}
+
+export function usePrivateLock({
+  sessionToken,
+  onLock,
+  idleTimeoutMs = DEFAULT_IDLE_TIMEOUT_MS,
+  blurGraceMs = DEFAULT_BLUR_GRACE_MS,
+}: UsePrivateLockOptions): UsePrivateLockReturn {
+  const [overlayVisible, setOverlayVisible] = useState(false);
+
+  // Refs for stale-closure prevention — synced in effects for React 19 concurrent safety
+  const sessionTokenRef = useRef(sessionToken);
+  useEffect(() => {
+    sessionTokenRef.current = sessionToken;
+  });
+
+  const onLockRef = useRef(onLock);
+  useEffect(() => {
+    onLockRef.current = onLock;
+  });
+
+  // Double-lock prevention: reset when a new token arrives (re-unlock)
+  const lockedRef = useRef(false);
+  useEffect(() => {
+    if (sessionToken) lockedRef.current = false;
+  }, [sessionToken]);
+
+  // Timer refs
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const blurGraceTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const lastActivityRef = useRef(Date.now());
+
+  // --- fireLock: raw fetch with keepalive (not request() helper) ---
+  const fireLock = useCallback(() => {
+    if (lockedRef.current) return;
+    const token = sessionTokenRef.current;
+    if (!token) return;
+    lockedRef.current = true;
+    const authToken = getToken();
+    fetch("/api/private/lock", {
+      method: "POST",
+      headers: {
+        ...(authToken && { Authorization: `Bearer ${authToken}` }),
+        "X-Private-Token": token,
+      },
+      keepalive: true,
+    });
+  }, []);
+
+  // --- Shared lock sequence: overlay → fireLock → onLock ---
+  const performLock = useCallback(() => {
+    if (lockedRef.current) return;
+    flushSync(() => setOverlayVisible(true));
+    fireLock();
+    onLockRef.current();
+  }, [fireLock]);
+
+  // --- Trigger A: visibilitychange ---
+  useEffect(() => {
+    if (!sessionToken) return;
+    const handleVisibility = () => {
+      if (document.visibilityState === "hidden") {
+        performLock();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () => document.removeEventListener("visibilitychange", handleVisibility);
+  }, [sessionToken, performLock]);
+
+  // --- Trigger B: blur/focus (overlay-only, no lock API) ---
+  useEffect(() => {
+    if (!sessionToken) return;
+
+    const handleBlur = () => {
+      if (lockedRef.current) return;
+      if (blurGraceTimerRef.current) return; // Already pending
+      blurGraceTimerRef.current = setTimeout(() => {
+        blurGraceTimerRef.current = undefined;
+        if (!lockedRef.current && sessionTokenRef.current) {
+          flushSync(() => setOverlayVisible(true));
+        }
+      }, blurGraceMs);
+    };
+
+    const handleFocus = () => {
+      // Cancel pending grace timer
+      if (blurGraceTimerRef.current) {
+        clearTimeout(blurGraceTimerRef.current);
+        blurGraceTimerRef.current = undefined;
+      }
+      // Hide blur-only overlay (not a full lock)
+      if (!lockedRef.current) {
+        setOverlayVisible(false);
+      }
+    };
+
+    window.addEventListener("blur", handleBlur);
+    window.addEventListener("focus", handleFocus);
+    return () => {
+      window.removeEventListener("blur", handleBlur);
+      window.removeEventListener("focus", handleFocus);
+      if (blurGraceTimerRef.current) {
+        clearTimeout(blurGraceTimerRef.current);
+        blurGraceTimerRef.current = undefined;
+      }
+    };
+  }, [sessionToken, blurGraceMs]);
+
+  // --- Trigger C: idle timer ---
+  useEffect(() => {
+    if (!sessionToken) return;
+
+    // Start idle timer
+    lastActivityRef.current = Date.now();
+    idleTimerRef.current = setTimeout(() => {
+      if (sessionTokenRef.current) performLock();
+    }, idleTimeoutMs);
+
+    const handleActivity = () => {
+      const now = Date.now();
+      if (now - lastActivityRef.current < IDLE_THROTTLE_MS) return;
+      lastActivityRef.current = now;
+      clearTimeout(idleTimerRef.current);
+      idleTimerRef.current = setTimeout(() => {
+        if (sessionTokenRef.current) performLock();
+      }, idleTimeoutMs);
+    };
+
+    document.addEventListener("pointerdown", handleActivity, { passive: true });
+    document.addEventListener("keydown", handleActivity, { passive: true });
+    document.addEventListener("scroll", handleActivity, { passive: true });
+
+    return () => {
+      document.removeEventListener("pointerdown", handleActivity);
+      document.removeEventListener("keydown", handleActivity);
+      document.removeEventListener("scroll", handleActivity);
+      clearTimeout(idleTimerRef.current);
+      idleTimerRef.current = undefined;
+    };
+  }, [sessionToken, idleTimeoutMs, performLock]);
+
+  // --- Trigger D: unmount (route navigation away) ---
+  useEffect(() => {
+    if (!sessionToken) return;
+    return () => {
+      fireLock();
+    };
+  }, [sessionToken, fireLock]);
+
+  // --- clearOverlay: called on successful PIN unlock ---
+  const clearOverlay = useCallback(() => {
+    setOverlayVisible(false);
+  }, []);
+
+  return { overlayVisible, clearOverlay };
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -22,7 +22,7 @@ import type {
 
 const API_BASE = "/api";
 
-function getToken(): string | null {
+export function getToken(): string | null {
   return localStorage.getItem("auth_token");
 }
 

--- a/src/routes/private.tsx
+++ b/src/routes/private.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef, lazy, Suspense } from "react";
 import { PrivateOverlay } from "@/components/private-overlay";
+import { usePrivateLock } from "@/hooks/use-private-lock";
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Input } from "@/components/ui/input";
@@ -1023,54 +1024,16 @@ function ListHeader({
 
 function PrivatePage() {
   const [sessionToken, setSessionToken] = useState<string | null>(null);
-  const [overlayVisible, setOverlayVisible] = useState(false);
 
   const { data: status, isLoading: statusLoading } = useQuery({
     queryKey: queryKeys.private.status,
     queryFn: getPrivateStatus,
   });
 
-  // Lock helper: fires lock API and clears token. Uses ref to prevent double-lock.
-  const lockedRef = useRef(false);
-  useEffect(() => {
-    if (sessionToken) lockedRef.current = false;
-  }, [sessionToken]);
-
-  const fireLock = useCallback((tokenToLock: string) => {
-    if (lockedRef.current) return;
-    lockedRef.current = true;
-    const authToken = localStorage.getItem("auth_token");
-    fetch("/api/private/lock", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${authToken}`,
-        "X-Private-Token": tokenToLock,
-      },
-      keepalive: true,
-    });
-  }, []);
-
-  // visibilitychange: lock when page becomes hidden (before OS screenshot)
-  useEffect(() => {
-    if (!sessionToken) return;
-    const handleVisibility = () => {
-      if (document.visibilityState === "hidden") {
-        setOverlayVisible(true); // Sync render before OS takes screenshot
-        fireLock(sessionToken);
-        setSessionToken(null);
-      }
-    };
-    document.addEventListener("visibilitychange", handleVisibility);
-    return () => document.removeEventListener("visibilitychange", handleVisibility);
-  }, [sessionToken, fireLock]);
-
-  // Route leave: lock on unmount (navigation away from /private)
-  useEffect(() => {
-    if (!sessionToken) return;
-    return () => {
-      fireLock(sessionToken);
-    };
-  }, [sessionToken, fireLock]);
+  const { overlayVisible, clearOverlay } = usePrivateLock({
+    sessionToken,
+    onLock: () => setSessionToken(null),
+  });
 
   const content = (() => {
     if (statusLoading) {
@@ -1095,7 +1058,7 @@ function PrivatePage() {
     return (
       <PinUnlockView
         onUnlocked={(token) => {
-          setOverlayVisible(false);
+          clearOverlay();
           setSessionToken(token);
         }}
       />


### PR DESCRIPTION
## Summary

- Extract inline lock logic from `PrivatePage` into `usePrivateLock` hook (net -35 lines from `private.tsx`)
- Add **idle timer** (5 min default) — locks private notes when user is inactive (PC walk-away scenario)
- Add **blur/focus handler** with 200ms grace period — shows overlay earlier than `visibilitychange` for app switcher
- Use `flushSync` for synchronous overlay rendering before OS screenshots
- Activity detection via `pointerdown`/`keydown`/`scroll` with 30s throttle
- Fix latent bug: old code sent `Authorization: Bearer null` when auth token was missing
- Export `getToken()` from `api.ts` to eliminate duplicated `localStorage.getItem("auth_token")`

## Test plan

- [x] 22 new unit tests for `usePrivateLock` hook (all 7 trigger groups)
- [x] All 1066 existing tests pass
- [x] `tsc --noEmit` clean
- [ ] Manual: unlock private notes → switch tab → verify "已鎖定" on return
- [ ] Manual: unlock → wait 5 min idle → verify auto-lock
- [ ] Manual: unlock → click address bar → verify NO lock (blur grace)
- [ ] Manual: mobile — unlock → switch app → verify "已鎖定" on return

🤖 Generated with [Claude Code](https://claude.com/claude-code)