### PR TITLE
fix(frontend): auto-clear lock overlay to reveal PIN unlock view

### DIFF
--- a/src/components/private-overlay.tsx
+++ b/src/components/private-overlay.tsx
@@ -2,19 +2,22 @@ import { Lock } from "lucide-react";
 
 interface PrivateOverlayProps {
   visible: boolean;
+  onDismiss?: () => void;
 }
 
-export function PrivateOverlay({ visible }: PrivateOverlayProps) {
+export function PrivateOverlay({ visible, onDismiss }: PrivateOverlayProps) {
   if (!visible) return null;
 
   return (
     <div
-      className="fixed inset-0 bg-background flex items-center justify-center"
+      className="fixed inset-0 bg-background flex items-center justify-center cursor-pointer"
       style={{ zIndex: 9999 }}
+      onClick={onDismiss}
     >
       <div className="flex flex-col items-center gap-3 text-muted-foreground">
         <Lock className="h-12 w-12" />
         <p className="text-lg font-medium">已鎖定</p>
+        <p className="text-sm">點擊解鎖</p>
       </div>
     </div>
   );

--- a/src/hooks/__tests__/use-private-lock.test.ts
+++ b/src/hooks/__tests__/use-private-lock.test.ts
@@ -387,6 +387,36 @@ describe("usePrivateLock", () => {
       expect(result.current.overlayVisible).toBe(false);
     });
 
+    it("auto-clears overlay when sessionToken becomes null after full lock", () => {
+      const onLock = vi.fn();
+      const { result, rerender } = renderHook(
+        ({ token }) => usePrivateLock({ sessionToken: token, onLock }),
+        { initialProps: { token: "tok" as string | null } },
+      );
+
+      // Full lock — overlay visible
+      act(() => fireVisibilityChange("hidden"));
+      expect(result.current.overlayVisible).toBe(true);
+
+      // Parent sets sessionToken to null (simulating onLock callback effect)
+      rerender({ token: null });
+      expect(result.current.overlayVisible).toBe(false);
+    });
+
+    it("does NOT auto-clear overlay when sessionToken is still set (blur-only)", () => {
+      const { result } = renderHook(() =>
+        usePrivateLock({ sessionToken: "tok", onLock: vi.fn(), blurGraceMs: 200 }),
+      );
+
+      // Blur-only overlay — sessionToken still set
+      act(() => window.dispatchEvent(new Event("blur")));
+      act(() => vi.advanceTimersByTime(200));
+      expect(result.current.overlayVisible).toBe(true);
+
+      // Auto-clear should NOT fire because sessionToken is still "tok"
+      // (overlay should only be cleared by focus handler)
+    });
+
     it("allows re-locking after clearOverlay + new token", () => {
       const onLock = vi.fn();
       const { result, rerender } = renderHook(

--- a/src/hooks/use-private-lock.ts
+++ b/src/hooks/use-private-lock.ts
@@ -165,6 +165,13 @@ export function usePrivateLock({
     };
   }, [sessionToken, fireLock]);
 
+  // Auto-clear overlay after full lock: content is now PinUnlockView (safe to show)
+  useEffect(() => {
+    if (!sessionToken && overlayVisible) {
+      setOverlayVisible(false);
+    }
+  }, [sessionToken, overlayVisible]);
+
   // --- clearOverlay: called on successful PIN unlock ---
   const clearOverlay = useCallback(() => {
     setOverlayVisible(false);

--- a/src/routes/private.tsx
+++ b/src/routes/private.tsx
@@ -1068,7 +1068,7 @@ function PrivatePage() {
   return (
     <>
       {content}
-      <PrivateOverlay visible={overlayVisible} />
+      <PrivateOverlay visible={overlayVisible} onDismiss={clearOverlay} />
     </>
   );
 }


### PR DESCRIPTION
## Summary

- After full lock, `PrivateOverlay` (z-index 9999) blocked `PinUnlockView` — user was stuck
- Add auto-clear effect in `usePrivateLock`: overlay dismisses when `sessionToken` becomes null
- Add click-to-dismiss as safety net (`onDismiss` prop + "點擊解鎖" text)
- Does NOT affect blur-only overlay (sessionToken still set during blur)

## Test plan

- [x] 24 unit tests pass (2 new: auto-clear + blur-only no-clear)
- [x] All 1068 tests pass
- [ ] Manual: unlock → switch tab → return → overlay auto-clears, PIN input visible
- [ ] Manual: unlock → idle 5 min → overlay auto-clears to PIN input

🤖 Generated with [Claude Code](https://claude.com/claude-code)