### PR TITLE
fix(frontend): add private notes entry to mobile bottom navigation

### DIFF
--- a/src/components/__tests__/bottom-nav.test.tsx
+++ b/src/components/__tests__/bottom-nav.test.tsx
@@ -68,6 +68,7 @@ describe("BottomNav", () => {
 
     await user.click(screen.getByText("更多"));
 
+    expect(screen.getByText("私密筆記")).toBeInTheDocument();
     expect(screen.getByText("全部")).toBeInTheDocument();
     expect(screen.getByText("已封存")).toBeInTheDocument();
     expect(screen.getByText("分享管理")).toBeInTheDocument();
@@ -99,6 +100,14 @@ describe("BottomNav", () => {
 
   it("highlights 更多 button when a more-menu view is active", () => {
     mockPathname = "/settings";
+    renderWithContext(<BottomNav />);
+
+    const moreButton = screen.getByText("更多").closest("button")!;
+    expect(moreButton.className).toContain("text-primary");
+  });
+
+  it("highlights 更多 button when on private notes page", () => {
+    mockPathname = "/private";
     renderWithContext(<BottomNav />);
 
     const moreButton = screen.getByText("更多").closest("button")!;

--- a/src/components/bottom-nav.tsx
+++ b/src/components/bottom-nav.tsx
@@ -11,6 +11,7 @@ import {
   Settings,
   StickyNote,
   Share2,
+  Lock,
 } from "lucide-react";
 
 const mainNavItems = [
@@ -27,6 +28,7 @@ const mainNavItems = [
 ];
 
 const moreItems = [
+  { id: "private", label: "私密筆記", icon: <Lock className="h-4 w-4" />, path: "/private" },
   { id: "all", label: "全部", icon: <FileText className="h-4 w-4" />, path: "/all" },
   { id: "archived", label: "已封存", icon: <Archive className="h-4 w-4" />, path: "/archived" },
   { id: "shares", label: "分享管理", icon: <Share2 className="h-4 w-4" />, path: "/shares" },

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -14,6 +14,7 @@ const VIEW_TO_PATH: Record<string, string> = {
   archived: "/archived",
   settings: "/settings",
   shares: "/shares",
+  private: "/private",
   search: "/", // search is a non-routed overlay, fallback to root
 };
 
@@ -30,6 +31,7 @@ const PATH_TO_VIEW: Record<string, string> = {
   "/archived": "archived",
   "/settings": "settings",
   "/shares": "shares",
+  "/private": "private",
 };
 
 export function viewToPath(view: string): string {


### PR DESCRIPTION
## Summary
- 手機版底部導航「更多」選單加入「私密筆記」入口（`Lock` icon + `/private` 路由）
- `navigation.ts` 加入 `/private` 雙向路徑映射，讓 active 狀態正確 highlight
- 新增測試：驗證選單項目出現 + 「更多」按鈕在 `/private` 頁面 highlight

## Test plan
- [x] `npx vitest run src/components/__tests__/bottom-nav.test.tsx` — 8 tests passed
- [x] `npx tsc --noEmit` — no errors
- [ ] 手機版開啟 → 點「更多」→ 看到「私密筆記」→ 點入可正常進入 `/private`

🤖 Generated with [Claude Code](https://claude.com/claude-code)