### PR TITLE
fix(frontend): keep mobile bottom nav visible when detail panel is open

### DIFF
--- a/src/lib/__tests__/navigation.test.ts
+++ b/src/lib/__tests__/navigation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { viewToPath, pathToView, isListRoute } from "../navigation";
+import { viewToPath, pathToView } from "../navigation";
 
 describe("viewToPath", () => {
   it("maps known views to paths", () => {
@@ -42,24 +42,5 @@ describe("pathToView", () => {
   it("returns undefined for unknown paths", () => {
     expect(pathToView("/unknown")).toBeUndefined();
     expect(pathToView("/")).toBeUndefined();
-  });
-});
-
-describe("isListRoute", () => {
-  it("identifies list routes", () => {
-    expect(isListRoute("/notes/fleeting")).toBe(true);
-    expect(isListRoute("/notes/developing")).toBe(true);
-    expect(isListRoute("/todos")).toBe(true);
-    expect(isListRoute("/todos/done")).toBe(true);
-    expect(isListRoute("/scratch")).toBe(true);
-    expect(isListRoute("/all")).toBe(true);
-    expect(isListRoute("/archived")).toBe(true);
-  });
-
-  it("rejects non-list routes", () => {
-    expect(isListRoute("/dashboard")).toBe(false);
-    expect(isListRoute("/settings")).toBe(false);
-    expect(isListRoute("/shares")).toBe(false);
-    expect(isListRoute("/")).toBe(false);
   });
 });

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -41,20 +41,3 @@ export function viewToPath(view: string): string {
 export function pathToView(path: string): string | undefined {
   return PATH_TO_VIEW[path];
 }
-
-/** Routes that use the list+detail split panel layout */
-export const LIST_ROUTE_PREFIXES = [
-  "/notes",
-  "/todos",
-  "/scratch",
-  "/all",
-  "/archived",
-  "/unreviewed",
-  "/recent",
-  "/attention",
-  "/stale",
-] as const;
-
-export function isListRoute(path: string): boolean {
-  return LIST_ROUTE_PREFIXES.some((prefix) => path === prefix || path.startsWith(prefix + "/"));
-}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useMemo, useState, useCallback } from "react";
-import { createRootRoute, Link, Outlet, useRouterState } from "@tanstack/react-router";
+import { createRootRoute, Link, Outlet } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { Sidebar } from "@/components/sidebar";
 import { BottomNav } from "@/components/bottom-nav";
@@ -12,7 +12,6 @@ import { getConfig } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
 import { AppContext } from "@/lib/app-context";
 import { rootSearchSchema } from "@/lib/search-params";
-import { isListRoute } from "@/lib/navigation";
 import { LoadingFallback } from "@/components/loading-fallback";
 import { X } from "lucide-react";
 
@@ -51,9 +50,7 @@ function NotFoundPage() {
 
 function RootLayout() {
   const isOnline = useOnlineStatus();
-  const { item: selectedId } = Route.useSearch();
   const navigate = Route.useNavigate();
-  const pathname = useRouterState({ select: (s) => s.location.pathname });
   const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
 
   const { data: obsidianEnabled = false } = useQuery({
@@ -93,8 +90,6 @@ function RootLayout() {
 
   useKeyboardShortcuts(keyboardHandlers);
 
-  const hideBottomNav = !!(selectedId && isListRoute(pathname));
-
   return (
     <AppContext.Provider value={{ obsidianEnabled, isOnline }}>
       <div className="h-dvh flex flex-col overflow-hidden">
@@ -107,8 +102,8 @@ function RootLayout() {
             <Sidebar />
           </div>
 
-          {/* Main content area */}
-          <div className="flex-1 flex flex-col md:flex-row min-w-0 overflow-hidden">
+          {/* Main content area — relative for mobile detail panel positioning */}
+          <div className="relative flex-1 flex flex-col md:flex-row min-w-0 overflow-hidden">
             <Suspense fallback={<LoadingFallback />}>
               <Outlet />
             </Suspense>
@@ -125,8 +120,7 @@ function RootLayout() {
           />
         )}
 
-        {/* Mobile Bottom Nav - hidden when detail panel is open on list routes */}
-        {!hideBottomNav && <BottomNav onSearchClick={() => setMobileSearchOpen(true)} />}
+        <BottomNav onSearchClick={() => setMobileSearchOpen(true)} />
       </div>
     </AppContext.Provider>
   );

--- a/src/routes/__tests__/__root.test.tsx
+++ b/src/routes/__tests__/__root.test.tsx
@@ -6,7 +6,6 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const mockNavigate = vi.fn();
 let mockSearchParams: Record<string, unknown> = {};
-let mockPathname = "/notes/fleeting";
 
 vi.mock("@tanstack/react-router", () => ({
   createRootRoute: (opts: { component: React.FC }) => ({
@@ -14,8 +13,6 @@ vi.mock("@tanstack/react-router", () => ({
     useSearch: () => mockSearchParams,
     useNavigate: () => mockNavigate,
   }),
-  useRouterState: ({ select }: { select: (s: unknown) => unknown }) =>
-    select({ location: { pathname: mockPathname, search: mockSearchParams } }),
   Link: ({
     children,
     to,
@@ -75,7 +72,6 @@ const RootLayout = Route.component!;
 beforeEach(() => {
   vi.clearAllMocks();
   mockSearchParams = {};
-  mockPathname = "/notes/fleeting";
   mockGetConfig.mockResolvedValue({ obsidian_export_enabled: false });
 });
 
@@ -114,29 +110,5 @@ describe("RootLayout", () => {
       item: undefined,
       tag: "idea",
     });
-  });
-
-  it("hides bottom nav when item selected on list route", () => {
-    mockSearchParams = { item: "abc-123" };
-    mockPathname = "/notes/fleeting";
-    renderRoot();
-
-    expect(screen.queryByTestId("bottom-nav")).not.toBeInTheDocument();
-  });
-
-  it("shows bottom nav when no item selected", () => {
-    mockSearchParams = {};
-    mockPathname = "/notes/fleeting";
-    renderRoot();
-
-    expect(screen.getByTestId("bottom-nav")).toBeInTheDocument();
-  });
-
-  it("shows bottom nav when item selected on non-list route", () => {
-    mockSearchParams = { item: "abc-123" };
-    mockPathname = "/settings";
-    renderRoot();
-
-    expect(screen.getByTestId("bottom-nav")).toBeInTheDocument();
   });
 });

--- a/src/routes/_list.tsx
+++ b/src/routes/_list.tsx
@@ -26,7 +26,7 @@ function ListLayout() {
 
       {/* Detail panel */}
       {selectedId && (
-        <div className="fixed inset-0 z-50 bg-background md:static md:z-auto md:flex-1 md:min-w-0 md:border-l">
+        <div className="absolute inset-0 z-10 bg-background md:static md:z-auto md:flex-1 md:min-w-0 md:border-l">
           <ErrorBoundary>
             <Suspense fallback={<LoadingFallback />}>
               <ItemDetail

--- a/src/routes/private.tsx
+++ b/src/routes/private.tsx
@@ -908,7 +908,7 @@ function PrivateItemsList({ token }: { token: string }) {
         </div>
 
         {/* Detail panel */}
-        <div className="fixed inset-0 z-50 bg-background md:static md:z-auto md:flex-1 md:min-w-0 md:border-l">
+        <div className="absolute inset-0 z-10 bg-background md:static md:z-auto md:flex-1 md:min-w-0 md:border-l">
           <PrivateItemDetail
             token={token}
             itemId={selectedId}


### PR DESCRIPTION
## Summary

- Detail panels 從 `fixed inset-0 z-50` 改為 `absolute inset-0 z-10`，填滿內容區域而非整個 viewport
- 內容容器加 `relative` 建立 positioning context，BottomNav 保持在 flex flow 中
- 移除 `hideBottomNav` 條件渲染邏輯及相關 dead code（`isListRoute`、`LIST_ROUTE_PREFIXES`）
- 淨刪 70 行

## Test plan

- [x] `npx tsc --noEmit` 通過
- [x] `npx vitest run` 全部通過（1064 tests）
- [ ] `npm run test:e2e` E2E 測試
- [ ] 手機模式：列表頁點開項目 → 底部導航列保持可見
- [ ] 手機模式：detail 開啟時點導航列 → 正常切換頁面
- [ ] 桌面模式：side-by-side layout 不受影響
- [ ] "更多" 選單、搜尋 overlay、Dialog 層級正常
- [ ] 私密筆記 detail 同樣保持導航列可見

🤖 Generated with [Claude Code](https://claude.com/claude-code)