### PR TITLE
feat(frontend): replace 最近新增 dashboard card with 最近活動

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -11,7 +11,7 @@ test.describe("Dashboard", () => {
 
     const main = page.locator(".max-w-2xl");
     await expect(main.getByText("未處理", { exact: true })).toBeVisible();
-    await expect(main.getByText("最近新增", { exact: true })).toBeVisible();
+    await expect(main.getByText("最近活動", { exact: true })).toBeVisible();
     await expect(main.getByText("需要關注", { exact: true })).toBeVisible();
     await expect(main.getByText("Zettelkasten 管道")).toBeVisible();
     await expect(main.getByText("本月活動")).toBeVisible();

--- a/mcp-server/src/client.ts
+++ b/mcp-server/src/client.ts
@@ -186,7 +186,7 @@ export async function getUnreviewed(
 export async function getRecent(
   limit = 20,
   offset = 0,
-): Promise<{ items: SparkleItem[]; total: number }> {
+): Promise<{ items: (SparkleItem & { activity: "created" | "updated" })[]; total: number }> {
   const params = new URLSearchParams();
   if (limit !== 20) params.set("limit", String(limit));
   if (offset) params.set("offset", String(offset));

--- a/mcp-server/src/format.ts
+++ b/mcp-server/src/format.ts
@@ -53,21 +53,31 @@ export function formatItem(item: SparkleItem): string {
 }
 
 /** Format a list of items as a compact markdown list */
-export function formatItemList(
-  items: SparkleItem[],
+export function formatItemList<T extends SparkleItem>(
+  items: T[],
   total: number,
   pagination?: { offset: number; limit: number },
+  options?: {
+    emptyMessage?: string;
+    formatLine?: (item: T, shared: { tagStr: string; catStr: string }) => string;
+  },
 ): string {
-  if (items.length === 0) return "No items found.";
+  if (items.length === 0) return options?.emptyMessage ?? "No items found.";
 
   const lines: string[] = [`Found ${total} items (showing ${items.length}):\n`];
   for (const item of items) {
     const tags = parseTags(item);
     const tagStr = tags.length > 0 ? ` [${tags.join(", ")}]` : "";
-    const dueStr = item.due ? ` (due: ${item.due})` : "";
-    const priorityStr = item.priority ? ` ⚡${item.priority}` : "";
     const catStr = item.category_name ? ` 📁${item.category_name}` : "";
-    lines.push(`- **${item.title}** — ${item.status}${priorityStr}${dueStr}${catStr}${tagStr}`);
+    if (options?.formatLine) {
+      lines.push(options.formatLine(item, { tagStr, catStr }));
+    } else {
+      const dueStr = item.due ? ` (due: ${item.due})` : "";
+      const priorityStr = item.priority ? ` ⚡${item.priority}` : "";
+      lines.push(
+        `- **${item.title}** — ${item.status}${priorityStr}${dueStr}${catStr}${tagStr}`,
+      );
+    }
     lines.push(`  ID: ${item.id} | Type: ${item.type} | Modified: ${item.modified}`);
   }
   if (pagination) {

--- a/mcp-server/src/tools/dashboard.ts
+++ b/mcp-server/src/tools/dashboard.ts
@@ -44,9 +44,9 @@ export function registerDashboardTools(server: McpServer): void {
   server.registerTool(
     "sparkle_list_recent",
     {
-      title: "List Recently Created Items",
+      title: "List Recent Activity",
       description:
-        "列出最近 N 天內建立的項目（天數由 Sparkle settings 的 recent_days 控制，預設 7 天）。",
+        "列出最近 N 天內有活動的項目（新建或修改），按修改時間排序。每筆標示 activity: created 或 updated。天數由 recent_days 設定控制（預設 7 天）。",
       inputSchema: z
         .object({
           limit: z
@@ -69,7 +69,13 @@ export function registerDashboardTools(server: McpServer): void {
     async ({ limit, offset }) => {
       try {
         const data = await getRecent(limit, offset);
-        const text = formatItemList(data.items, data.total, { offset, limit });
+        const text = formatItemList(data.items, data.total, { offset, limit }, {
+          emptyMessage: "No recent activity found.",
+          formatLine: (item, { tagStr, catStr }) => {
+            const label = item.activity === "updated" ? "🔄 updated" : "✨ created";
+            return `- **${item.title}** — ${label} | ${item.status}${catStr}${tagStr}`;
+          },
+        });
         return { content: [{ type: "text", text }] };
       } catch (error) {
         return formatToolError(error);

--- a/server/lib/stats.ts
+++ b/server/lib/stats.ts
@@ -105,6 +105,12 @@ export interface DashboardItem {
   viewed_at: string | null;
 }
 
+export type ActivityType = "created" | "updated";
+
+export interface RecentActivityItem extends DashboardItem {
+  activity: ActivityType;
+}
+
 export interface AttentionItem extends DashboardItem {
   attention_reason: "overdue" | "high_priority";
 }
@@ -185,25 +191,29 @@ export function getRecentItems(
   days: number,
   limit = 5,
   offset = 0,
-): { items: DashboardItem[]; total: number } {
+): { items: RecentActivityItem[]; total: number } {
   const items = sqlite
     .prepare(
-      `SELECT i.*, c.name AS category_name
+      `SELECT i.*, c.name AS category_name,
+        CASE
+          WHEN (julianday(i.modified) - julianday(i.created)) * 1440 < 1 THEN 'created'
+          ELSE 'updated'
+        END AS activity
        FROM items i
        LEFT JOIN categories c ON i.category_id = c.id
-       WHERE i.created >= datetime('now', '-' || ? || ' days')
+       WHERE i.modified >= datetime('now', '-' || ? || ' days')
          AND i.status != 'archived'
          AND i.is_private = 0
-       ORDER BY i.created DESC
+       ORDER BY i.modified DESC
        LIMIT ? OFFSET ?`,
     )
-    .all(days, limit, offset) as DashboardItem[];
+    .all(days, limit, offset) as RecentActivityItem[];
 
   const countRow = sqlite
     .prepare(
       `SELECT COUNT(*) AS count
        FROM items i
-       WHERE i.created >= datetime('now', '-' || ? || ' days')
+       WHERE i.modified >= datetime('now', '-' || ? || ' days')
          AND i.status != 'archived'
          AND i.is_private = 0`,
     )

--- a/src/components/__tests__/dashboard.test.tsx
+++ b/src/components/__tests__/dashboard.test.tsx
@@ -133,18 +133,32 @@ describe("Dashboard", () => {
       expect(screen.getByText("筆記")).toBeInTheDocument();
     });
 
-    it("shows recent items with relative time", async () => {
+    it("shows recent items with activity badge and relative time", async () => {
       mockGetStats.mockResolvedValue(makeStats());
       mockGetUnreviewed.mockResolvedValue({ items: [], total: 0 });
+      const oneHourAgo = new Date(Date.now() - 3600000).toISOString();
       mockGetRecent.mockResolvedValue({
         items: [
-          makeDashboardItem({
-            id: "rc-1",
-            title: "Recent Item",
-            created: new Date(Date.now() - 3600000).toISOString(),
-          }),
+          {
+            ...makeDashboardItem({
+              id: "rc-1",
+              title: "Recent Item",
+              created: oneHourAgo,
+              modified: oneHourAgo,
+            }),
+            activity: "created",
+          },
+          {
+            ...makeDashboardItem({
+              id: "rc-2",
+              title: "Updated Item",
+              created: "2026-03-01T00:00:00Z",
+              modified: oneHourAgo,
+            }),
+            activity: "updated",
+          },
         ],
-        total: 1,
+        total: 2,
       });
       mockGetAttention.mockResolvedValue({ items: [], total: 0 });
       mockGetDashboardStale.mockResolvedValue({ items: [], total: 0 });
@@ -155,7 +169,9 @@ describe("Dashboard", () => {
       await waitFor(() => {
         expect(screen.getByText("Recent Item")).toBeInTheDocument();
       });
-      expect(screen.getByText("1 小時前")).toBeInTheDocument();
+      expect(screen.getByText("新增")).toBeInTheDocument();
+      expect(screen.getByText("更新")).toBeInTheDocument();
+      expect(screen.getAllByText("1 小時前")).toHaveLength(2);
     });
 
     it("shows attention items with overdue badge", async () => {
@@ -224,7 +240,7 @@ describe("Dashboard", () => {
       await waitFor(() => {
         expect(screen.getByText("沒有未處理的項目")).toBeInTheDocument();
       });
-      expect(screen.getByText("最近沒有新增項目")).toBeInTheDocument();
+      expect(screen.getByText("最近沒有活動")).toBeInTheDocument();
       expect(screen.getByText("沒有需要關注的項目")).toBeInTheDocument();
     });
 

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -10,7 +10,7 @@ import {
   getCategoryDistribution,
 } from "@/lib/api";
 import { parseItems, type ParsedItem } from "@/lib/types";
-import type { AttentionItem, DashboardStaleItem } from "@/lib/types";
+import type { ActivityType, DashboardStaleItem } from "@/lib/types";
 import { queryKeys } from "@/lib/query-keys";
 import { formatRelativeTime } from "@/lib/date-utils";
 import { toast } from "sonner";
@@ -26,7 +26,7 @@ import {
   Clock,
   Loader2,
   Inbox,
-  CalendarPlus,
+  Activity,
   AlertCircle,
 } from "lucide-react";
 
@@ -39,26 +39,46 @@ function typeLabel(item: ParsedItem): string {
   return labels[item.type] ?? item.type;
 }
 
+const ACTIVITY_STYLES: Record<ActivityType, { className: string; label: string }> = {
+  created: {
+    className: "text-green-600 border-green-300 dark:text-green-400 dark:border-green-700",
+    label: "新增",
+  },
+  updated: {
+    className: "text-blue-600 border-blue-300 dark:text-blue-400 dark:border-blue-700",
+    label: "更新",
+  },
+};
+
+export function ActivityBadge({ activity }: { activity: ActivityType }) {
+  const style = ACTIVITY_STYLES[activity];
+  return (
+    <Badge variant="outline" className={`text-xs shrink-0 ${style.className}`}>
+      {style.label}
+    </Badge>
+  );
+}
+
 function getItemRoute(item: ParsedItem): string {
   if (item.type === "todo") return item.status === "done" ? "/todos/done" : "/todos";
   if (item.type === "scratch") return "/scratch";
   return `/notes/${item.status}`;
 }
 
-interface DashboardCardProps {
+interface DashboardCardProps<T extends ParsedItem> {
   title: string;
   icon: React.ReactNode;
   count: number | undefined;
-  items: ParsedItem[];
+  items: T[];
   borderColor: string;
   loading: boolean;
   viewAllPath: string;
-  renderItem: (item: ParsedItem) => React.ReactNode;
-  onItemClick: (item: ParsedItem) => void;
+  renderItem: (item: T) => React.ReactNode;
+  onItemClick: (item: T) => void;
   emptyText: string;
 }
 
-function DashboardCard({
+function DashboardCard<T extends ParsedItem>({
   title,
   icon,
   count,
@@ -69,7 +89,7 @@ function DashboardCard({
   renderItem,
   onItemClick,
   emptyText,
-}: DashboardCardProps) {
+}: DashboardCardProps<T>) {
   const navigate = useNavigate();
 
   return (
@@ -163,8 +183,7 @@ export function Dashboard() {
 
   const unreviewedItems = unreviewedData ? parseItems(unreviewedData.items) : [];
   const recentItems = recentData ? parseItems(recentData.items) : [];
-  const attentionItems = attentionData ? parseItems(attentionData.items as AttentionItem[]) : [];
-  const attentionRawItems = attentionData?.items ?? [];
+  const attentionItems = attentionData ? parseItems(attentionData.items) : [];
 
   if (statsLoading || categoryLoading) {
     return (
@@ -215,21 +234,24 @@ export function Dashboard() {
               onItemClick={navigateToItem}
             />
 
-            {/* Recently created card */}
+            {/* Recent activity card */}
             <DashboardCard
-              title="最近新增"
-              icon={<CalendarPlus className="h-4 w-4" />}
+              title="最近活動"
+              icon={<Activity className="h-4 w-4" />}
               count={recentData?.total}
               items={recentItems}
               borderColor="border-l-blue-500"
               loading={recentLoading}
               viewAllPath="/recent"
-              emptyText="最近沒有新增項目"
+              emptyText="最近沒有活動"
               renderItem={(item) => (
                 <div className="flex items-center justify-between gap-2">
-                  <span className="truncate">{item.title}</span>
+                  <div className="flex items-center gap-1.5 min-w-0">
+                    <ActivityBadge activity={item.activity} />
+                    <span className="truncate">{item.title}</span>
+                  </div>
                   <span className="text-xs text-muted-foreground shrink-0">
-                    {formatRelativeTime(item.created)}
+                    {formatRelativeTime(item.modified)}
                   </span>
                 </div>
               )}
@@ -246,25 +268,21 @@ export function Dashboard() {
               loading={attentionLoading}
               viewAllPath="/attention"
               emptyText="沒有需要關注的項目"
-              renderItem={(item) => {
-                const rawItem = attentionRawItems.find((r) => r.id === item.id);
-                const reason = rawItem ? (rawItem as AttentionItem).attention_reason : undefined;
-                return (
-                  <div className="flex items-center gap-2">
-                    {reason === "overdue" && (
-                      <Badge variant="destructive" className="text-xs shrink-0">
-                        逾期
-                      </Badge>
-                    )}
-                    {reason === "high_priority" && (
-                      <Badge className="text-xs shrink-0 bg-orange-500 hover:bg-orange-600">
-                        高優先
-                      </Badge>
-                    )}
-                    <span className="truncate">{item.title}</span>
-                  </div>
-                );
-              }}
+              renderItem={(item) => (
+                <div className="flex items-center gap-2">
+                  {item.attention_reason === "overdue" && (
+                    <Badge variant="destructive" className="text-xs shrink-0">
+                      逾期
+                    </Badge>
+                  )}
+                  {item.attention_reason === "high_priority" && (
+                    <Badge className="text-xs shrink-0 bg-orange-500 hover:bg-orange-600">
+                      高優先
+                    </Badge>
+                  )}
+                  <span className="truncate">{item.title}</span>
+                </div>
+              )}
               onItemClick={navigateToItem}
             />
           </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -16,6 +16,7 @@ import type {
   ShareResponse,
   ListSharesResponse,
   DashboardItemsResponse,
+  RecentActivityResponse,
   AttentionResponse,
   DashboardStaleResponse,
 } from "./types";
@@ -429,12 +430,12 @@ export async function getUnreviewed(params?: {
 export async function getRecent(params?: {
   limit?: number;
   offset?: number;
-}): Promise<DashboardItemsResponse> {
+}): Promise<RecentActivityResponse> {
   const search = new URLSearchParams();
   if (params?.limit) search.set("limit", String(params.limit));
   if (params?.offset) search.set("offset", String(params.offset));
   const qs = search.toString();
-  return request<DashboardItemsResponse>(`/dashboard/recent${qs ? `?${qs}` : ""}`);
+  return request<RecentActivityResponse>(`/dashboard/recent${qs ? `?${qs}` : ""}`);
 }
 
 export async function getAttention(params?: { limit?: number }): Promise<AttentionResponse> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -131,6 +131,17 @@ export interface SettingsResponse {
 }
 
 // Dashboard types
+export type ActivityType = "created" | "updated";
+
+export interface RecentActivityItem extends Item {
+  activity: ActivityType;
+}
+
+export interface RecentActivityResponse {
+  items: RecentActivityItem[];
+  total: number;
+}
+
 export interface DashboardItemsResponse {
   items: Item[];
   total: number;
@@ -176,7 +187,9 @@ function safeParseStringArray(json: string): string[] {
   return [];
 }
 
-export function parseItem(item: Item): ParsedItem {
+export function parseItem<T extends Item>(
+  item: T,
+): Omit<T, "tags" | "aliases"> & { tags: string[]; aliases: string[] } {
   return {
     ...item,
     tags: safeParseStringArray(item.tags),
@@ -184,7 +197,9 @@ export function parseItem(item: Item): ParsedItem {
   };
 }
 
-export function parseItems(items: Item[]): ParsedItem[] {
+export function parseItems<T extends Item>(
+  items: T[],
+): (Omit<T, "tags" | "aliases"> & { tags: string[]; aliases: string[] })[] {
   return items.map(parseItem);
 }
 

--- a/src/routes/_list/attention.tsx
+++ b/src/routes/_list/attention.tsx
@@ -2,7 +2,6 @@ import { createFileRoute, useNavigate, type NavigateOptions } from "@tanstack/re
 import { useQuery } from "@tanstack/react-query";
 import { getAttention } from "@/lib/api";
 import { parseItems } from "@/lib/types";
-import type { AttentionItem } from "@/lib/types";
 import { queryKeys } from "@/lib/query-keys";
 import { Badge } from "@/components/ui/badge";
 import { Loader2 } from "lucide-react";
@@ -13,8 +12,7 @@ function AttentionPage() {
     queryKey: [...queryKeys.attention, "full"],
     queryFn: () => getAttention({ limit: 100 }),
   });
-  const items = data ? parseItems(data.items as AttentionItem[]) : [];
-  const rawItems = data?.items ?? [];
+  const items = data ? parseItems(data.items) : [];
 
   return (
     <div className="flex-1 overflow-y-auto">
@@ -28,35 +26,29 @@ function AttentionPage() {
         {items.length === 0 && !isLoading ? (
           <p className="text-sm text-muted-foreground py-8 text-center">沒有需要關注的項目</p>
         ) : null}
-        {items.map((item) => {
-          const rawItem = rawItems.find((r) => r.id === item.id);
-          const reason = rawItem ? (rawItem as AttentionItem).attention_reason : undefined;
-          return (
-            <button
-              key={item.id}
-              className="w-full border rounded-lg p-3 text-left hover:bg-accent"
-              onClick={() =>
-                navigate({
-                  search: (prev) => ({ ...prev, item: item.id }),
-                } as NavigateOptions)
-              }
-            >
-              <div className="flex items-center gap-2">
-                {reason === "overdue" && (
-                  <Badge variant="destructive" className="text-xs shrink-0">
-                    逾期
-                  </Badge>
-                )}
-                {reason === "high_priority" && (
-                  <Badge className="text-xs shrink-0 bg-orange-500 hover:bg-orange-600">
-                    高優先
-                  </Badge>
-                )}
-                <span className="text-sm truncate">{item.title}</span>
-              </div>
-            </button>
-          );
-        })}
+        {items.map((item) => (
+          <button
+            key={item.id}
+            className="w-full border rounded-lg p-3 text-left hover:bg-accent"
+            onClick={() =>
+              navigate({
+                search: (prev) => ({ ...prev, item: item.id }),
+              } as NavigateOptions)
+            }
+          >
+            <div className="flex items-center gap-2">
+              {item.attention_reason === "overdue" && (
+                <Badge variant="destructive" className="text-xs shrink-0">
+                  逾期
+                </Badge>
+              )}
+              {item.attention_reason === "high_priority" && (
+                <Badge className="text-xs shrink-0 bg-orange-500 hover:bg-orange-600">高優先</Badge>
+              )}
+              <span className="text-sm truncate">{item.title}</span>
+            </div>
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/src/routes/_list/recent.tsx
+++ b/src/routes/_list/recent.tsx
@@ -4,6 +4,7 @@ import { getRecent } from "@/lib/api";
 import { parseItems } from "@/lib/types";
 import { queryKeys } from "@/lib/query-keys";
 import { formatRelativeTime } from "@/lib/date-utils";
+import { ActivityBadge } from "@/components/dashboard";
 import { Loader2 } from "lucide-react";
 
 function RecentPage() {
@@ -17,14 +18,14 @@ function RecentPage() {
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="p-4 space-y-2">
-        <h2 className="text-sm font-semibold text-muted-foreground">最近新增</h2>
+        <h2 className="text-sm font-semibold text-muted-foreground">最近活動</h2>
         {isLoading ? (
           <div className="flex justify-center py-8">
             <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
           </div>
         ) : null}
         {items.length === 0 && !isLoading ? (
-          <p className="text-sm text-muted-foreground py-8 text-center">最近沒有新增項目</p>
+          <p className="text-sm text-muted-foreground py-8 text-center">最近沒有活動</p>
         ) : null}
         {items.map((item) => (
           <button
@@ -37,9 +38,12 @@ function RecentPage() {
             }
           >
             <div className="flex items-center justify-between gap-2">
-              <span className="text-sm truncate">{item.title}</span>
+              <div className="flex items-center gap-1.5 min-w-0">
+                <ActivityBadge activity={item.activity} />
+                <span className="text-sm truncate">{item.title}</span>
+              </div>
               <span className="text-xs text-muted-foreground shrink-0">
-                {formatRelativeTime(item.created)}
+                {formatRelativeTime(item.modified)}
               </span>
             </div>
           </button>


### PR DESCRIPTION
## Summary
- Merge "最近新增" (recently created) card into "最近活動" (recent activity) card that shows both new and modified items
- Each item displays activity badge: 新增 (created) or 更新 (updated), determined by 1-minute threshold between created/modified timestamps
- Sort by `modified` instead of `created`, filter on `modified >= N days`

## Refactoring
- Generic `parseItems<T>` and `DashboardCard<T>` to preserve extra fields through parsing — eliminates `rawItems.find()` pattern in 4 call sites (dashboard recent, dashboard attention, recent.tsx, attention.tsx)
- Extract shared `ActivityBadge` component with `ACTIVITY_STYLES` constant
- Unify MCP `formatRecentActivity` into `formatItemList` via `options.formatLine` callback

## Files changed
- `server/lib/stats.ts` — `getRecentItems` query + `RecentActivityItem` type
- `src/components/dashboard.tsx` — generic `DashboardCard<T>`, `ActivityBadge`, card UI
- `src/routes/_list/recent.tsx` — use `ActivityBadge`, remove parallel array
- `src/routes/_list/attention.tsx` — remove parallel array (bonus cleanup)
- `src/lib/types.ts` — generic `parseItems<T>`, `RecentActivityResponse`
- `src/lib/api.ts` — `getRecent` return type
- `mcp-server/src/format.ts` — generic `formatItemList` with options
- `mcp-server/src/tools/dashboard.ts` — updated tool description
- `mcp-server/src/client.ts` — `getRecent` return type

## Test plan
- [x] Unit tests: 60 files / 1064 tests passing
- [x] E2E tests: dashboard 3 tests passing
- [x] TypeScript: client + server + mcp-server all pass
- [x] ESLint + Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)