### PR TITLE
fix: address week data issues from Phase 1 review (#220, #221, #222)

### DIFF
--- a/server/lib/__tests__/week-data.test.ts
+++ b/server/lib/__tests__/week-data.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
 import { createTestDb } from "../../test-utils.js";
 import { getWeekData } from "../stats.js";
@@ -52,7 +52,7 @@ describe("getWeekData", () => {
     sqlite = testDb.sqlite;
   });
 
-  afterAll(() => {
+  afterEach(() => {
     sqlite?.close();
   });
 
@@ -105,6 +105,7 @@ describe("getWeekData", () => {
     expect(result.days[0]!.todos_due).toHaveLength(1);
     expect(result.days[0]!.todos_due[0]!.title).toBe("Todo Mon");
     expect(result.days[0]!.todos_due[0]!.priority).toBe("high");
+    expect(result.days[0]!.todos_due[0]!.status).toBe("active");
 
     // Wednesday
     expect(result.days[2]!.todos_due).toHaveLength(1);

--- a/server/lib/stats.ts
+++ b/server/lib/stats.ts
@@ -347,6 +347,7 @@ export interface WeekTodoItem {
   id: string;
   title: string;
   priority: string | null;
+  status: string;
 }
 
 export interface WeekNoteItem {
@@ -416,7 +417,7 @@ export function getWeekData(sqlite: Database.Database, startDate: string): WeekD
   // due is stored as bare YYYY-MM-DD (implicitly local), so compare directly
   const todosDueWithDate = sqlite
     .prepare(
-      `SELECT id, title, priority, due
+      `SELECT id, title, priority, status, due
        FROM items
        WHERE type = 'todo'
          AND status NOT IN ('archived')
@@ -427,13 +428,19 @@ export function getWeekData(sqlite: Database.Database, startDate: string): WeekD
     id: string;
     title: string;
     priority: string | null;
+    status: string;
     due: string;
   }[];
 
   for (const todo of todosDueWithDate) {
     const day = dayMap.get(todo.due);
     if (day) {
-      day.todos_due.push({ id: todo.id, title: todo.title, priority: todo.priority });
+      day.todos_due.push({
+        id: todo.id,
+        title: todo.title,
+        priority: todo.priority,
+        status: todo.status,
+      });
     }
   }
 
@@ -493,8 +500,8 @@ export function getWeekData(sqlite: Database.Database, startDate: string): WeekD
     }
   }
 
-  // Compute overdue_count per day (historical: relative to each day, not today)
-  // An active todo is overdue on a given day if its due date is strictly before that day
+  // Compute overdue_count per day: counts currently-active todos that were already
+  // overdue by each day. Uses current status, not historical snapshots.
   // Upper bound: only fetch todos due before the last day of the week (optimization)
   const activeTodosWithDue = sqlite
     .prepare(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -174,6 +174,7 @@ export interface WeekTodoItem {
   id: string;
   title: string;
   priority: string | null;
+  status: string;
 }
 
 export interface WeekNoteItem {


### PR DESCRIPTION
## Summary
- **#220**: `afterAll` → `afterEach` in `week-data.test.ts` to properly close each test's DB instance
- **#221**: Add `status` field to `WeekTodoItem` (backend interface, SQL SELECT, frontend type) so Phase 2 WeekView can distinguish done/active todos
- **#222**: Fix misleading `overdue_count` comment — clarify it uses current status, not historical snapshots

## Test plan
- [x] All 15 week-data tests pass
- [x] TypeScript type check passes (client + server)
- [x] ESLint clean (0 errors)

Closes #220, closes #221, closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)