### PR TITLE
feat: search by sparkle id via id:<prefix> syntax

### DIFF
--- a/e2e/search-by-id.spec.ts
+++ b/e2e/search-by-id.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from "@playwright/test";
+
+import { createItemViaApi } from "./helpers";
+
+test.describe("Search by id: syntax", () => {
+  test("shows id: hint when search is empty, hides once user types", async ({ page }) => {
+    await page.goto("/");
+    const searchInput = page.getByPlaceholder("搜尋...");
+
+    await searchInput.click();
+    await expect(page.getByText("可以用筆記 ID")).toBeVisible();
+
+    await searchInput.fill("anything");
+    await expect(page.getByText("可以用筆記 ID")).not.toBeVisible();
+  });
+
+  test("id:<full-uuid> finds the item and click-through opens detail", async ({
+    page,
+    request,
+  }) => {
+    const title = `IdSearchFull ${Date.now()}`;
+    const created = await createItemViaApi(request, { title });
+    const itemId = created.item?.id ?? created.id;
+
+    await page.goto("/");
+    await page.getByPlaceholder("搜尋...").fill(`id:${itemId}`);
+
+    await expect(page.getByText("找到 1 個結果")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(title).first()).toBeVisible();
+
+    await page.getByText(title).first().click();
+    await expect(page.locator(`input[value="${title}"]`)).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("id:<short hex prefix> finds the item", async ({ page, request }) => {
+    const title = `IdSearchPrefix ${Date.now()}`;
+    const created = await createItemViaApi(request, { title });
+    const itemId = created.item?.id ?? created.id;
+
+    await page.goto("/");
+    await page.getByPlaceholder("搜尋...").fill(`id:${itemId.slice(0, 8)}`);
+
+    await expect(page.getByText(title).first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("id:<prefix-with-dash> works after dash stripping (T1)", async ({ page, request }) => {
+    const title = `IdSearchDashy ${Date.now()}`;
+    const created = await createItemViaApi(request, { title });
+    const itemId: string = created.item?.id ?? created.id;
+
+    await page.goto("/");
+    // First 13 chars of UUID = 8 hex + dash + 4 hex (e.g. "abc12345-1111")
+    await page.getByPlaceholder("搜尋...").fill(`id:${itemId.slice(0, 13)}`);
+
+    await expect(page.getByText(title).first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("id:<unmatched-hex> shows ID-specific empty state, not generic", async ({ page }) => {
+    await page.goto("/");
+    // Hex prefix that's valid syntax but won't match any stored UUID
+    // (UUIDs are random 122-bit; collision with this exact 12-char run is astronomically unlikely)
+    await page.getByPlaceholder("搜尋...").fill("id:fadeadbe0000");
+
+    await expect(page.getByText(/找不到此 ID/)).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("plain FTS no-match shows generic empty state (not ID-specific)", async ({ page }) => {
+    await page.goto("/");
+    await page.getByPlaceholder("搜尋...").fill(`ZzqNoMatch${Date.now()}`);
+
+    await expect(page.getByText("找不到結果", { exact: true })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(/找不到此 ID/)).not.toBeVisible();
+  });
+});

--- a/mcp-server/src/__tests__/tools.test.ts
+++ b/mcp-server/src/__tests__/tools.test.ts
@@ -160,6 +160,26 @@ describe("sparkle_search_all", () => {
     expect(result.isError).toBeUndefined();
     expect(result.content[0].text).toContain("No results found");
   });
+
+  it("skips vault filesystem search for id: queries (cross-package regex parity)", async () => {
+    const handler = getHandler();
+    searchItems.mockResolvedValue({
+      results: [makeItem({ id: "abc12345-1111-4111-8111-111111111111", title: "ID Match" })],
+    });
+    await handler({ query: "id:abc12345", limit: 20 });
+    expect(searchItems).toHaveBeenCalledWith("id:abc12345", 20);
+    // Critical: vault FS search is keyed by title/content, not Sparkle ID — skipping
+    // saves an obsidian-cli round-trip on a guaranteed empty result.
+    expect(mockSearchVault).not.toHaveBeenCalled();
+  });
+
+  it("does NOT skip vault search for non-id: queries (regression guard)", async () => {
+    const handler = getHandler();
+    searchItems.mockResolvedValue({ results: [] });
+    mockSearchVault.mockResolvedValue([]);
+    await handler({ query: "regular search", limit: 20 });
+    expect(mockSearchVault).toHaveBeenCalledWith("regular search", { limit: 20 });
+  });
 });
 
 describe("sparkle_list_notes", () => {

--- a/mcp-server/src/docs/content.ts
+++ b/mcp-server/src/docs/content.ts
@@ -565,6 +565,13 @@ sparkle_read_obsidian(id)       → Vault 版本
 - 搜尋結果包含所有類型（筆記、待辦、暫存）
 - 善用搜尋找到相關的舊筆記，建立連結
 
+### 用 ID 精準定位筆記
+- 在 \`sparkle_search\` / \`sparkle_search_all\` 的 query 前綴 \`id:\`，可直接以 Sparkle ID 找到筆記
+- \`id:<完整 UUID>\` → 精準匹配；\`id:abc12345\` → 4–32 hex 字元前綴查找（不含 dashes）
+- **跨 items_active + items_vault 兩張表**——即使筆記已匯出到 vault 也找得到，這是一般 FTS 做不到的
+- 非 hex 字元或 <4 字元前綴會直接回空，不會降級到 FTS（避免誤觸發）
+- 使用情境：使用者貼上一段筆記 ID 或前綴時，直接用 \`id:\` 比 FTS 更精準
+
 ### 高效編輯筆記
 
 內容編輯一律走 \`sparkle_edit_note\`（v2 atomic ops）。\`sparkle_update_note\` 只負責 metadata（title/tags/status/...），不再接受 \`content\` 或 \`old_content\`。

--- a/mcp-server/src/docs/content.ts
+++ b/mcp-server/src/docs/content.ts
@@ -567,9 +567,9 @@ sparkle_read_obsidian(id)       → Vault 版本
 
 ### 用 ID 精準定位筆記
 - 在 \`sparkle_search\` / \`sparkle_search_all\` 的 query 前綴 \`id:\`，可直接以 Sparkle ID 找到筆記
-- \`id:<完整 UUID>\` → 精準匹配；\`id:abc12345\` → 4–32 hex 字元前綴查找（不含 dashes）
+- \`id:<完整 UUID>\` → 精準匹配；\`id:abc12345\` 或 \`id:abc12345-1111\` → 4–32 hex 字元前綴查找（dashes 會自動去除）
 - **跨 items_active + items_vault 兩張表**——即使筆記已匯出到 vault 也找得到，這是一般 FTS 做不到的
-- 非 hex 字元或 <4 字元前綴會直接回空，不會降級到 FTS（避免誤觸發）
+- 非 hex 字元或去 dash 後 <4 字元前綴會直接回空，不會降級到 FTS（避免誤觸發）
 - 使用情境：使用者貼上一段筆記 ID 或前綴時，直接用 \`id:\` 比 FTS 更精準
 
 ### 高效編輯筆記

--- a/mcp-server/src/tools/search.ts
+++ b/mcp-server/src/tools/search.ts
@@ -18,9 +18,9 @@ Queries shorter than 3 characters fall back to LIKE matching.
 
 **ID lookup syntax**: prefix the query with \`id:\` to find a note by its Sparkle ID.
   - \`id:<full-uuid>\` → exact match (36-char canonical UUID with dashes)
-  - \`id:abc12345\` → 4–32 hex-char prefix lookup (hex only, no dashes; pass the leading hex run from a UUID)
+  - \`id:abc12345\` → 4–32 hex-char prefix lookup (dashes optional — \`id:abc12345-1111\` works too; they're stripped before validation)
   - Searches across BOTH items_active + items_vault (so you can locate exported notes too).
-  - Returns 0 results on non-hex chars, dashes in short prefix, or <4-char prefix — no silent FTS fallback.
+  - Returns 0 results on non-hex chars or <4-char prefix after dash stripping — no silent FTS fallback.
 
 Args:
   - query (string): Search keywords (e.g., "量子計算", "machine learning") OR \`id:<prefix>\`

--- a/mcp-server/src/tools/search.ts
+++ b/mcp-server/src/tools/search.ts
@@ -11,13 +11,19 @@ export function registerSearchTools(server: McpServer): void {
     "sparkle_search",
     {
       title: "Search Sparkle",
-      description: `Full-text search over items_active only (fleeting/developing/permanent/archived). As of v1.4.0, exported notes live in items_vault and are NOT searchable from this tool — use \`sparkle_search_obsidian\` (vault FTS via obsidian-cli) or \`sparkle_search_all\` (union of DB + vault) for "all notes" queries.
+      description: `Full-text search over items_active (fleeting/developing/permanent/archived). As of v1.4.0, exported notes live in items_vault — for vault content, use \`sparkle_search_obsidian\` (vault FTS via obsidian-cli) or \`sparkle_search_all\` (union of DB + vault).
 
 Searches title and content fields. Supports Chinese characters (trigram tokenizer).
 Queries shorter than 3 characters fall back to LIKE matching.
 
+**ID lookup syntax**: prefix the query with \`id:\` to find a note by its Sparkle ID.
+  - \`id:<full-uuid>\` → exact match
+  - \`id:abc12345\` → 4–36 hex-char prefix lookup
+  - Searches across BOTH items_active + items_vault (so you can locate exported notes too).
+  - Returns 0 results on non-hex chars or <4-char prefix — no silent FTS fallback.
+
 Args:
-  - query (string): Search keywords (e.g., "量子計算", "machine learning")
+  - query (string): Search keywords (e.g., "量子計算", "machine learning") OR \`id:<prefix>\`
   - limit (number, optional): Max results 1-50, default 20
 
 Returns: List of matching items with title, status, tags, and metadata.`,
@@ -53,8 +59,10 @@ Returns: List of matching items with title, status, tags, and metadata.`,
 
 Runs both searches in parallel. Automatically deduplicates: exported notes found in the vault are only shown in the Vault section. If Obsidian integration is not enabled, gracefully falls back to Sparkle-only results.
 
+**ID lookup syntax** (same as \`sparkle_search\`): prefix the query with \`id:\` to find a note by Sparkle ID across items_active + items_vault. Vault filesystem search is skipped for \`id:\` queries (vault files are keyed by title, not ID).
+
 Args:
-  - query (string): Search keywords
+  - query (string): Search keywords OR \`id:<prefix>\`
   - limit (number, optional): Max results per source (default 20, max 50)
 
 Returns: Results grouped by source — [Sparkle] for database items, [Vault] for vault files.`,
@@ -76,9 +84,14 @@ Returns: Results grouped by source — [Sparkle] for database items, [Vault] for
       },
     },
     async ({ query, limit }) => {
+      // Keep in sync with `ID_PREFIX_QUERY_RE` in server/lib/items.ts — when
+      // that loosens or tightens, this must too. Vault filesystem search keys
+      // by title/content (not Sparkle ID), so skip it for id: queries.
+      const isIdQuery = /^id:\s*\S+\s*$/i.test(query.trim());
+
       const [sparkleResult, vaultResult] = await Promise.allSettled([
         searchItems(query, limit),
-        searchVault(query, { limit }),
+        isIdQuery ? Promise.resolve([]) : searchVault(query, { limit }),
       ]);
 
       const sparkleItems =

--- a/mcp-server/src/tools/search.ts
+++ b/mcp-server/src/tools/search.ts
@@ -17,10 +17,10 @@ Searches title and content fields. Supports Chinese characters (trigram tokenize
 Queries shorter than 3 characters fall back to LIKE matching.
 
 **ID lookup syntax**: prefix the query with \`id:\` to find a note by its Sparkle ID.
-  - \`id:<full-uuid>\` → exact match
-  - \`id:abc12345\` → 4–36 hex-char prefix lookup
+  - \`id:<full-uuid>\` → exact match (36-char canonical UUID with dashes)
+  - \`id:abc12345\` → 4–32 hex-char prefix lookup (hex only, no dashes; pass the leading hex run from a UUID)
   - Searches across BOTH items_active + items_vault (so you can locate exported notes too).
-  - Returns 0 results on non-hex chars or <4-char prefix — no silent FTS fallback.
+  - Returns 0 results on non-hex chars, dashes in short prefix, or <4-char prefix — no silent FTS fallback.
 
 Args:
   - query (string): Search keywords (e.g., "量子計算", "machine learning") OR \`id:<prefix>\`

--- a/server/lib/__tests__/items.test.ts
+++ b/server/lib/__tests__/items.test.ts
@@ -532,11 +532,13 @@ describe("Data Access Layer", () => {
         expect(results).toHaveLength(0);
       });
 
-      it("does NOT fall back to FTS when id: prefix produces no match", () => {
-        // 'meeting' would normally FTS-match this row's title; with id: syntax
-        // we want strict ID semantics — no accidental keyword fallback.
-        createItem(db, { title: "Meeting notes containing the word meeting" });
-        const results = searchItems(sqlite, db, "id:meeting1");
+      it("does NOT fall back to FTS when id: prefix is valid hex but matches no ID", () => {
+        // The prefix must be valid hex (passes HEX_PREFIX_RE) and the title
+        // must contain it — only then can we observe FTS fallback. The earlier
+        // 'id:meeting1' phrasing was a tautology: 'meeting1' was rejected up-front
+        // by the hex guard, never reaching the FTS-skip code path.
+        createItem(db, { title: "cafedead is in my title" });
+        const results = searchItems(sqlite, db, "id:cafedead");
         expect(results).toHaveLength(0);
       });
 
@@ -597,19 +599,46 @@ describe("Data Access Layer", () => {
         expect(results[0]!.id).toBe(note.id);
       });
 
-      it("rejects hex+dash mixed short prefix (would never match UUID position)", () => {
-        // UUIDs have dashes at fixed positions (8-4-4-4-12); a 'abc-1234' prefix
-        // would always produce 0 LIKE matches, so reject it explicitly rather
-        // than silently returning empty after a wasted query.
-        insertActiveRow(sqlite, {
-          id: "abc12345-8888-4888-8888-888888888888",
-          title: "No dash prefix",
-        });
-        expect(searchItems(sqlite, db, "id:abc-1234")).toHaveLength(0);
+      it("accepts mid-prefix with dash and matches stored id (strip-then-validate)", () => {
+        // Highlight-and-copy from a UUID tooltip naturally captures dashes
+        // (e.g. 'abc12345-1111'). Strip them, validate hex, then rebuild
+        // canonical UUID-segment shape before GLOB so it still hits the PK.
+        const id = "abc12345-1111-4111-8111-111111111111";
+        insertActiveRow(sqlite, { id, title: "Mid prefix with dash" });
+        const results = searchItems(sqlite, db, "id:abc12345-1111");
+        expect(results).toHaveLength(1);
+        expect(results[0]!.id).toBe(id);
       });
 
-      it("rejects all-dash prefix", () => {
+      it("accepts short prefix with dash (e.g. id:abc-1234) by stripping the dash", () => {
+        const id = "abc12345-8888-4888-8888-888888888888";
+        insertActiveRow(sqlite, { id, title: "Short dashy prefix" });
+        const results = searchItems(sqlite, db, "id:abc-1234");
+        expect(results).toHaveLength(1);
+        expect(results[0]!.id).toBe(id);
+      });
+
+      it("treats 32 stripped hex chars (no dashes) as equivalent to full UUID", () => {
+        const id = "deadcafe-9999-4999-8999-999999999999";
+        insertActiveRow(sqlite, { id, title: "Stripped 32 hex" });
+        const stripped = id.replace(/-/g, "");
+        expect(stripped).toHaveLength(32);
+        const results = searchItems(sqlite, db, `id:${stripped}`);
+        expect(results).toHaveLength(1);
+        expect(results[0]!.id).toBe(id);
+      });
+
+      it("rejects all-dash prefix (nothing left after stripping)", () => {
         expect(searchItems(sqlite, db, "id:----")).toHaveLength(0);
+      });
+
+      it("rejects too-short prefix after stripping dashes", () => {
+        // 'ab-c' → 'abc' (3 chars) → < 4 char minimum
+        insertActiveRow(sqlite, {
+          id: "abc12345-1010-4010-8010-101010101010",
+          title: "Should not match",
+        });
+        expect(searchItems(sqlite, db, "id:ab-c")).toHaveLength(0);
       });
     });
   });

--- a/server/lib/__tests__/items.test.ts
+++ b/server/lib/__tests__/items.test.ts
@@ -570,6 +570,15 @@ describe("Data Access Layer", () => {
         expect(searchItems(sqlite, db, `id:${id}`, 20, true, true)).toHaveLength(1);
       });
 
+      it("includePrivate='only' returns only private rows", () => {
+        const pubId = "11110000-9999-4999-8999-999999999999";
+        const privId = "11119999-9999-4999-8999-999999999999";
+        insertActiveRow(sqlite, { id: pubId, title: "Public match" });
+        insertActiveRow(sqlite, { id: privId, title: "Private match", is_private: 1 });
+        const results = searchItems(sqlite, db, "id:1111", 20, true, "only");
+        expect(results.map((r) => r.id)).toEqual([privId]);
+      });
+
       it("respects limit when ambiguous prefix has many matches", () => {
         for (let i = 0; i < 5; i++) {
           insertActiveRow(sqlite, {

--- a/server/lib/__tests__/items.test.ts
+++ b/server/lib/__tests__/items.test.ts
@@ -476,6 +476,133 @@ describe("Data Access Layer", () => {
       expect(results[0]!.linked_todo_count).toBe(1);
       expect(results[0]!.linked_note_title).toBeNull();
     });
+
+    describe("id: prefix syntax", () => {
+      it("finds an active item by full UUID", () => {
+        const note = createItem(db, { title: "Find me by full id" });
+        const results = searchItems(sqlite, db, `id:${note.id}`);
+        expect(results).toHaveLength(1);
+        expect(results[0]!.id).toBe(note.id);
+        expect(results[0]!.origin).toBe("active");
+      });
+
+      it("finds an active item by short hex prefix (>= 4 chars)", () => {
+        const id = "abc12345-1111-4111-8111-111111111111";
+        insertActiveRow(sqlite, { id, title: "Short prefix lookup" });
+        const results = searchItems(sqlite, db, "id:abc12345");
+        expect(results).toHaveLength(1);
+        expect(results[0]!.id).toBe(id);
+      });
+
+      it("finds a vault item by id (cross-table)", () => {
+        const id = "deadbeef-2222-4222-8222-222222222222";
+        insertVaultRow(sqlite, { id, title: "Vault exported note" });
+        const results = searchItems(sqlite, db, `id:${id}`);
+        expect(results).toHaveLength(1);
+        expect(results[0]!.id).toBe(id);
+        expect(results[0]!.origin).toBe("vault");
+        expect(results[0]!.status).toBe("exported");
+      });
+
+      it("returns multiple matches when prefix is ambiguous across both tables", () => {
+        insertActiveRow(sqlite, {
+          id: "cafe1111-3333-4333-8333-333333333333",
+          title: "Active ambiguous A",
+        });
+        insertActiveRow(sqlite, {
+          id: "cafe2222-3333-4333-8333-333333333333",
+          title: "Active ambiguous B",
+        });
+        insertVaultRow(sqlite, {
+          id: "cafe3333-3333-4333-8333-333333333333",
+          title: "Vault ambiguous C",
+        });
+        const results = searchItems(sqlite, db, "id:cafe");
+        expect(results).toHaveLength(3);
+        expect(results.map((r) => r.id).sort()).toEqual([
+          "cafe1111-3333-4333-8333-333333333333",
+          "cafe2222-3333-4333-8333-333333333333",
+          "cafe3333-3333-4333-8333-333333333333",
+        ]);
+      });
+
+      it("returns empty when no item matches the id prefix", () => {
+        createItem(db, { title: "Unrelated" });
+        const results = searchItems(sqlite, db, "id:00000000");
+        expect(results).toHaveLength(0);
+      });
+
+      it("does NOT fall back to FTS when id: prefix produces no match", () => {
+        // 'meeting' would normally FTS-match this row's title; with id: syntax
+        // we want strict ID semantics — no accidental keyword fallback.
+        createItem(db, { title: "Meeting notes containing the word meeting" });
+        const results = searchItems(sqlite, db, "id:meeting1");
+        expect(results).toHaveLength(0);
+      });
+
+      it("returns empty for shorter-than-4-char prefix", () => {
+        insertActiveRow(sqlite, {
+          id: "ab123456-4444-4444-8444-444444444444",
+          title: "Has short prefix",
+        });
+        const results = searchItems(sqlite, db, "id:ab");
+        expect(results).toHaveLength(0);
+      });
+
+      it("returns empty for non-hex characters after id:", () => {
+        createItem(db, { title: "Has id:zzzz in title" });
+        const results = searchItems(sqlite, db, "id:zzzzzzzz");
+        expect(results).toHaveLength(0);
+      });
+
+      it("is case-insensitive on the id: prefix and hex chars", () => {
+        const id = "abcdef99-5555-4555-8555-555555555555";
+        insertActiveRow(sqlite, { id, title: "Case insensitive" });
+        const results = searchItems(sqlite, db, "ID:ABCDEF99");
+        expect(results).toHaveLength(1);
+        expect(results[0]!.id).toBe(id);
+      });
+
+      it("respects privacy filter (excludes private rows by default)", () => {
+        const id = "11112222-6666-4666-8666-666666666666";
+        insertActiveRow(sqlite, { id, title: "Private", is_private: 1 });
+        expect(searchItems(sqlite, db, `id:${id}`)).toHaveLength(0);
+        expect(searchItems(sqlite, db, `id:${id}`, 20, true, true)).toHaveLength(1);
+      });
+
+      it("respects limit when ambiguous prefix has many matches", () => {
+        for (let i = 0; i < 5; i++) {
+          insertActiveRow(sqlite, {
+            id: `deadbe${i}f-7777-4777-8777-777777777777`,
+            title: `Limit test ${i}`,
+          });
+        }
+        const results = searchItems(sqlite, db, "id:deadbe", 2);
+        expect(results).toHaveLength(2);
+      });
+
+      it("tolerates whitespace around the id value", () => {
+        const note = createItem(db, { title: "Whitespace tolerant" });
+        const results = searchItems(sqlite, db, `id:  ${note.id}  `);
+        expect(results).toHaveLength(1);
+        expect(results[0]!.id).toBe(note.id);
+      });
+
+      it("rejects hex+dash mixed short prefix (would never match UUID position)", () => {
+        // UUIDs have dashes at fixed positions (8-4-4-4-12); a 'abc-1234' prefix
+        // would always produce 0 LIKE matches, so reject it explicitly rather
+        // than silently returning empty after a wasted query.
+        insertActiveRow(sqlite, {
+          id: "abc12345-8888-4888-8888-888888888888",
+          title: "No dash prefix",
+        });
+        expect(searchItems(sqlite, db, "id:abc-1234")).toHaveLength(0);
+      });
+
+      it("rejects all-dash prefix", () => {
+        expect(searchItems(sqlite, db, "id:----")).toHaveLength(0);
+      });
+    });
   });
 
   describe("getAllTags", () => {

--- a/server/lib/items.ts
+++ b/server/lib/items.ts
@@ -621,6 +621,28 @@ export const ID_PREFIX_QUERY_RE = /^id:\s*(\S+)\s*$/i;
 const HEX_PREFIX_RE = /^[0-9a-f]{4,32}$/i;
 
 /**
+ * Rebuild canonical UUID dash positions (8-4-4-4-12) from a dash-stripped
+ * hex prefix so GLOB matches stored IDs (which always carry dashes).
+ *   'abc12345'         → 'abc12345'
+ *   'abc123451111'     → 'abc12345-1111'
+ *   '<32 hex chars>'   → canonical 36-char UUID
+ * Caller has already validated input is 4–32 lowercase hex chars.
+ */
+function reconstructUuidPrefix(stripped: string): string {
+  const segments = [8, 4, 4, 4, 12];
+  let result = "";
+  let consumed = 0;
+  for (const seg of segments) {
+    const take = Math.min(stripped.length - consumed, seg);
+    if (take <= 0) break;
+    if (consumed > 0) result += "-";
+    result += stripped.slice(consumed, consumed + take);
+    consumed += take;
+  }
+  return result;
+}
+
+/**
  * Cross-table ID lookup for the `id:<prefix>` search syntax. Returns full UUID
  * exact matches and short hex prefix matches across items_active + items_vault.
  * Invalid prefixes (non-hex chars, < 4 chars) return [] without an FTS fallback.
@@ -659,13 +681,18 @@ function searchItemsByIdPrefix(
     return resolveLinkedInfo(db, [{ kind: "vault", row: vault }], enrich, enrichIncludePrivate);
   }
 
-  if (!HEX_PREFIX_RE.test(id)) return [];
+  // Tolerate user-pasted prefixes that include UUID dashes (highlight-and-copy
+  // from the item-detail tooltip is a natural source). Strip dashes, validate
+  // the hex run, then rebuild canonical UUID-segment shape so the GLOB pattern
+  // matches stored IDs (dashes at positions 8/13/18/23).
+  const stripped = id.replace(/-/g, "");
+  if (!HEX_PREFIX_RE.test(stripped)) return [];
 
   // GLOB instead of LIKE: SQLite's `case_sensitive_like=OFF` default + BINARY-collated
   // text PRIMARY KEY means `id LIKE 'prefix%'` falls back to SCAN, while
   // `id GLOB 'prefix*'` is case-sensitive and uses the PK index (verified via
   // EXPLAIN QUERY PLAN). Prefix is hex-only and pre-lowercased, so no metachar risk.
-  const globPattern = `${id}*`;
+  const globPattern = `${reconstructUuidPrefix(stripped)}*`;
 
   const activeRows = db
     .select()

--- a/server/lib/items.ts
+++ b/server/lib/items.ts
@@ -606,6 +606,89 @@ export function deleteVaultItem(
   })();
 }
 
+/**
+ * Match any `id:<token>` query. Token is captured permissively (`\S+`) so that
+ * invalid IDs still take the strict-ID path and return 0 results instead of
+ * silently falling through to FTS — that fallback would surprise users who
+ * meant "find this exact ID."
+ *
+ * Mirror this when changing it: `mcp-server/src/tools/search.ts` keeps a
+ * matching predicate to skip the vault filesystem search for ID queries.
+ */
+export const ID_PREFIX_QUERY_RE = /^id:\s*(\S+)\s*$/i;
+
+/** Strict hex prefix (no dashes). UUID hex run is 32 chars, so cap at 32. */
+const HEX_PREFIX_RE = /^[0-9a-f]{4,32}$/i;
+
+/**
+ * Cross-table ID lookup for the `id:<prefix>` search syntax. Returns full UUID
+ * exact matches and short hex prefix matches across items_active + items_vault.
+ * Invalid prefixes (non-hex chars, < 4 chars) return [] without an FTS fallback.
+ */
+function searchItemsByIdPrefix(
+  db: DB,
+  id: string,
+  enrich: boolean,
+  includePrivate: boolean | "only",
+  limit: number,
+): ItemWithLinkedInfo[] {
+  if (!id) return [];
+
+  const privacyConds = (table: typeof itemsActive | typeof itemsVault) => {
+    if (includePrivate === "only") return [eq(table.is_private, 1)];
+    if (includePrivate === true) return [];
+    return [eq(table.is_private, 0)];
+  };
+  const enrichIncludePrivate = includePrivate === true || includePrivate === "only";
+
+  if (UUID_RE.test(id)) {
+    const active = db
+      .select()
+      .from(itemsActive)
+      .where(and(eq(itemsActive.id, id), ...privacyConds(itemsActive)))
+      .get();
+    if (active) {
+      return resolveLinkedInfo(db, [{ kind: "active", row: active }], enrich, enrichIncludePrivate);
+    }
+    const vault = db
+      .select()
+      .from(itemsVault)
+      .where(and(eq(itemsVault.id, id), ...privacyConds(itemsVault)))
+      .get();
+    if (!vault) return [];
+    return resolveLinkedInfo(db, [{ kind: "vault", row: vault }], enrich, enrichIncludePrivate);
+  }
+
+  if (!HEX_PREFIX_RE.test(id)) return [];
+
+  const activeRows = db
+    .select()
+    .from(itemsActive)
+    .where(and(like(itemsActive.id, `${id}%`), ...privacyConds(itemsActive)))
+    .orderBy(asc(itemsActive.id))
+    .limit(limit)
+    .all();
+
+  const remaining = limit - activeRows.length;
+  const vaultRows =
+    remaining > 0
+      ? db
+          .select()
+          .from(itemsVault)
+          .where(and(like(itemsVault.id, `${id}%`), ...privacyConds(itemsVault)))
+          .orderBy(asc(itemsVault.id))
+          .limit(remaining)
+          .all()
+      : [];
+
+  const sources = [
+    ...activeRows.map((row) => ({ kind: "active" as const, row })),
+    ...vaultRows.map((row) => ({ kind: "vault" as const, row })),
+  ];
+  if (sources.length === 0) return [];
+  return resolveLinkedInfo(db, sources, enrich, enrichIncludePrivate);
+}
+
 export function searchItems(
   sqlite: Database.Database,
   db: DB,
@@ -614,6 +697,13 @@ export function searchItems(
   enrich = true,
   includePrivate: boolean | "only" = false,
 ): ItemWithLinkedInfo[] {
+  // No FTS fallback for `id:` queries — user explicitly asked for an ID match.
+  const idMatch = query.trim().match(ID_PREFIX_QUERY_RE);
+  if (idMatch) {
+    const idPart = idMatch[1]!.toLowerCase();
+    return searchItemsByIdPrefix(db, idPart, enrich, includePrivate, limit);
+  }
+
   const privateClause =
     includePrivate === "only"
       ? "AND items_active.is_private = 1"

--- a/server/lib/items.ts
+++ b/server/lib/items.ts
@@ -661,10 +661,16 @@ function searchItemsByIdPrefix(
 
   if (!HEX_PREFIX_RE.test(id)) return [];
 
+  // GLOB instead of LIKE: SQLite's `case_sensitive_like=OFF` default + BINARY-collated
+  // text PRIMARY KEY means `id LIKE 'prefix%'` falls back to SCAN, while
+  // `id GLOB 'prefix*'` is case-sensitive and uses the PK index (verified via
+  // EXPLAIN QUERY PLAN). Prefix is hex-only and pre-lowercased, so no metachar risk.
+  const globPattern = `${id}*`;
+
   const activeRows = db
     .select()
     .from(itemsActive)
-    .where(and(like(itemsActive.id, `${id}%`), ...privacyConds(itemsActive)))
+    .where(and(sql`${itemsActive.id} GLOB ${globPattern}`, ...privacyConds(itemsActive)))
     .orderBy(asc(itemsActive.id))
     .limit(limit)
     .all();
@@ -675,7 +681,7 @@ function searchItemsByIdPrefix(
       ? db
           .select()
           .from(itemsVault)
-          .where(and(like(itemsVault.id, `${id}%`), ...privacyConds(itemsVault)))
+          .where(and(sql`${itemsVault.id} GLOB ${globPattern}`, ...privacyConds(itemsVault)))
           .orderBy(asc(itemsVault.id))
           .limit(remaining)
           .all()

--- a/server/routes/__tests__/api.test.ts
+++ b/server/routes/__tests__/api.test.ts
@@ -1116,6 +1116,42 @@ describe("Search", () => {
     expect(res.status).toBe(400);
   });
 
+  it("GET /api/search?q=id:<full-uuid> returns the matching item via id: syntax", async () => {
+    const createRes = await app.request("/api/items", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ title: "Find me via id syntax" }),
+    });
+    const created = await createRes.json();
+    const itemId = created.item?.id ?? created.id;
+    expect(itemId).toBeTruthy();
+    // URL-encode the colon to confirm Hono decodes it correctly
+    const res = await app.request(`/api/search?q=${encodeURIComponent(`id:${itemId}`)}`, {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0].id).toBe(itemId);
+  });
+
+  it("GET /api/search?q=id:<8-hex-prefix> returns prefix match (no FTS fallback)", async () => {
+    const createRes = await app.request("/api/items", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ title: "Prefix me" }),
+    });
+    const created = await createRes.json();
+    const itemId = created.item?.id ?? created.id;
+    const prefix = itemId.slice(0, 8);
+    const res = await app.request(`/api/search?q=${encodeURIComponent(`id:${prefix}`)}`, {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.results.map((r: { id: string }) => r.id)).toContain(itemId);
+  });
+
   it("logs error and returns 500 when search throws", async () => {
     const err = new Error("DB connection failed");
     const spy = vi

--- a/src/components/item-detail.tsx
+++ b/src/components/item-detail.tsx
@@ -254,7 +254,7 @@ export function ItemDetail({ itemId, onDeleted, onBack, onNavigate }: ItemDetail
             <button
               type="button"
               className="hover:text-foreground transition-colors cursor-pointer"
-              title="點擊複製完整 ID"
+              title="點擊複製完整 ID（搜尋時用 id:xxxxxxxx 即可定位）"
               onClick={() => {
                 navigator.clipboard.writeText(item.id);
                 toast.success("已複製 ID");
@@ -384,7 +384,7 @@ export function ItemDetail({ itemId, onDeleted, onBack, onNavigate }: ItemDetail
               <button
                 type="button"
                 className="hover:text-foreground transition-colors cursor-pointer"
-                title="點擊複製完整 ID"
+                title="點擊複製完整 ID（搜尋時用 id:xxxxxxxx 即可定位）"
                 onClick={() => {
                   navigator.clipboard.writeText(item.id);
                   toast.success("已複製 ID");

--- a/src/components/search-bar.tsx
+++ b/src/components/search-bar.tsx
@@ -180,7 +180,7 @@ export function SearchBar({ onSelect, autoFocus }: SearchBarProps) {
       {!query && (
         <p className="text-[11px] text-muted-foreground/70 px-1">
           提示：輸入 <code className="bg-muted rounded px-1 py-0.5">id:xxxx</code> 可以用筆記 ID
-          前綴定位（4+ 字元，跨 active + vault）
+          前綴定位（4+ 字元，dash 可省略，跨 active + vault）
         </p>
       )}
 
@@ -193,7 +193,7 @@ export function SearchBar({ onSelect, autoFocus }: SearchBarProps) {
       {!loading && searched && results.length === 0 && (
         <p className="text-sm text-muted-foreground text-center py-4">
           {/^id:/i.test(query.trim())
-            ? "找不到此 ID（前綴需 4+ 個十六進位字元、不含 dashes，例如 abc12345）"
+            ? "找不到此 ID（前綴需 4+ 個十六進位字元，例如 abc12345 或 abc12345-1111）"
             : "找不到結果"}
         </p>
       )}

--- a/src/components/search-bar.tsx
+++ b/src/components/search-bar.tsx
@@ -177,6 +177,13 @@ export function SearchBar({ onSelect, autoFocus }: SearchBarProps) {
         </div>
       </div>
 
+      {!query && (
+        <p className="text-[11px] text-muted-foreground/70 px-1">
+          提示：輸入 <code className="bg-muted rounded px-1 py-0.5">id:xxxx</code> 可以用筆記 ID
+          前綴定位（4+ 字元，跨 active + vault）
+        </p>
+      )}
+
       {loading && (
         <div className="flex justify-center py-4">
           <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />

--- a/src/components/search-bar.tsx
+++ b/src/components/search-bar.tsx
@@ -191,7 +191,11 @@ export function SearchBar({ onSelect, autoFocus }: SearchBarProps) {
       )}
 
       {!loading && searched && results.length === 0 && (
-        <p className="text-sm text-muted-foreground text-center py-4">找不到結果</p>
+        <p className="text-sm text-muted-foreground text-center py-4">
+          {/^id:/i.test(query.trim())
+            ? "找不到此 ID（前綴需 4+ 個十六進位字元、不含 dashes，例如 abc12345）"
+            : "找不到結果"}
+        </p>
       )}
 
       {!loading && results.length > 0 && (


### PR DESCRIPTION
## Summary

- 搜尋欄支援 `id:<prefix>` 語法直接以 Sparkle ID 定位筆記（跨 items_active + items_vault，含已匯出筆記）
- 完整 UUID 走 exact match；4–32 hex char 短前綴走 cross-table LIKE
- 無效 prefix（含 dashes、非 hex 字元、< 4 字元）直接回 0 結果，**不**降級到 FTS — 使用者打 `id:` 就是要 ID 語意
- MCP `sparkle_search_all` 偵測 `id:` 查詢時跳過 vault filesystem 搜尋（vault 不以 ID 索引）
- UI 搜尋欄空白時顯示語法提示

## Implementation

| 改動 | 檔案 |
|------|------|
| `ID_PREFIX_QUERY_RE` short-circuit + `searchItemsByIdPrefix()` helper | `server/lib/items.ts` |
| 13 個新測試（UUID/prefix/cross-table/ambiguous/case/privacy/limit/whitespace/dash 拒絕） | `server/lib/__tests__/items.test.ts` |
| MCP tool descriptions + `sparkle_search_all` vault skip | `mcp-server/src/tools/search.ts` |
| 語法提示 `<p>` | `src/components/search-bar.tsx` |

## Design Decisions

- **明確 `id:` 前綴語法 vs 自動偵測**：避免 8-char hex 詞（如 `cafedead`）誤觸發
- **ID 命中時優先回傳該筆記**：ambiguous prefix 也回傳全部 match，便於跨 active/vault 對齊
- **`HEX_PREFIX_RE = /^[0-9a-f]{4,32}$/i`**（嚴格 hex，無 dashes）：避免 `id:abc-1234` 這類永遠 0 結果的 silent wasted query
- **MCP 端 regex 重複**：保留同步註解（兩個 npm package 無共享 lib）

## Test plan

- [x] 112 unit tests pass（含 13 個新 id: 測試）
- [x] `tsc --noEmit` clean
- [x] `lint:fix` + `format` clean
- [x] MCP server `tsc` clean
- [ ] 手動煙霧測試：在 search bar 輸入 `id:<完整 UUID>` 找到 active 筆記
- [ ] 手動煙霧測試：輸入 `id:<vault 筆記前綴>` 找到 vault 筆記
- [ ] 手動煙霧測試：輸入 `id:xxxx`（不存在）正確顯示「找不到結果」而非降級到 FTS

🤖 Generated with [Claude Code](https://claude.com/claude-code)